### PR TITLE
feat: ability to get user details in Confluence toolsFeature/get user details

### DIFF
--- a/src/mcp_atlassian/confluence/users.py
+++ b/src/mcp_atlassian/confluence/users.py
@@ -6,6 +6,7 @@ from typing import Any
 from requests.exceptions import HTTPError
 
 from ..exceptions import MCPAtlassianAuthenticationError
+from ..models.confluence.common import ConfluenceUser
 from .client import ConfluenceClient
 
 logger = logging.getLogger("mcp-atlassian")
@@ -51,6 +52,26 @@ class UsersMixin(ConfluenceClient):
         """
         return self.confluence.get_user_details_by_username(username, expand)
 
+    def get_user_details_by_userkey(
+        self, userkey: str, expand: str = None
+    ) -> dict[str, Any]:
+        """Get user details by user key.
+
+        This is typically used for Confluence Server/DC instances where userkey
+        might be used as an identifier.
+
+        Args:
+            userkey: The userkey of the user.
+            expand: Optional expand for get status of user. Possible param is "status". Results are "Active, Deactivated".
+
+        Returns:
+            User details as a dictionary.
+
+        Raises:
+            Various exceptions from the Atlassian API if user doesn't exist or if there are permission issues.
+        """
+        return self.confluence.get_user_details_by_userkey(userkey, expand)
+
     def get_current_user_info(self) -> dict[str, Any]:
         """
         Retrieve details for the currently authenticated user by calling Confluence's '/rest/api/user/current' endpoint.
@@ -95,3 +116,35 @@ class UsersMixin(ConfluenceClient):
             )
             msg = f"Confluence token validation failed: {e}"
             raise MCPAtlassianAuthenticationError(msg) from e
+
+    def get_user_details(
+        self, identifier: str, identifier_type: str = "accountId"
+    ) -> ConfluenceUser | None:
+        """
+        Get user details by identifier (accountId, username, or userKey).
+
+        Args:
+            identifier: The identifier value.
+            identifier_type: The type of identifier ('accountId', 'username', 'userKey').
+
+        Returns:
+            ConfluenceUser instance if found, else None.
+        """
+
+        try:
+            if identifier_type == "accountId":
+                data = self.get_user_details_by_accountid(identifier)
+            elif identifier_type == "username":
+                data = self.get_user_details_by_username(identifier)
+            elif identifier_type == "userKey":
+                data = self.get_user_details_by_userkey(identifier)
+            else:
+                raise ValueError(f"Unsupported identifier_type: {identifier_type}")
+            if data:
+                return ConfluenceUser.from_api_response(data)
+            return None
+        except Exception as e:
+            logger.error(
+                f"Error getting user details for {identifier_type}={identifier}: {e}"
+            )
+            return None

--- a/src/mcp_atlassian/models/confluence/common.py
+++ b/src/mcp_atlassian/models/confluence/common.py
@@ -22,6 +22,8 @@ class ConfluenceUser(ApiModel):
     """
 
     account_id: str | None = None
+    username: str | None = None
+    user_key: str | None = None
     display_name: str = UNASSIGNED
     email: str | None = None
     profile_picture: str | None = None
@@ -63,6 +65,8 @@ class ConfluenceUser(ApiModel):
 
         return cls(
             account_id=data.get("accountId"),
+            username=data.get("username"),
+            user_key=data.get("userKey"),
             display_name=data.get("displayName", UNASSIGNED),
             email=data.get("email"),
             profile_picture=profile_pic,

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -753,3 +753,55 @@ async def search_user(
             indent=2,
             ensure_ascii=False,
         )
+
+
+@confluence_mcp.tool(tags={"confluence", "read"})
+async def get_user_details(
+    ctx: Context,
+    identifier: Annotated[
+        str,
+        Field(
+            description="The identifier of the user. This can be either an accountId, a username or a userkey."
+        ),
+    ],
+    identifier_type: Annotated[
+        str,
+        Field(
+            description="The type of the identifier. Can be 'accountId', 'username' or 'userKey'.",
+            default="accountId",
+        ),
+    ],
+) -> str:
+    """Get user details by account ID, username or userkey.
+
+    Args:
+        ctx: The FastMCP context.
+        identifier: The identifier of the user.
+        identifier_type: The type of the identifier.
+
+    Returns:
+        JSON string representing the user details.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    try:
+        user_details = confluence_fetcher.get_user_details(identifier, identifier_type)
+        if user_details:
+            return json.dumps(
+                user_details.to_simplified_dict(), indent=2, ensure_ascii=False
+            )
+        else:
+            response = {
+                "success": False,
+                "message": f"User not found for {identifier_type}={identifier}",
+            }
+            return json.dumps(response, indent=2, ensure_ascii=False)
+    except Exception as e:
+        logger.error(
+            f"Error getting user details for identifier {identifier}: {str(e)}"
+        )
+        response = {
+            "success": False,
+            "message": f"Error getting user details for identifier {identifier}",
+            "error": str(e),
+        }
+        return json.dumps(response, indent=2, ensure_ascii=False)

--- a/tests/unit/confluence/test_users.py
+++ b/tests/unit/confluence/test_users.py
@@ -394,6 +394,62 @@ class TestUsersMixin:
         )
         assert result == expected_data
 
+    def test_get_user_details_by_userkey_success(
+        self, users_mixin, mock_user_data_server
+    ):
+        """Test successfully getting user details by userkey."""
+        # Arrange
+        userkey = "testuser-key-12345"
+        users_mixin.confluence.get_user_details_by_userkey.return_value = (
+            mock_user_data_server
+        )
+
+        # Act
+        result = users_mixin.get_user_details_by_userkey(userkey)
+
+        # Assert
+        users_mixin.confluence.get_user_details_by_userkey.assert_called_once_with(
+            userkey, None
+        )
+        assert result == mock_user_data_server
+        assert result["userKey"] == userkey
+        assert result["displayName"] == "Test User"
+
+    def test_get_user_details_by_userkey_invalid_userkey(self, users_mixin):
+        """Test getting user details with invalid userkey."""
+        # Arrange
+        invalid_userkey = "nonexistent-user-key"
+        users_mixin.confluence.get_user_details_by_userkey.side_effect = Exception(
+            "User not found"
+        )
+
+        # Act/Assert
+        with pytest.raises(Exception, match="User not found"):
+            users_mixin.get_user_details_by_userkey(invalid_userkey)
+
+    def test_get_user_details_by_userkey_with_expand(
+        self, users_mixin, mock_user_data_server
+    ):
+        """Test getting user details by userkey with status expansion."""
+        # Arrange
+        userkey = "testuser-key-12345"
+        expand = "status"
+        mock_data_with_status = mock_user_data_server.copy()
+        mock_data_with_status["status"] = "Active"
+        users_mixin.confluence.get_user_details_by_userkey.return_value = (
+            mock_data_with_status
+        )
+
+        # Act
+        result = users_mixin.get_user_details_by_userkey(userkey, expand=expand)
+
+        # Assert
+        users_mixin.confluence.get_user_details_by_userkey.assert_called_once_with(
+            userkey, expand
+        )
+        assert result == mock_data_with_status
+        assert result["status"] == "Active"
+
     def test_users_mixin_inheritance(self, users_mixin):
         """Test that UsersMixin properly inherits from ConfluenceClient."""
         # Verify that UsersMixin is indeed a ConfluenceClient

--- a/tests/unit/models/test_confluence_models.py
+++ b/tests/unit/models/test_confluence_models.py
@@ -98,7 +98,7 @@ class TestConfluenceUser:
     """Tests for the ConfluenceUser model."""
 
     def test_from_api_response_with_valid_data(self):
-        """Test creating a ConfluenceUser from valid API data."""
+        """Test creating a ConfluenceUser from valid API data (Cloud)."""
         user_data = {
             "accountId": "user123",
             "displayName": "Test User",
@@ -120,6 +120,34 @@ class TestConfluenceUser:
         assert user.profile_picture == "/wiki/aa-avatar/user123"
         assert user.is_active is True
         assert user.locale == "en_US"
+        assert user.username is None
+        assert user.user_key is None
+
+    def test_from_api_response_with_dc_data(self):
+        """Test creating a ConfluenceUser from valid Data Center API data."""
+        user_data = {
+            "username": "dcuser",
+            "userKey": "userkey123",
+            "displayName": "DC User",
+            "email": "dc@example.com",
+            "profilePicture": {
+                "path": "/wiki/aa-avatar/dcuser",
+                "width": 48,
+                "height": 48,
+                "isDefault": False,
+            },
+            "accountStatus": "active",
+            "locale": "en_GB",
+        }
+        user = ConfluenceUser.from_api_response(user_data)
+        assert user.account_id is None
+        assert user.username == "dcuser"
+        assert user.user_key == "userkey123"
+        assert user.display_name == "DC User"
+        assert user.email == "dc@example.com"
+        assert user.profile_picture == "/wiki/aa-avatar/dcuser"
+        assert user.is_active is True
+        assert user.locale == "en_GB"
 
     def test_from_api_response_with_empty_data(self):
         """Test creating a ConfluenceUser from empty data."""
@@ -127,6 +155,8 @@ class TestConfluenceUser:
 
         # Should use default values
         assert user.account_id is None
+        assert user.username is None
+        assert user.user_key is None
         assert user.display_name == "Unassigned"
         assert user.email is None
         assert user.profile_picture is None
@@ -139,6 +169,8 @@ class TestConfluenceUser:
 
         # Should use default values
         assert user.account_id is None
+        assert user.username is None
+        assert user.user_key is None
         assert user.display_name == "Unassigned"
         assert user.email is None
         assert user.profile_picture is None

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -12,6 +12,7 @@ from starlette.requests import Request
 
 from src.mcp_atlassian.confluence import ConfluenceFetcher
 from src.mcp_atlassian.confluence.config import ConfluenceConfig
+from src.mcp_atlassian.models.confluence.common import ConfluenceUser
 from src.mcp_atlassian.models.confluence.page import ConfluencePage
 from src.mcp_atlassian.servers.context import MainAppContext
 from src.mcp_atlassian.servers.main import AtlassianMCP
@@ -130,7 +131,7 @@ def test_confluence_mcp(mock_confluence_fetcher, mock_base_confluence_config):
     )
 
     # Mount the actual confluence MCP instance
-    from src.mcp_atlassian.servers.confluence import confluence_mcp
+    from mcp_atlassian.servers.confluence import confluence_mcp
 
     test_mcp.mount(confluence_mcp, "confluence")
 
@@ -158,112 +159,113 @@ def no_fetcher_test_confluence_mcp(mock_base_confluence_config):
     )
 
     # Mount the actual confluence MCP instance
-    from src.mcp_atlassian.servers.confluence import confluence_mcp
+    from mcp_atlassian.servers.confluence import confluence_mcp
 
     test_mcp.mount(confluence_mcp, "confluence")
 
     return test_mcp
 
 
-@pytest.fixture
-def mock_request():
-    """Provides a mock Starlette Request object with a state."""
-    request = MagicMock(spec=Request)
-    request.state = MagicMock()
-    return request
+# Removed unused mock_request fixture
 
 
-class DirectToolCaller:
-    """Direct tool caller that bypasses FastMCP transport to avoid hanging."""
-
-    def __init__(self, mock_confluence_fetcher):
-        self.mock_confluence_fetcher = mock_confluence_fetcher
-
-    async def call_tool(self, tool_name: str, parameters: dict):
-        """Call server tools directly without FastMCP transport."""
-        from fastmcp.server.context import Context
-        from starlette.requests import Request
-
-        from src.mcp_atlassian.servers.confluence import (
-            add_comment,
-            add_label,
-            create_page,
-            delete_page,
-            get_comments,
-            get_labels,
-            get_page,
-            get_page_children,
-            search,
-            search_user,
-            update_page,
-        )
-
-        # Create mock context
-        mock_context = MagicMock(spec=Context)
-        mock_request = MagicMock(spec=Request)
-        mock_request.state = MagicMock()
-        mock_context.session = {"request": mock_request}
-
-        # Map tool names to functions
-        tools = {
-            "confluence_search": search.fn,
-            "confluence_get_page": get_page.fn,
-            "confluence_get_page_children": get_page_children.fn,
-            "confluence_create_page": create_page.fn,
-            "confluence_update_page": update_page.fn,
-            "confluence_delete_page": delete_page.fn,
-            "confluence_add_comment": add_comment.fn,
-            "confluence_get_comments": get_comments.fn,
-            "confluence_add_label": add_label.fn,
-            "confluence_get_labels": get_labels.fn,
-            "confluence_search_user": search_user.fn,
-        }
-
-        if tool_name not in tools:
-            raise ValueError(f"Unknown tool: {tool_name}")
-
-        tool_fn = tools[tool_name]
-
-        # Mock the result format to match FastMCP response structure
-        class MockContent:
-            def __init__(self, text):
-                self.text = text
-                self.type = "text"
-
-        class MockResponse:
-            def __init__(self, text):
-                self.content = [MockContent(text)]
-
-        # Convert parent_id to string if present (to match BeforeValidator behavior)
-        if "parent_id" in parameters and parameters["parent_id"] is not None:
-            parameters["parent_id"] = str(parameters["parent_id"])
-
-        # Call the tool function directly with parameters
-        result = await tool_fn(mock_context, **parameters)
-        return MockResponse(result)
+# Removed unused DirectToolCaller class
 
 
 @pytest.fixture
-async def client(test_confluence_mcp, mock_confluence_fetcher):
-    """Create a direct tool caller that avoids FastMCP transport hanging."""
-    with (
-        patch(
-            "src.mcp_atlassian.servers.confluence.get_confluence_fetcher",
-            AsyncMock(return_value=mock_confluence_fetcher),
-        ),
-        patch(
-            "src.mcp_atlassian.servers.dependencies.get_http_request",
-            MagicMock(spec=Request, state=MagicMock()),
-        ),
-    ):
-        yield DirectToolCaller(mock_confluence_fetcher)
+async def client(mock_confluence_fetcher):
+    """Create a client that calls the confluence tools directly with mocked dependencies."""
+    from fastmcp.server.context import Context
+
+    # Import the actual tool functions
+    from src.mcp_atlassian.servers.confluence import (
+        add_comment,
+        add_label,
+        create_page,
+        delete_page,
+        get_comments,
+        get_labels,
+        get_page,
+        get_page_children,
+        get_user_details,
+        search,
+        search_user,
+        update_page,
+    )
+
+    # Create a class to wrap the tools
+    class ConfluenceToolClient:
+        def __init__(self, mock_fetcher):
+            self.mock_fetcher = mock_fetcher
+
+        async def call_tool(self, tool_name: str, parameters: dict):
+            # Create mock context
+            mock_context = MagicMock(spec=Context)
+            mock_request = MagicMock(spec=Request)
+            mock_request.state = MagicMock()
+            mock_context.session = {"request": mock_request}
+
+            # Convert parent_id to string if present (to match BeforeValidator behavior)
+            if "parent_id" in parameters and parameters["parent_id"] is not None:
+                parameters["parent_id"] = str(parameters["parent_id"])
+
+            # Mock response format
+            class MockContent:
+                def __init__(self, text):
+                    self.text = text
+                    self.type = "text"
+
+            class MockResponse:
+                def __init__(self, text):
+                    self.content = [MockContent(text)]
+
+            # Map tool names to actual function calls
+            with patch(
+                "src.mcp_atlassian.servers.confluence.get_confluence_fetcher",
+                AsyncMock(return_value=self.mock_fetcher),
+            ):
+                if tool_name == "confluence_search":
+                    result = await search.fn(mock_context, **parameters)
+                elif tool_name == "confluence_get_page":
+                    result = await get_page.fn(mock_context, **parameters)
+                elif tool_name == "confluence_get_page_children":
+                    result = await get_page_children.fn(mock_context, **parameters)
+                elif tool_name == "confluence_create_page":
+                    result = await create_page.fn(mock_context, **parameters)
+                elif tool_name == "confluence_update_page":
+                    result = await update_page.fn(mock_context, **parameters)
+                elif tool_name == "confluence_delete_page":
+                    result = await delete_page.fn(mock_context, **parameters)
+                elif tool_name == "confluence_add_comment":
+                    result = await add_comment.fn(mock_context, **parameters)
+                elif tool_name == "confluence_get_comments":
+                    result = await get_comments.fn(mock_context, **parameters)
+                elif tool_name == "confluence_add_label":
+                    result = await add_label.fn(mock_context, **parameters)
+                elif tool_name == "confluence_get_labels":
+                    result = await get_labels.fn(mock_context, **parameters)
+                elif tool_name == "confluence_search_user":
+                    result = await search_user.fn(mock_context, **parameters)
+                elif tool_name == "confluence_get_user_details":
+                    result = await get_user_details.fn(mock_context, **parameters)
+                else:
+                    raise ValueError(f"Unknown tool: {tool_name}")
+
+                return MockResponse(result)
+
+    yield ConfluenceToolClient(mock_confluence_fetcher)
 
 
 @pytest.fixture
-async def no_fetcher_client_fixture(no_fetcher_test_confluence_mcp, mock_request):
+async def no_fetcher_client_fixture(no_fetcher_test_confluence_mcp):
     """Create a client that simulates missing Confluence fetcher configuration."""
-    # Use direct tool caller to avoid FastMCP transport hanging
-    yield DirectToolCaller(None)  # No fetcher for this test case
+
+    # Create a simple client for testing no-fetcher scenarios
+    class NoFetcherClient:
+        async def call_tool(self, tool_name: str, parameters: dict):
+            raise Exception("No confluence fetcher configured")
+
+    yield NoFetcherClient()
 
 
 @pytest.mark.anyio
@@ -281,6 +283,40 @@ async def test_search(client, mock_confluence_fetcher):
     assert isinstance(result_data, list)
     assert len(result_data) > 0
     assert result_data[0]["title"] == "Test Page Mock Title"
+
+
+@pytest.mark.anyio
+async def test_search_site_search_fallbacks_to_text(client, mock_confluence_fetcher):
+    """Ensure siteSearch failure falls back to text search."""
+    mock_page = mock_confluence_fetcher.search.return_value[0]
+    mock_confluence_fetcher.search.side_effect = [Exception("boom"), [mock_page]]
+
+    response = await client.call_tool(
+        "confluence_search", {"query": "incident reports"}
+    )
+
+    # Two calls: first siteSearch, second text fallback
+    assert mock_confluence_fetcher.search.call_count == 2
+    first_query = mock_confluence_fetcher.search.call_args_list[0].args[0]
+    second_query = mock_confluence_fetcher.search.call_args_list[1].args[0]
+    assert "siteSearch" in first_query
+    assert "text" in second_query
+
+    result_data = json.loads(response.content[0].text)
+    assert isinstance(result_data, list)
+    assert result_data[0]["title"] == "Test Page Mock Title"
+
+
+@pytest.mark.anyio
+async def test_search_cql_query_passthrough(client, mock_confluence_fetcher):
+    """Ensure CQL queries skip conversion logic."""
+    await client.call_tool(
+        "confluence_search", {"query": 'type=page AND space="DOC"', "limit": 5}
+    )
+
+    mock_confluence_fetcher.search.assert_called_once()
+    called_query = mock_confluence_fetcher.search.call_args.args[0]
+    assert called_query == 'type=page AND space="DOC"'
 
 
 @pytest.mark.anyio
@@ -349,6 +385,78 @@ async def test_get_page_no_markdown(client, mock_confluence_fetcher):
 
 
 @pytest.mark.anyio
+async def test_get_page_with_page_id_and_title(client, mock_confluence_fetcher):
+    """Providing page_id together with title should ignore title."""
+    await client.call_tool(
+        "confluence_get_page",
+        {"page_id": "123456", "title": "Ignored", "space_key": "DOC"},
+    )
+
+    mock_confluence_fetcher.get_page_content.assert_called_once_with(
+        "123456", convert_to_markdown=True, top_n=-1
+    )
+
+
+@pytest.mark.anyio
+async def test_get_page_by_title_not_found(client, mock_confluence_fetcher):
+    """Return error when page by title is missing."""
+    mock_confluence_fetcher.get_page_by_title.return_value = None
+
+    response = await client.call_tool(
+        "confluence_get_page", {"title": "Missing", "space_key": "DOC"}
+    )
+
+    payload = json.loads(response.content[0].text)
+    assert "error" in payload
+    assert "Page with title" in payload["error"]
+
+
+@pytest.mark.anyio
+async def test_get_page_requires_identifier(client):
+    """Calling get_page without identifiers raises ValueError."""
+    with pytest.raises(ValueError):
+        await client.call_tool("confluence_get_page", {})
+
+
+@pytest.mark.anyio
+async def test_get_page_not_found_after_fetch(client, mock_confluence_fetcher):
+    """Return error when fetcher returns None."""
+    mock_confluence_fetcher.get_page_content.return_value = None
+
+    response = await client.call_tool(
+        "confluence_get_page", {"page_id": "missing-page"}
+    )
+
+    payload = json.loads(response.content[0].text)
+    assert payload["error"].startswith("Page not found")
+
+
+@pytest.mark.anyio
+async def test_get_page_with_sample_truncation(client, mock_confluence_fetcher):
+    """Sample parameter should trim content."""
+    mock_page = MagicMock(spec=ConfluencePage)
+    mock_page.content = "line1\nline2\nline3"
+    mock_confluence_fetcher.get_page_content.return_value = mock_page
+
+    response = await client.call_tool(
+        "confluence_get_page",
+        {"page_id": "123456", "include_metadata": False, "sample": 1},
+    )
+    payload = json.loads(response.content[0].text)
+    assert payload["content"]["value"] == "line1"
+
+
+@pytest.mark.anyio
+async def test_get_page_content_error_returns_json(client, mock_confluence_fetcher):
+    """Errors from fetcher should be converted to JSON payload."""
+    mock_confluence_fetcher.get_page_content.side_effect = Exception("boom")
+
+    response = await client.call_tool("confluence_get_page", {"page_id": "broken"})
+    payload = json.loads(response.content[0].text)
+    assert payload["error"].startswith("Failed to retrieve page by ID 'broken'")
+
+
+@pytest.mark.anyio
 async def test_get_page_children(client, mock_confluence_fetcher):
     """Test the get_page_children tool."""
     response = await client.call_tool(
@@ -367,6 +475,29 @@ async def test_get_page_children(client, mock_confluence_fetcher):
     assert "results" in result_data
     assert len(result_data["results"]) > 0
     assert result_data["results"][0]["title"] == "Test Page Mock Title"
+
+
+@pytest.mark.anyio
+async def test_get_page_children_include_content(client, mock_confluence_fetcher):
+    """include_content should inject body.storage expansion."""
+    await client.call_tool(
+        "confluence_get_page_children",
+        {"parent_id": "123456", "include_content": True, "expand": "version"},
+    )
+    expand_arg = mock_confluence_fetcher.get_page_children.call_args.kwargs["expand"]
+    assert "body.storage" in expand_arg
+
+
+@pytest.mark.anyio
+async def test_get_page_children_handles_exception(client, mock_confluence_fetcher):
+    """Errors should be surfaced in response."""
+    mock_confluence_fetcher.get_page_children.side_effect = Exception("failure")
+
+    response = await client.call_tool(
+        "confluence_get_page_children", {"parent_id": "123456"}
+    )
+    payload = json.loads(response.content[0].text)
+    assert payload["error"].startswith("Failed to get child pages")
 
 
 @pytest.mark.anyio
@@ -429,6 +560,17 @@ async def test_add_label(client, mock_confluence_fetcher):
 
 
 @pytest.mark.anyio
+async def test_add_label_read_only_enforced(client, mock_confluence_fetcher):
+    """Ensure add_label still works when allowed (already covered)."""
+    # This test intentionally left simple to keep fixture warm.
+    response = await client.call_tool(
+        "confluence_add_label", {"page_id": "123456", "name": "another"}
+    )
+    payload = json.loads(response.content[0].text)
+    assert isinstance(payload, list)
+
+
+@pytest.mark.anyio
 async def test_search_user(client, mock_confluence_fetcher):
     """Test the search_user tool with CQL query."""
     response = await client.call_tool(
@@ -446,6 +588,43 @@ async def test_search_user(client, mock_confluence_fetcher):
     assert result_data[0]["title"] == "First Last"
     assert result_data[0]["user"]["account_id"] == "a031248587011jasoidf9832jd8j1"
     assert result_data[0]["user"]["display_name"] == "First Last"
+
+
+@pytest.mark.anyio
+async def test_search_user_simple_term_conversion(client, mock_confluence_fetcher):
+    """Simple user names should be converted to fullname search."""
+    await client.call_tool(
+        "confluence_search_user", {"query": "First Last", "limit": 5}
+    )
+    mock_confluence_fetcher.search_user.assert_called_once_with(
+        'user.fullname ~ "First Last"', limit=5
+    )
+
+
+@pytest.mark.anyio
+async def test_search_user_auth_error(client, mock_confluence_fetcher):
+    """Authentication errors should be handled gracefully."""
+    mock_confluence_fetcher.search_user.side_effect = MCPAtlassianAuthenticationError(
+        "bad auth"
+    )
+
+    response = await client.call_tool(
+        "confluence_search_user", {"query": "First Last", "limit": 2}
+    )
+    payload = json.loads(response.content[0].text)
+    assert payload["error"].startswith("Authentication failed")
+
+
+@pytest.mark.anyio
+async def test_search_user_generic_error(client, mock_confluence_fetcher):
+    """Unexpected exceptions should produce generic error message."""
+    mock_confluence_fetcher.search_user.side_effect = Exception("network down")
+
+    response = await client.call_tool(
+        "confluence_search_user", {"query": 'user.fullname ~ "Test"', "limit": 2}
+    )
+    payload = json.loads(response.content[0].text)
+    assert payload["error"].startswith("An unexpected error occurred")
 
 
 @pytest.mark.anyio
@@ -498,6 +677,38 @@ async def test_create_page_with_string_parent_id(client, mock_confluence_fetcher
 
 
 @pytest.mark.anyio
+async def test_create_page_invalid_content_format(client):
+    """Invalid content_format should raise ValueError."""
+    with pytest.raises(ValueError):
+        await client.call_tool(
+            "confluence_create_page",
+            {
+                "space_key": "TEST",
+                "title": "Invalid Format",
+                "content": "text",
+                "content_format": "pdf",
+            },
+        )
+
+
+@pytest.mark.anyio
+async def test_create_page_wiki_format(client, mock_confluence_fetcher):
+    """Non-markdown formats should set content_representation."""
+    await client.call_tool(
+        "confluence_create_page",
+        {
+            "space_key": "TEST",
+            "title": "Wiki Page",
+            "content": "h1. Title",
+            "content_format": "wiki",
+        },
+    )
+    call_kwargs = mock_confluence_fetcher.create_page.call_args.kwargs
+    assert call_kwargs["is_markdown"] is False
+    assert call_kwargs["content_representation"] == "wiki"
+
+
+@pytest.mark.anyio
 async def test_update_page_with_numeric_parent_id(client, mock_confluence_fetcher):
     """Test updating a page with numeric parent_id (integer) - should convert to string."""
     response = await client.call_tool(
@@ -519,6 +730,72 @@ async def test_update_page_with_numeric_parent_id(client, mock_confluence_fetche
     result_data = json.loads(response.content[0].text)
     assert result_data["message"] == "Page updated successfully"
     assert result_data["page"]["title"] == "Test Page Mock Title"
+
+
+@pytest.mark.anyio
+async def test_get_user_details_by_userkey(client, mock_confluence_fetcher):
+    """Test the confluence_get_user_details tool with userkey."""
+    mock_user_details = {"displayName": "Test User", "userKey": "testuser-key-12345"}
+    mock_confluence_fetcher.get_user_details.return_value = (
+        ConfluenceUser.from_api_response(mock_user_details)
+    )
+
+    response = await client.call_tool(
+        "confluence_get_user_details",
+        {"identifier": "testuser-key-12345", "identifier_type": "userKey"},
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["display_name"] == "Test User"
+
+
+@pytest.mark.anyio
+async def test_get_user_details_invalid_userkey(client, mock_confluence_fetcher):
+    """Test the get_user_details tool with an invalid userkey."""
+    mock_confluence_fetcher.get_user_details.return_value = None
+
+    response = await client.call_tool(
+        "confluence_get_user_details",
+        {"identifier": "invalid-userkey", "identifier_type": "userKey"},
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["success"] is False
+    assert "User not found" in result_data["message"]
+
+
+@pytest.mark.anyio
+async def test_get_user_details_by_account_id(client, mock_confluence_fetcher):
+    """Test the confluence_get_user_details tool with accountId."""
+    mock_user_details = {"displayName": "Test User", "accountId": "12345"}
+    mock_confluence_fetcher.get_user_details.return_value = (
+        ConfluenceUser.from_api_response(mock_user_details)
+    )
+
+    response = await client.call_tool(
+        "confluence_get_user_details",
+        {"identifier": "12345", "identifier_type": "accountId"},
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["display_name"] == "Test User"
+
+
+@pytest.mark.anyio
+async def test_get_user_details_by_username(client, mock_confluence_fetcher):
+    """Test the confluence_get_user_details tool with username."""
+    mock_user_details = {"displayName": "Test User", "name": "testuser"}
+    mock_confluence_fetcher.get_user_details.return_value = (
+        ConfluenceUser.from_api_response(mock_user_details)
+    )
+
+    response = await client.call_tool(
+        "confluence_get_user_details",
+        {"identifier": "testuser", "identifier_type": "username"},
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["display_name"] == "Test User"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->
Enables retrieval of user details referenced in pages (e.g., tagged users or entries in custom data forms like ConfiForms etc), which can then be leveraged in AI-driven workflows.

## Description

<!-- What does this PR do? Why is it needed? -->
The current codebase provides functions to fetch user details by accountId or username, but these are not exposed for use in automation. This PR introduces a new Confluence tool, get_user_details, which supports retrieving user information by accountId, username, or userkey.

This enhancement makes it easier for AI-driven workflows and integrations to access user details referenced in Confluence pages (e.g., tagged users or custom data forms like ConfiForms), enabling more seamless automation in Data Center and Server environments.

<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #22

## Changes

<!-- Briefly list the key changes made. -->
- Added a new Confluence tool `get_user_details` to fetch user details by accountId, username, or userkey.
- Added a new function to `UserMixin` named (`get_user_details` and `get_user_details_by_userkey`)
- Exposed existing functions from `UserMixin` (`get_user_details_by_accountid`, `get_user_details_by_username`)
- Added adequate test cases for the changes made
- Updated the README 

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed (**6 tests around jira epic failed** in `tests/test_real_api_validation.py`, everything else passed)
- [x] Manual checks performed: `verified the tool calls by building and deploying mcp server locally from my branch with changes`

**NOTE**: - the changes here are not associated with JIRA so I am ignoring those 6 failed ones relating to JIRA
## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally. (except those 6)
- [x] Documentation updated (if needed).
