### PR TITLE
Fix/search endpoint (#1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,9 @@ JIRA_URL=https://your-company.atlassian.net
 # Example Cloud: https://your-company.atlassian.net/wiki
 # Example Server/DC: https://confluence.your-internal-domain.com
 CONFLUENCE_URL=https://your-company.atlassian.net/wiki
-# Example Cloud: https://bitbucket.org
+# Example Cloud: https://api.bitbucket.org
 # Example Server/DC: https://bitbucket.your-internal-domain.com
-BITBUCKET_URL=https://bitbucket.org
+BITBUCKET_URL=https://api.bitbucket.org
 
 # =============================================
 # AUTHENTICATION: CHOOSE ONE METHOD PER PRODUCT (Jira/Confluence/Bitbucket)
@@ -29,7 +29,7 @@ BITBUCKET_URL=https://bitbucket.org
 
 # --- METHOD 1: API TOKEN (Recommended for Atlassian Cloud) ---
 # Get API tokens from: https://id.atlassian.com/manage-profile/security/api-tokens
-# Get Bitbucket App Passwords from: https://bitbucket.org/account/settings/app-passwords/
+# Get Bitbucket API tokens from: https://id.atlassian.com/manage-profile/security/api-tokens
 # This is the simplest and most reliable authentication method for Cloud deployments.
 #JIRA_USERNAME=your.email@example.com
 #JIRA_API_TOKEN=your_jira_api_token
@@ -38,7 +38,7 @@ BITBUCKET_URL=https://bitbucket.org
 #CONFLUENCE_API_TOKEN=your_confluence_api_token
 
 #BITBUCKET_USERNAME=your.email@example.com
-#BITBUCKET_APP_PASSWORD=your_bitbucket_app_password
+#BITBUCKET_API_TOKEN=your_bitbucket_api_token
 
 # --- METHOD 2: PERSONAL ACCESS TOKEN (PAT) (Server / Data Center - Recommended) ---
 # Create PATs in your Jira/Confluence/Bitbucket profile settings (usually under "Personal Access Tokens").
@@ -46,7 +46,9 @@ BITBUCKET_URL=https://bitbucket.org
 
 #CONFLUENCE_PERSONAL_TOKEN=your_confluence_personal_access_token
 
-#BITBUCKET_PERSONAL_TOKEN=your_bitbucket_personal_access_token
+# For Bitbucket Cloud workspace/project/repository access tokens, this variable
+# is sent as a Bearer token. For Server/DC, it remains a personal access token.
+#BITBUCKET_PERSONAL_TOKEN=your_bitbucket_access_token
 
 # --- METHOD 3: USERNAME/PASSWORD (Server / Data Center - Uses Basic Authentication) ---
 #JIRA_USERNAME=your_server_dc_username

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ playground/
 
 # Claude
 .claude/
+
+# Snyk Security Extension - AI Rules (auto-generated)
+.cursor/rules/snyk_rules.mdc

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ https://github.com/user-attachments/assets/7fe9c488-ad0c-4876-9b54-120b666bb785
 | **Confluence** | Server/Data Center | ✅ Supported (version 6.0+)  |
 | **Jira**       | Cloud              | ✅ Fully supported           |
 | **Jira**       | Server/Data Center | ✅ Supported (version 8.14+) |
-| **Bitbucket**  | Cloud              | ⚠️ Not Tested                |
+| **Bitbucket**  | Cloud              | ✅ Supported (REST API 2.0) |
 | **Bitbucket**  | Server/Data Center | ✅ Supported (version 9.0+)  |
 
 ## Quick Start Guide
@@ -52,6 +52,13 @@ MCP Atlassian supports four authentication methods:
 1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
 2. Click **Create API token**, name it
 3. Copy the token immediately
+
+For Bitbucket Cloud, set `BITBUCKET_URL=https://api.bitbucket.org`, your
+Atlassian account email in `BITBUCKET_USERNAME`, and the token in
+`BITBUCKET_API_TOKEN`. Existing deployments may continue passing an API token
+through `BITBUCKET_APP_PASSWORD` while their secret wiring is migrated. Cloud
+workspace, project, or repository access tokens can instead be supplied as
+`BITBUCKET_PERSONAL_TOKEN` and are sent with Bearer authentication.
 
 #### B. Personal Access Token (Server/Data Center)
 
@@ -129,7 +136,7 @@ For **Confluence authentication**:
 - `X-Atlassian-Confluence-Url`: Your Confluence instance URL
 
 For **Bitbucket authentication**:
-- `X-Atlassian-Bitbucket-Personal-Token`: Your Bitbucket PAT or app password
+- `X-Atlassian-Bitbucket-Personal-Token`: Your Bitbucket Cloud access token or Server/DC PAT
 - `X-Atlassian-Bitbucket-Url`: Your Bitbucket instance URL
 
 **Benefits:**
@@ -151,7 +158,7 @@ For **Bitbucket authentication**:
       "X-Atlassian-Jira-Url": "https://your-jira-instance.com",
       "X-Atlassian-Confluence-Personal-Token": "your_confluence_pat_or_api_token",
       "X-Atlassian-Confluence-Url": "https://your-confluence-instance.com",
-      "X-Atlassian-Bitbucket-Personal-Token": "your_bitbucket_pat_or_app_password",
+      "X-Atlassian-Bitbucket-Personal-Token": "your_bitbucket_access_token",
       "X-Atlassian-Bitbucket-Url": "https://your-bitbucket-instance.com"
     },
     "type": "http"
@@ -231,7 +238,7 @@ There are three main approaches to configure the Docker container:
         "-e", "JIRA_API_TOKEN",
         "-e", "BITBUCKET_URL",
         "-e", "BITBUCKET_USERNAME",
-        "-e", "BITBUCKET_APP_PASSWORD",
+        "-e", "BITBUCKET_API_TOKEN",
         "ghcr.io/SharkyND/mcp-atlassian:latest"
       ],
       "env": {
@@ -241,9 +248,9 @@ There are three main approaches to configure the Docker container:
         "JIRA_URL": "https://your-company.atlassian.net",
         "JIRA_USERNAME": "your.email@company.com",
         "JIRA_API_TOKEN": "your_jira_api_token",
-        "BITBUCKET_URL": "https://bitbucket.org",
+        "BITBUCKET_URL": "https://api.bitbucket.org",
         "BITBUCKET_USERNAME": "your.email@company.com",
-        "BITBUCKET_APP_PASSWORD": "your_bitbucket_app_password"
+        "BITBUCKET_API_TOKEN": "your_bitbucket_api_token"
       }
     }
   }
@@ -968,7 +975,8 @@ Use the header to temporarily override server defaults for a single client reque
 - `get_commits`: Get commit history for a repository
 - `create_pull_request`: Create a new pull request
 - `create_branch`: Create a new branch in a repository
-- `add_pull_request_blocker_comment`: Add a blocking comment to a pull request
+- `add_pull_request_blocker_comment`: Add a blocking comment to a pull request;
+  Cloud maps blockers to pull-request tasks
 - `add_pull_request_comment`: Add a regular comment to a pull request
 
 

--- a/src/mcp_atlassian/bitbucket/__init__.py
+++ b/src/mcp_atlassian/bitbucket/__init__.py
@@ -4,6 +4,7 @@ from atlassian.bitbucket import Bitbucket
 
 from .branches import BranchesMixin
 from .client import BitbucketClient
+from .cloud import BitbucketCloudClient
 from .config import BitbucketConfig
 from .pullrequests import PullRequestsMixin
 from .repositories import RepositoriesMixin
@@ -38,6 +39,7 @@ class BitbucketFetcher(
 
 __all__ = [
     "BitbucketClient",
+    "BitbucketCloudClient",
     "BitbucketConfig",
     "BitbucketFetcher",
     "UsersMixin",

--- a/src/mcp_atlassian/bitbucket/branches.py
+++ b/src/mcp_atlassian/bitbucket/branches.py
@@ -265,7 +265,6 @@ class BranchesMixin(BitbucketClient):
                 merges=merges,
                 commit_id=commit_id,
             )
-            print(changes)
             return CommitChanges.from_api_response(changes)
         except HTTPError as http_err:
             if http_err.response is not None and http_err.response.status_code in [

--- a/src/mcp_atlassian/bitbucket/client.py
+++ b/src/mcp_atlassian/bitbucket/client.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from atlassian import Bitbucket
 from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.utils.logging import (
@@ -14,6 +16,7 @@ from mcp_atlassian.utils.logging import (
 from mcp_atlassian.utils.oauth import configure_oauth_session
 from mcp_atlassian.utils.ssl import configure_ssl_verification
 
+from .cloud import BitbucketCloudClient
 from .config import BitbucketConfig
 
 # Configure logging
@@ -38,29 +41,48 @@ class BitbucketClient:
         # Load configuration from environment variables if not provided
         self.config = config or BitbucketConfig.from_env()
 
-        # Initialize the Bitbucket client based on auth type
-        if self.config.auth_type == "oauth":
-            if not self.config.oauth_config or not self.config.oauth_config.cloud_id:
-                error_msg = "OAuth authentication requires a valid cloud_id"
-                raise ValueError(error_msg)
-
-            # Create a session for OAuth
+        # Bitbucket Cloud and Server/Data Center use different API dialects.
+        # Cloud always uses the native REST 2.0 adapter; the third-party client
+        # remains in place for Server/Data Center compatibility.
+        if self.config.is_cloud:
             session = Session()
+            retry = Retry(
+                total=3,
+                connect=3,
+                read=3,
+                status=3,
+                backoff_factor=0.5,
+                status_forcelist=(429, 500, 502, 503, 504),
+                allowed_methods=frozenset({"GET", "HEAD", "OPTIONS"}),
+                respect_retry_after_header=True,
+            )
+            adapter = HTTPAdapter(max_retries=retry)
+            session.mount("https://", adapter)
+            session.mount("http://", adapter)
+            if self.config.auth_type == "oauth":
+                if not self.config.oauth_config:
+                    error_msg = "OAuth authentication requires OAuth configuration"
+                    raise ValueError(error_msg)
+                if not configure_oauth_session(session, self.config.oauth_config):
+                    error_msg = "Failed to configure OAuth session"
+                    raise MCPAtlassianAuthenticationError(error_msg)
+            elif self.config.auth_type == "pat":
+                session.headers["Authorization"] = (
+                    f"Bearer {self.config.personal_token}"
+                )
+            else:
+                session.auth = (
+                    self.config.username or "",
+                    self.config.cloud_api_token or "",
+                )
 
-            # Configure the session with OAuth authentication
-            if not configure_oauth_session(session, self.config.oauth_config):
-                error_msg = "Failed to configure OAuth session"
-                raise MCPAtlassianAuthenticationError(error_msg)
-
-            # The Bitbucket API URL with OAuth is different
-            api_url = f"https://api.atlassian.com/ex/bitbucket/{self.config.oauth_config.cloud_id}"
-
-            # Initialize Bitbucket with the session
-            self.bitbucket = Bitbucket(
-                url=api_url,
+            self.bitbucket = BitbucketCloudClient(
                 session=session,
-                cloud=True,  # OAuth is only for Cloud
-                verify_ssl=self.config.ssl_verify,
+                url=self.config.url,
+            )
+            logger.debug(
+                "Initialized native Bitbucket Cloud REST 2.0 client with %s auth",
+                self.config.auth_type,
             )
         elif self.config.auth_type == "pat":
             logger.debug(
@@ -79,7 +101,7 @@ class BitbucketClient:
             logger.debug(
                 f"Initializing Bitbucket client with Basic auth. "
                 f"URL: {self.config.url}, Username: {self.config.username}, "
-                f"App Password present: {bool(self.config.app_password)}, "
+                f"Password present: {bool(self.config.app_password)}, "
                 f"Is Cloud: {self.config.is_cloud}"
             )
             self.bitbucket = Bitbucket(
@@ -90,8 +112,8 @@ class BitbucketClient:
                 verify_ssl=self.config.ssl_verify,
             )
             logger.debug(
-                f"Bitbucket client initialized. Session headers (Authorization masked): "
-                f"{get_masked_session_headers(dict(self.bitbucket._session.headers))}"
+                "Bitbucket client initialized. Session headers "
+                f"(Authorization masked): {get_masked_session_headers(dict(self.bitbucket._session.headers))}"
             )
 
         # Configure SSL verification using the shared utility
@@ -114,7 +136,7 @@ class BitbucketClient:
 
         if proxies:
             self.bitbucket._session.proxies.update(proxies)
-            logger.debug(f"Configured proxies: {proxies}")
+            logger.debug("Configured Bitbucket proxies for: %s", list(proxies))
 
         # Configure no_proxy
         if self.config.no_proxy:
@@ -142,13 +164,15 @@ class BitbucketClient:
             List of comment dictionaries
         """
         try:
-            # Use the generic get method with the appropriate endpoint
             if self.config.is_cloud:
-                # Bitbucket Cloud API 2.0
-                endpoint = f"repositories/{workspace}/{repository}/pullrequests/{pull_request_id}/activities"
-            else:
-                # Bitbucket Server/DC API 1.0
-                endpoint = f"projects/{workspace}/repos/{repository}/pull-requests/{pull_request_id}/activities"
+                return self.bitbucket.get_pull_request_activities(
+                    workspace, repository, pull_request_id
+                )
+
+            endpoint = (
+                f"projects/{workspace}/repos/{repository}/pull-requests/"
+                f"{pull_request_id}/activities"
+            )
 
             response = self.bitbucket.get(endpoint)
 

--- a/src/mcp_atlassian/bitbucket/cloud.py
+++ b/src/mcp_atlassian/bitbucket/cloud.py
@@ -197,7 +197,11 @@ class BitbucketCloudClient:
 
     def project_list(self) -> list[dict[str, Any]]:
         """List workspaces visible to the authenticated principal."""
-        return self._get_paginated("user/workspaces")
+        workspace_access = self._get_paginated("user/workspaces")
+        return [
+            access["workspace"] if isinstance(access.get("workspace"), dict) else access
+            for access in workspace_access
+        ]
 
     def get_repositories(self, workspace: str | None = None) -> list[dict[str, Any]]:
         """List repositories for one workspace or the authenticated user."""

--- a/src/mcp_atlassian/bitbucket/cloud.py
+++ b/src/mcp_atlassian/bitbucket/cloud.py
@@ -1,0 +1,492 @@
+"""Native Bitbucket Cloud REST API client.
+
+The ``atlassian-python-api`` Bitbucket client primarily models the Server/Data
+Center REST API.  Bitbucket Cloud has a different URL structure and response
+schema, so Cloud requests are kept in this small compatibility client instead
+of mixing both API dialects in the MCP operation mixins.
+"""
+
+import logging
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import quote, urlparse, urlunparse
+
+from requests import Session
+from requests.exceptions import HTTPError
+
+from .constants import CLOUD_API_BASE, DEFAULT_PAGE_SIZE, MAX_FILE_SIZE_BYTES
+
+logger = logging.getLogger("mcp-bitbucket")
+
+
+class BitbucketCloudClient:
+    """Synchronous client for the Bitbucket Cloud REST API 2.0."""
+
+    def __init__(
+        self,
+        session: Session,
+        url: str = CLOUD_API_BASE,
+        timeout: float = 30.0,
+        max_pages: int = 100,
+    ) -> None:
+        """Initialize a native Bitbucket Cloud client.
+
+        Args:
+            session: Configured requests session containing authentication.
+            url: User-configured Bitbucket URL.
+            timeout: Per-request timeout in seconds.
+            max_pages: Safety limit for paginated operations.
+        """
+        self._session = session
+        self.base_url = self._normalize_base_url(url)
+        self.timeout = timeout
+        self.max_pages = max_pages
+
+    @staticmethod
+    def _normalize_base_url(url: str) -> str:
+        """Return the canonical Bitbucket Cloud API 2.0 URL."""
+        if not url:
+            return CLOUD_API_BASE
+
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").lower()
+        if hostname in {"bitbucket.org", "www.bitbucket.org", "api.bitbucket.org"}:
+            return CLOUD_API_BASE
+
+        # OAuth configurations created by older versions used the Atlassian
+        # gateway. Bitbucket OAuth tokens are now accepted directly by the
+        # canonical API, so Cloud traffic must not retain that gateway path.
+        if hostname == "api.atlassian.com":
+            return CLOUD_API_BASE
+
+        return url.rstrip("/")
+
+    @staticmethod
+    def _segment(value: str | int) -> str:
+        """URL-encode one path segment."""
+        return quote(str(value), safe="")
+
+    @staticmethod
+    def _path(value: str) -> str:
+        """URL-encode a repository path while preserving separators."""
+        return quote(value.strip("/"), safe="/")
+
+    @staticmethod
+    def _sanitized_url(url: str) -> str:
+        """Remove query parameters from a URL before placing it in an error."""
+        parsed = urlparse(url)
+        return urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+
+    @staticmethod
+    def _error_detail(response: Any) -> str:
+        """Extract the useful nested Bitbucket error message."""
+        try:
+            payload = response.json()
+        except (TypeError, ValueError):
+            return str(getattr(response, "text", "")).strip()
+
+        if not isinstance(payload, dict):
+            return str(payload)
+        error = payload.get("error")
+        if isinstance(error, dict):
+            return str(error.get("message") or error.get("detail") or error)
+        return str(payload.get("message") or error or payload)
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        raw: bool = False,
+    ) -> Any:
+        """Perform one Cloud API request and return decoded data."""
+        url = (
+            endpoint
+            if endpoint.startswith("http")
+            else f"{self.base_url}/{endpoint.lstrip('/')}"
+        )
+        response = self._session.request(
+            method,
+            url,
+            params=params,
+            json=json,
+            timeout=self.timeout,
+        )
+        try:
+            response.raise_for_status()
+        except HTTPError as exc:
+            detail = self._error_detail(response)
+            message = (
+                f"Bitbucket Cloud API {method.upper()} "
+                f"{self._sanitized_url(url)} returned HTTP {response.status_code}"
+            )
+            if detail:
+                message = f"{message}: {detail}"
+            raise HTTPError(
+                message,
+                response=response,
+                request=getattr(response, "request", None),
+            ) from exc
+
+        if raw:
+            content = response.content
+            if len(content) > MAX_FILE_SIZE_BYTES:
+                msg = (
+                    "Bitbucket file is larger than the supported "
+                    f"{MAX_FILE_SIZE_BYTES}-byte limit"
+                )
+                raise ValueError(msg)
+            return content
+
+        if response.status_code == 204 or not response.content:
+            return {}
+        try:
+            return response.json()
+        except ValueError as exc:
+            msg = (
+                f"Bitbucket Cloud API returned invalid JSON for "
+                f"{method.upper()} {self._sanitized_url(url)}"
+            )
+            raise HTTPError(msg, response=response) from exc
+
+    def _get_paginated(
+        self,
+        endpoint: str,
+        *,
+        params: dict[str, Any] | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Follow Bitbucket Cloud ``next`` links with a bounded page count."""
+        values: list[dict[str, Any]] = []
+        next_url: str | None = endpoint
+        next_params = dict(params or {})
+        next_params.setdefault("pagelen", DEFAULT_PAGE_SIZE)
+
+        for _ in range(self.max_pages):
+            if not next_url:
+                break
+            page = self._request("GET", next_url, params=next_params)
+            next_params = {}
+            if isinstance(page, list):
+                page_values = page
+                next_url = None
+            elif isinstance(page, dict):
+                page_values = page.get("values", [])
+                next_url = page.get("next")
+            else:
+                page_values = []
+                next_url = None
+
+            values.extend(item for item in page_values if isinstance(item, dict))
+            if limit is not None and len(values) >= limit:
+                return values[:limit]
+        else:
+            logger.warning(
+                "Stopped Bitbucket Cloud pagination after %s pages for %s",
+                self.max_pages,
+                endpoint,
+            )
+
+        return values if limit is None else values[:limit]
+
+    def get(self, endpoint: str) -> Any:
+        """Compatibility wrapper for a generic GET request."""
+        return self._request("GET", endpoint)
+
+    def project_list(self) -> list[dict[str, Any]]:
+        """List workspaces visible to the authenticated principal."""
+        return self._get_paginated("workspaces")
+
+    def get_repositories(self, workspace: str | None = None) -> list[dict[str, Any]]:
+        """List repositories for one workspace or the authenticated user."""
+        if workspace:
+            endpoint = f"repositories/{self._segment(workspace)}"
+            return self._get_paginated(endpoint)
+        return self._get_paginated("repositories", params={"role": "member"})
+
+    def repo_list(self, workspace: str | None = None) -> Iterator[dict[str, Any]]:
+        """Compatibility iterator for repository listing."""
+        yield from self.get_repositories(workspace)
+
+    def get_repo(self, workspace: str, repository: str) -> dict[str, Any]:
+        """Get one repository."""
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/{self._segment(repository)}"
+        )
+        return self._request("GET", endpoint)
+
+    def get_content_of_file(
+        self, workspace: str, repository: str, path: str, branch: str
+    ) -> bytes:
+        """Return raw file content at a branch or commit."""
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/src/{self._segment(branch)}"
+        )
+        encoded_path = self._path(path)
+        if encoded_path:
+            endpoint = f"{endpoint}/{encoded_path}"
+        return self._request("GET", endpoint, raw=True)
+
+    def get_file_list(
+        self, workspace: str, repository: str, path: str, branch: str
+    ) -> list[dict[str, Any]]:
+        """List entries in a repository directory."""
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/src/{self._segment(branch)}"
+        )
+        encoded_path = self._path(path)
+        if encoded_path:
+            endpoint = f"{endpoint}/{encoded_path}"
+        return self._get_paginated(endpoint)
+
+    def get_branches(
+        self,
+        workspace: str,
+        repository: str,
+        base: str | None = None,
+        filter: str | None = None,
+        start: int = 0,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List repository branches using Cloud refs."""
+        del base  # Server/DC-only graph traversal option.
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/refs/branches"
+        )
+        fetch_limit = None if limit is None or filter else max(0, start) + max(0, limit)
+        branches = self._get_paginated(endpoint, limit=fetch_limit)
+        if filter:
+            branches = [
+                branch
+                for branch in branches
+                if filter.lower() in str(branch.get("name", "")).lower()
+            ]
+        end = None if limit is None else max(0, start) + max(0, limit)
+        return branches[max(0, start) : end]
+
+    def get_default_branch(self, workspace: str, repository: str) -> dict[str, Any]:
+        """Get the repository main branch."""
+        repository_data = self.get_repo(workspace, repository)
+        main_branch = repository_data.get("mainbranch")
+        if not isinstance(main_branch, dict):
+            return {}
+        return {**main_branch, "isDefault": True}
+
+    def get_commits(
+        self,
+        workspace: str,
+        repository: str,
+        limit: int = 25,
+        until: str | None = None,
+        since: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List commits, mapping Server/DC range names to Cloud parameters."""
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/commits"
+        )
+        params: dict[str, Any] = {}
+        if until:
+            params["include"] = until
+        if since:
+            params["exclude"] = since
+        return self._get_paginated(endpoint, params=params, limit=max(0, limit))
+
+    def get_commit_changes(
+        self,
+        *,
+        project_key: str,
+        repository_slug: str,
+        commit_id: str,
+        hash_newest: str | None = None,
+        merges: str = "include",
+    ) -> dict[str, Any]:
+        """Get Cloud diffstat entries for a commit or revision range."""
+        del (
+            merges
+        )  # Cloud diffstat includes merge changes in its native representation.
+        revision = f"{commit_id}..{hash_newest}" if hash_newest else commit_id
+        endpoint = (
+            f"repositories/{self._segment(project_key)}/"
+            f"{self._segment(repository_slug)}/diffstat/{self._segment(revision)}"
+        )
+        values = self._get_paginated(endpoint)
+        return {
+            "fromHash": commit_id,
+            "toHash": hash_newest or commit_id,
+            "values": values,
+        }
+
+    def create_branch(
+        self, workspace: str, repository: str, name: str, start_point: str
+    ) -> dict[str, Any]:
+        """Create a branch from an existing Cloud branch or commit hash."""
+        branch_endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/refs/branches/{self._segment(start_point)}"
+        )
+        source = self._request("GET", branch_endpoint)
+        target = source.get("target", {}) if isinstance(source, dict) else {}
+        target_hash = target.get("hash") or start_point
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/refs/branches"
+        )
+        return self._request(
+            "POST",
+            endpoint,
+            json={"name": name, "target": {"hash": target_hash}},
+        )
+
+    def get_pull_requests(
+        self, workspace: str, repository: str, state: str = "OPEN"
+    ) -> list[dict[str, Any]]:
+        """List pull requests in a state."""
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/pullrequests"
+        )
+        return self._get_paginated(endpoint, params={"state": state})
+
+    def get_pull_request(
+        self, workspace: str, repository: str, pull_request_id: int
+    ) -> dict[str, Any]:
+        """Get one pull request."""
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/pullrequests/"
+            f"{self._segment(pull_request_id)}"
+        )
+        return self._request("GET", endpoint)
+
+    def get_pull_requests_commits(
+        self, workspace: str, repository: str, pull_request_id: int
+    ) -> list[dict[str, Any]]:
+        """List commits in a pull request."""
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/pullrequests/"
+            f"{self._segment(pull_request_id)}/commits"
+        )
+        return self._get_paginated(endpoint)
+
+    def get_pull_request_activities(
+        self, workspace: str, repository: str, pull_request_id: int
+    ) -> list[dict[str, Any]]:
+        """List all pull-request activities."""
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/pullrequests/"
+            f"{self._segment(pull_request_id)}/activity"
+        )
+        return self._get_paginated(endpoint)
+
+    @staticmethod
+    def _branch_name(reference: Any) -> str | None:
+        """Extract a branch name from Cloud or Server/DC PR input."""
+        if not isinstance(reference, dict):
+            return None
+        branch = reference.get("branch")
+        if isinstance(branch, dict) and branch.get("name"):
+            return str(branch["name"])
+        identifier = reference.get("id")
+        if identifier:
+            return str(identifier).removeprefix("refs/heads/")
+        return None
+
+    def create_pull_request(
+        self, workspace: str, repository: str, pr_data: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Create a pull request using the Cloud request schema."""
+        source_name = self._branch_name(pr_data.get("source")) or self._branch_name(
+            pr_data.get("fromRef")
+        )
+        destination_name = self._branch_name(
+            pr_data.get("destination")
+        ) or self._branch_name(pr_data.get("toRef"))
+        if not source_name or not destination_name:
+            msg = "Pull request source and destination branches are required"
+            raise ValueError(msg)
+
+        payload: dict[str, Any] = {
+            "title": pr_data.get("title"),
+            "source": {"branch": {"name": source_name}},
+            "destination": {"branch": {"name": destination_name}},
+        }
+        if pr_data.get("description") is not None:
+            payload["description"] = pr_data["description"]
+        if "close_source_branch" in pr_data:
+            payload["close_source_branch"] = bool(pr_data["close_source_branch"])
+        if pr_data.get("reviewers"):
+            payload["reviewers"] = pr_data["reviewers"]
+
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/pullrequests"
+        )
+        return self._request("POST", endpoint, json=payload)
+
+    @staticmethod
+    def _comment_text(comment_data: Any) -> str:
+        """Extract raw text from MCP, Cloud, or Server/DC comment input."""
+        if isinstance(comment_data, str):
+            return comment_data
+        if not isinstance(comment_data, dict):
+            return str(comment_data)
+        content = comment_data.get("content")
+        if isinstance(content, dict):
+            return str(content.get("raw") or content.get("text") or "")
+        if content is not None:
+            return str(content)
+        return str(comment_data.get("text") or comment_data.get("comment") or "")
+
+    def add_pull_request_comment(
+        self,
+        workspace: str,
+        repository: str,
+        pull_request_id: int,
+        comment_data: Any,
+    ) -> dict[str, Any]:
+        """Add a Cloud pull-request comment."""
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/pullrequests/"
+            f"{self._segment(pull_request_id)}/comments"
+        )
+        payload = {"content": {"raw": self._comment_text(comment_data)}}
+        return self._request("POST", endpoint, json=payload)
+
+    def add_pull_request_blocker_comment(
+        self,
+        workspace: str,
+        repository: str,
+        pull_request_id: int,
+        comment: str,
+        severity: str | None = None,
+    ) -> dict[str, Any]:
+        """Map blocker-comment semantics to Cloud comments or tasks.
+
+        Bitbucket Cloud has no Data Center blocker-comment resource. A normal
+        severity remains a PR comment, while a blocker becomes an actionable
+        PR task containing the supplied text.
+        """
+        if severity != "BLOCKER":
+            return self.add_pull_request_comment(
+                workspace, repository, pull_request_id, comment
+            )
+
+        endpoint = (
+            f"repositories/{self._segment(workspace)}/"
+            f"{self._segment(repository)}/pullrequests/"
+            f"{self._segment(pull_request_id)}/tasks"
+        )
+        return self._request(
+            "POST",
+            endpoint,
+            json={"content": {"raw": comment}},
+        )

--- a/src/mcp_atlassian/bitbucket/cloud.py
+++ b/src/mcp_atlassian/bitbucket/cloud.py
@@ -197,14 +197,26 @@ class BitbucketCloudClient:
 
     def project_list(self) -> list[dict[str, Any]]:
         """List workspaces visible to the authenticated principal."""
-        return self._get_paginated("workspaces")
+        return self._get_paginated("user/workspaces")
 
     def get_repositories(self, workspace: str | None = None) -> list[dict[str, Any]]:
         """List repositories for one workspace or the authenticated user."""
         if workspace:
             endpoint = f"repositories/{self._segment(workspace)}"
             return self._get_paginated(endpoint)
-        return self._get_paginated("repositories", params={"role": "member"})
+
+        repositories: list[dict[str, Any]] = []
+        for workspace_data in self.project_list():
+            workspace_id = workspace_data.get("slug") or workspace_data.get("uuid")
+            if not workspace_id:
+                logger.warning(
+                    "Skipping Bitbucket workspace without a slug or UUID: %s",
+                    workspace_data,
+                )
+                continue
+            endpoint = f"repositories/{self._segment(workspace_id)}"
+            repositories.extend(self._get_paginated(endpoint))
+        return repositories
 
     def repo_list(self, workspace: str | None = None) -> Iterator[dict[str, Any]]:
         """Compatibility iterator for repository listing."""
@@ -241,6 +253,8 @@ class BitbucketCloudClient:
         encoded_path = self._path(path)
         if encoded_path:
             endpoint = f"{endpoint}/{encoded_path}"
+        else:
+            endpoint = f"{endpoint}/"
         return self._get_paginated(endpoint)
 
     def get_branches(
@@ -260,6 +274,19 @@ class BitbucketCloudClient:
         )
         fetch_limit = None if limit is None or filter else max(0, start) + max(0, limit)
         branches = self._get_paginated(endpoint, limit=fetch_limit)
+        try:
+            default_branch = self.get_default_branch(workspace, repository)
+        except HTTPError:
+            logger.warning(
+                "Could not determine the default branch for %s/%s",
+                workspace,
+                repository,
+                exc_info=True,
+            )
+        else:
+            default_name = default_branch.get("name")
+            for branch in branches:
+                branch["isDefault"] = branch.get("name") == default_name
         if filter:
             branches = [
                 branch

--- a/src/mcp_atlassian/bitbucket/config.py
+++ b/src/mcp_atlassian/bitbucket/config.py
@@ -18,14 +18,15 @@ class BitbucketConfig:
     """Bitbucket API configuration.
 
     Handles authentication for Bitbucket Cloud and Server/Data Center:
-    - Cloud: username/app password (basic auth) or OAuth 2.0 (3LO)
+    - Cloud: email/API token (basic auth), access token, or OAuth 2.0 (3LO)
     - Server/DC: personal access token or basic auth
     """
 
     url: str  # Base URL for Bitbucket
     auth_type: Literal["basic", "pat", "oauth"]  # Authentication type
     username: str | None = None  # Email or username (Cloud)
-    app_password: str | None = None  # App password (Cloud)
+    app_password: str | None = None  # Password or deprecated Cloud input alias
+    api_token: str | None = None  # Bitbucket Cloud API token
     personal_token: str | None = None  # Personal access token (Server/DC)
     oauth_config: OAuthConfig | BYOAccessTokenOAuthConfig | None = None
     ssl_verify: bool = True  # Whether to verify SSL certificates
@@ -44,13 +45,8 @@ class BitbucketConfig:
             True if this is a cloud instance, False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
-        # Multi-Cloud OAuth mode: URL might be None, but we use api.atlassian.com
-        if (
-            self.auth_type == "oauth"
-            and self.oauth_config
-            and self.oauth_config.cloud_id
-        ):
-            # OAuth with cloud_id uses api.atlassian.com which is always Cloud
+        if self.auth_type == "oauth" and self.oauth_config:
+            # Bitbucket OAuth is Cloud-only and uses api.bitbucket.org directly.
             return True
 
         # For other auth types, use shared utility function for consistency
@@ -66,6 +62,16 @@ class BitbucketConfig:
         """
         return self.ssl_verify
 
+    @property
+    def cloud_api_token(self) -> str | None:
+        """Return the configured Cloud Basic-auth token.
+
+        ``BITBUCKET_APP_PASSWORD`` remains an input alias so existing
+        deployments can migrate without changing secret wiring at the same
+        time as this API fix.
+        """
+        return self.api_token or self.app_password
+
     def is_auth_configured(self) -> bool:
         """Check if authentication is properly configured.
 
@@ -77,7 +83,8 @@ class BitbucketConfig:
         elif self.auth_type == "pat":
             return bool(self.personal_token)
         elif self.auth_type == "basic":
-            return bool(self.username and self.app_password)
+            credential = self.cloud_api_token if self.is_cloud else self.app_password
+            return bool(self.username and credential)
         return False
 
     @classmethod
@@ -97,6 +104,7 @@ class BitbucketConfig:
 
         # Determine authentication type based on available environment variables
         username = os.getenv("BITBUCKET_USERNAME")
+        api_token = os.getenv("BITBUCKET_API_TOKEN")
         app_password = os.getenv("BITBUCKET_APP_PASSWORD")
         personal_token = os.getenv("BITBUCKET_PERSONAL_TOKEN")
 
@@ -109,19 +117,24 @@ class BitbucketConfig:
         if oauth_config:
             # OAuth is available - could be full config or minimal config for user-provided tokens
             auth_type = "oauth"
-        elif personal_token:
-            auth_type = "pat"
         elif is_cloud:
-            if username and app_password:
+            if username and (api_token or app_password):
                 auth_type = "basic"
+            elif personal_token:
+                # Workspace, project, repository, and OAuth access tokens use
+                # Bearer authentication against the Cloud API.
+                auth_type = "pat"
             else:
                 error_msg = (
-                    "For Bitbucket Cloud, either provide BITBUCKET_PERSONAL_TOKEN for PAT auth, "
-                    "BITBUCKET_USERNAME and BITBUCKET_APP_PASSWORD for basic auth, or configure OAuth"
+                    "For Bitbucket Cloud, provide BITBUCKET_USERNAME and "
+                    "BITBUCKET_API_TOKEN for basic auth, BITBUCKET_PERSONAL_TOKEN "
+                    "for bearer auth, or configure OAuth"
                 )
                 raise ValueError(error_msg)
         else:
-            if username and app_password:
+            if personal_token:
+                auth_type = "pat"
+            elif username and app_password:
                 auth_type = "basic"
             else:
                 error_msg = (
@@ -136,6 +149,7 @@ class BitbucketConfig:
             auth_type=auth_type,  # type: ignore[arg-type]
             username=username,
             app_password=app_password,
+            api_token=api_token,
             personal_token=personal_token,
             oauth_config=oauth_config,
             ssl_verify=is_env_ssl_verify("BITBUCKET_SSL_VERIFY"),

--- a/src/mcp_atlassian/bitbucket/repositories.py
+++ b/src/mcp_atlassian/bitbucket/repositories.py
@@ -35,9 +35,8 @@ class RepositoriesMixin(BitbucketClient):
             MCPAtlassianAuthenticationError: If authentication fails with the Bitbucket API (401/403)
         """
         try:
-            # Use the base class method that returns raw dictionaries
             raw_repos = self.bitbucket.get_repositories(workspace)
-            return raw_repos
+            return [BitbucketRepository.from_api_response(repo) for repo in raw_repos]
         except HTTPError as http_err:
             if http_err.response is not None and http_err.response.status_code in [
                 401,
@@ -181,11 +180,14 @@ class RepositoriesMixin(BitbucketClient):
             msg = f"Error getting directory content: {str(e)}"
             raise Exception(msg) from e
 
-    def get_repositories(self, workspace: str) -> list[BitbucketRepository]:
+    def get_repositories(
+        self, workspace: str | None = None
+    ) -> list[BitbucketRepository]:
         """Get list of repositories.
 
         Args:
-            workspace: Workspace name (Cloud) or project key (Server/DC)
+            workspace: Workspace name (Cloud) or project key (Server/DC).
+                Cloud can list repositories across accessible workspaces when omitted.
 
         Returns:
             List of repository dictionaries

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -1,6 +1,8 @@
 """Module for Jira search operations."""
 
 import logging
+import os
+from typing import Any
 
 import requests
 from requests.exceptions import HTTPError
@@ -12,6 +14,21 @@ from .constants import DEFAULT_READ_JIRA_FIELDS
 from .protocols import IssueOperationsProto
 
 logger = logging.getLogger("mcp-jira")
+
+_CLOUD_PAGE_UPPER_BOUND = 5000
+
+
+def _resolve_cloud_page_size(limit_value: int | None) -> int:
+    """Resolve the page size for Jira Cloud enhanced search."""
+    try:
+        from_env = int(os.getenv("JIRA_SEARCH_PAGE_SIZE", "1000"))
+    except ValueError:
+        from_env = 1000
+
+    base_size = min(max(from_env, 1), _CLOUD_PAGE_UPPER_BOUND)
+    if isinstance(limit_value, int) and limit_value > 0:
+        return min(base_size, limit_value)
+    return base_size
 
 
 class SearchMixin(JiraClient, IssueOperationsProto):
@@ -74,7 +91,7 @@ class SearchMixin(JiraClient, IssueOperationsProto):
                     # Only add if not already filtering by project
                     jql = f"({jql}) AND {project_query}"
 
-                logger.info(f"Applied projects filter to query: {jql}")
+                logger.info("Applied projects filter to query: %s", jql)
 
             # Convert fields to proper format if it's a list/tuple/set
             fields_param: str | None
@@ -86,56 +103,138 @@ class SearchMixin(JiraClient, IssueOperationsProto):
                 fields_param = fields
 
             if self.config.is_cloud:
-                actual_total = -1
+                limit_value = limit if isinstance(limit, int) else 50
+                limit_value = max(limit_value, 0)
+                response_dict_for_model: dict[str, Any] = {}
                 try:
-                    # Call 1: Get metadata (including total) using standard search API
-                    metadata_params = {"jql": jql, "maxResults": 0}
-                    metadata_response = self.jira.get(
-                        self.jira.resource_url("search"), params=metadata_params
-                    )
+                    issues_accumulated: list[dict] = []
+                    remaining = limit_value
+                    token_for_request: str | None = None
+                    last_response: dict[str, Any] | None = None
+                    page_size = _resolve_cloud_page_size(limit_value)
 
-                    if (
-                        isinstance(metadata_response, dict)
-                        and "total" in metadata_response
-                    ):
-                        try:
-                            actual_total = int(metadata_response["total"])
-                        except (ValueError, TypeError):
-                            logger.warning(
-                                f"Could not parse 'total' from metadata response for JQL: {jql}. Received: {metadata_response.get('total')}"
-                            )
-                    else:
-                        logger.warning(
-                            f"Could not retrieve total count from metadata response for JQL: {jql}. Response type: {type(metadata_response)}"
+                    if limit_value == 0:
+                        params: dict[str, Any] = {"jql": jql, "maxResults": 0}
+                        if fields_param:
+                            params["fields"] = fields_param
+                        if expand:
+                            params["expand"] = expand
+
+                        last_response = self.jira.get(
+                            self.jira.resource_url("search/jql"), params=params
                         )
-                except Exception as meta_err:
-                    logger.error(
-                        f"Error fetching metadata for JQL '{jql}': {str(meta_err)}"
+                        if not isinstance(last_response, dict):
+                            msg = (
+                                "Unexpected return value type from Jira search/jql "
+                                f"response when limit is zero: {type(last_response)}"
+                            )
+                            logger.error(msg)
+                            raise TypeError(msg)
+
+                        logger.info(
+                            "jira_search event=cloud_meta_only jql_hash=%d page_size=%d token_present=%s is_last=%s",
+                            hash(jql),
+                            0,
+                            bool(last_response.get("nextPageToken")),
+                            last_response.get("isLast"),
+                        )
+                    else:
+                        while remaining > 0:
+                            current_page_size = min(page_size, remaining)
+                            params = {"jql": jql, "maxResults": current_page_size}
+                            if token_for_request:
+                                params["nextPageToken"] = token_for_request
+                            if fields_param:
+                                params["fields"] = fields_param
+                            if expand:
+                                params["expand"] = expand
+
+                            response = self.jira.get(
+                                self.jira.resource_url("search/jql"), params=params
+                            )
+                            if not isinstance(response, dict):
+                                msg = f"Unexpected return value type from Jira search/jql response: {type(response)}"
+                                logger.error(msg)
+                                raise TypeError(msg)
+
+                            last_response = response
+                            page_issues = response.get("issues") or []
+                            if not isinstance(page_issues, list):
+                                msg = f"Unexpected issues payload type from Jira search/jql response: {type(page_issues)}"
+                                logger.error(msg)
+                                raise TypeError(msg)
+
+                            issues_accumulated.extend(page_issues)
+                            remaining = max(remaining - len(page_issues), 0)
+
+                            next_page_token = response.get("nextPageToken")
+                            is_last_page = response.get("isLast")
+
+                            logger.info(
+                                "jira_search event=cloud_page jql_hash=%d page_size=%d token_present=%s is_last=%s",
+                                hash(jql),
+                                current_page_size,
+                                bool(next_page_token),
+                                is_last_page,
+                            )
+
+                            if remaining <= 0:
+                                break
+                            if not page_issues:
+                                logger.warning(
+                                    "jira_search event=empty_page jql_hash=%d token_present=%s is_last=%s",
+                                    hash(jql),
+                                    bool(next_page_token),
+                                    is_last_page,
+                                )
+                                break
+                            if not next_page_token or is_last_page is True:
+                                break
+
+                            token_for_request = str(next_page_token)
+
+                    trimmed_issues = (
+                        issues_accumulated[:limit_value]
+                        if limit_value > 0
+                        else issues_accumulated
+                    )
+                    response_dict_for_model["issues"] = trimmed_issues
+                    response_dict_for_model["nextPageToken"] = (
+                        last_response.get("nextPageToken")
+                        if isinstance(last_response, dict)
+                        else None
+                    )
+                    response_dict_for_model["isLast"] = (
+                        last_response.get("isLast")
+                        if isinstance(last_response, dict)
+                        else None
                     )
 
-                # Call 2: Get the actual issues using the enhanced method
-                issues_response_list = self.jira.enhanced_jql_get_list_of_tickets(
-                    jql, fields=fields_param, limit=limit, expand=expand
-                )
+                    if isinstance(last_response, dict):
+                        total_value = last_response.get("total")
+                        if isinstance(total_value, int):
+                            response_dict_for_model["total"] = int(total_value)
+                        max_results_value = last_response.get("maxResults")
+                        if isinstance(max_results_value, int):
+                            response_dict_for_model["maxResults"] = int(
+                                max_results_value
+                            )
 
-                if not isinstance(issues_response_list, list):
-                    msg = f"Unexpected return value type from `jira.enhanced_jql_get_list_of_tickets`: {type(issues_response_list)}"
-                    logger.error(msg)
-                    raise TypeError(msg)
+                    if "maxResults" not in response_dict_for_model:
+                        response_dict_for_model["maxResults"] = len(trimmed_issues)
 
-                response_dict_for_model = {
-                    "issues": issues_response_list,
-                    "total": actual_total,
-                }
+                    search_result = JiraSearchResult.from_api_response(
+                        response_dict_for_model,
+                        base_url=self.config.url,
+                        requested_fields=fields_param,
+                    )
 
-                search_result = JiraSearchResult.from_api_response(
-                    response_dict_for_model,
-                    base_url=self.config.url,
-                    requested_fields=fields_param,
-                )
-
-                # Return the full search result object
-                return search_result
+                    return search_result
+                except Exception:
+                    logger.error(
+                        "Error executing Jira Cloud enhanced search", exc_info=True
+                    )
+                    raise
             else:
                 limit = min(limit, 50)
                 response = self.jira.jql(
@@ -166,10 +265,10 @@ class SearchMixin(JiraClient, IssueOperationsProto):
                 logger.error(error_msg)
                 raise MCPAtlassianAuthenticationError(error_msg) from http_err
             else:
-                logger.error(f"HTTP error during API call: {http_err}", exc_info=False)
+                logger.error("HTTP error during API call: %s", http_err, exc_info=False)
                 raise http_err
         except Exception as e:
-            logger.error(f"Error searching issues with JQL '{jql}': {str(e)}")
+            logger.error("Error searching issues with JQL '%s': %s", jql, e)
             msg = f"Error searching issues: {str(e)}"
             raise Exception(msg) from e
 
@@ -224,16 +323,12 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             )
             return search_result
         except requests.HTTPError as e:
-            logger.error(
-                f"Error searching issues for board with JQL '{board_id}': {str(e.response.content)}"
-            )
-            msg = (
-                f"Error searching issues for board with JQL: {str(e.response.content)}"
-            )
+            msg = f"Error searching issues for board with JQL: {e}"
+            logger.error(msg)
             raise Exception(msg) from e
         except Exception as e:
-            logger.error(f"Error searching issues for board with JQL '{jql}': {str(e)}")
-            msg = f"Error searching issues for board with JQL {str(e)}"
+            msg = f"Error searching issues for board with JQL: {e}"
+            logger.error(msg)
             raise Exception(msg) from e
 
     def get_sprint_issues(
@@ -280,12 +375,8 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             )
             return search_result
         except requests.HTTPError as e:
-            logger.error(
-                f"Error searching issues for sprint '{sprint_id}': {str(e.response.content)}"
-            )
-            msg = f"Error searching issues for sprint: {str(e.response.content)}"
-            raise Exception(msg) from e
+            logger.error("Error searching issues for sprint: %s", e)
+            raise Exception(f"Error searching issues for sprint: {e}") from e
         except Exception as e:
-            logger.error(f"Error searching issues for sprint: {sprint_id}': {str(e)}")
-            msg = f"Error searching issues for sprint: {str(e)}"
-            raise Exception(msg) from e
+            logger.error("Error searching issues for sprint: %s", e)
+            raise Exception(f"Error searching issues for sprint: {e}") from e

--- a/src/mcp_atlassian/models/bitbucket/common.py
+++ b/src/mcp_atlassian/models/bitbucket/common.py
@@ -88,7 +88,11 @@ class BitbucketWorkspace(ApiModel):
             return cls()
 
         return cls(
-            name=data.get("name", UNKNOWN),
+            name=data.get("name")
+            or data.get("slug")
+            or data.get("key")
+            or data.get("uuid")
+            or UNKNOWN,
             type=data.get("type"),
             description=data.get("description"),
             public=data.get("public", not data.get("is_private", True)),

--- a/src/mcp_atlassian/models/bitbucket/common.py
+++ b/src/mcp_atlassian/models/bitbucket/common.py
@@ -27,6 +27,9 @@ class BitbucketUser(ApiModel):
     display_name: str | None = None
     type: str | None = None
     links: dict[str, Any] | None = None
+    uuid: str | None = None
+    nickname: str | None = None
+    account_id: str | None = None
 
     @classmethod
     def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "BitbucketUser":
@@ -34,13 +37,30 @@ class BitbucketUser(ApiModel):
         if not data:
             return cls()
 
+        nested_user = data.get("user")
+        source = nested_user if isinstance(nested_user, dict) else data
+        raw_author = str(data.get("raw") or "")
+        raw_name, _, raw_email = raw_author.partition("<")
         return cls(
-            name=data.get("name"),
-            email=data.get("emailAddress"),
-            display_name=data.get("displayName", UNKNOWN),
-            active=data.get("active"),
-            type=data.get("type"),
-            links=data.get("links", {}),
+            name=source.get("name")
+            or source.get("nickname")
+            or source.get("username")
+            or raw_name.strip()
+            or None,
+            email=source.get("emailAddress")
+            or source.get("email")
+            or raw_email.rstrip(">").strip()
+            or None,
+            display_name=source.get("displayName")
+            or source.get("display_name")
+            or raw_name.strip()
+            or UNKNOWN,
+            active=source.get("active"),
+            type=source.get("type") or data.get("type"),
+            links=source.get("links", {}),
+            uuid=source.get("uuid"),
+            nickname=source.get("nickname"),
+            account_id=source.get("account_id"),
         )
 
 
@@ -53,6 +73,11 @@ class BitbucketWorkspace(ApiModel):
     public: bool = False
     type: str | None = None
     links: dict[str, Any] | None = None
+    slug: str | None = None
+    uuid: str | None = None
+    is_private: bool | None = None
+    created_on: str | None = None
+    updated_on: str | None = None
 
     @classmethod
     def from_api_response(
@@ -66,9 +91,14 @@ class BitbucketWorkspace(ApiModel):
             name=data.get("name", UNKNOWN),
             type=data.get("type"),
             description=data.get("description"),
-            public=data.get("public", False),
+            public=data.get("public", not data.get("is_private", True)),
             links=data.get("links"),
             key=data.get("key"),
+            slug=data.get("slug"),
+            uuid=data.get("uuid"),
+            is_private=data.get("is_private"),
+            created_on=data.get("created_on"),
+            updated_on=data.get("updated_on"),
         )
 
 
@@ -84,6 +114,16 @@ class BitbucketRepository(ApiModel):
     public: bool | None = False
     archived: bool | None = False
     links: dict[str, Any] | None = None
+    uuid: str | None = None
+    full_name: str | None = None
+    is_private: bool | None = None
+    scm: str | None = None
+    language: str | None = None
+    size: int | None = None
+    mainbranch: dict[str, Any] | None = None
+    owner: dict[str, Any] | None = None
+    created_on: str | None = None
+    updated_on: str | None = None
 
     @classmethod
     def from_api_response(
@@ -98,18 +138,28 @@ class BitbucketRepository(ApiModel):
             name=data.get("name"),
             description=data.get("description"),
             state=data.get("state"),
-            forkable=data.get("forkable", True),
+            forkable=data.get("forkable", data.get("fork_policy") != "no_forks"),
             project=data.get("project", {}),
-            public=data.get("public", False),
+            public=data.get("public", not data.get("is_private", True)),
             archived=data.get("archived", False),
             links=data.get("links", {}),
+            uuid=data.get("uuid"),
+            full_name=data.get("full_name"),
+            is_private=data.get("is_private"),
+            scm=data.get("scm"),
+            language=data.get("language"),
+            size=data.get("size"),
+            mainbranch=data.get("mainbranch"),
+            owner=data.get("owner"),
+            created_on=data.get("created_on"),
+            updated_on=data.get("updated_on"),
         )
 
 
 class BitbucketBranch(ApiModel):
     """Model representing a Bitbucket branch."""
 
-    id_: str = Field(alias="id")
+    id_: str | None = Field(default=None, alias="id")
     name: str | None = None
     type: str | None = None
     latest_commit: str | None = None
@@ -125,27 +175,29 @@ class BitbucketBranch(ApiModel):
         if not data:
             return cls()
 
+        target = data.get("target") if isinstance(data.get("target"), dict) else {}
+        branch_name = data.get("displayId") or data.get("name") or UNKNOWN
         return cls(
-            name=data.get("displayId", UNKNOWN),
-            id=data.get("id", UNKNOWN),
+            name=branch_name,
+            id=data.get("id") or branch_name,
             type=data.get("type"),
-            latest_commit=data.get("latestCommit"),
+            latest_commit=data.get("latestCommit") or target.get("hash"),
             latest_changeset=data.get("latestChangeset"),
             is_default=data.get("isDefault", False),
-            metadata=data.get("metadata", {}),
+            metadata=data.get("metadata") or target,
         )
 
 
 class BitbucketCommit(ApiModel):
     """Model representing a Bitbucket commit."""
 
-    id_: str | None = Field(alias="id")
+    id_: str | None = Field(default=None, alias="id")
     message: str | None = None
     author: BitbucketUser | None = None
     committer: BitbucketUser | None = None
     parents: list[dict[str, Any]] = Field(default_factory=list)
-    author_timestamp: int | None = None
-    committer_timestamp: int | None = None
+    author_timestamp: int | str | None = None
+    committer_timestamp: int | str | None = None
 
     @classmethod
     def from_api_response(
@@ -156,14 +208,14 @@ class BitbucketCommit(ApiModel):
             return cls()
 
         return cls(
-            id=data.get("id"),
+            id=data.get("id") or data.get("hash"),
             message=data.get("message"),
             author=BitbucketUser.from_api_response(data.get("author", {}))
             if data.get("author")
             else None,
             committer=BitbucketUser.from_api_response(data.get("committer", {})),
-            author_timestamp=data.get("authorTimestamp"),
-            committer_timestamp=data.get("committerTimestamp"),
+            author_timestamp=data.get("authorTimestamp") or data.get("date"),
+            committer_timestamp=data.get("committerTimestamp") or data.get("date"),
             parents=data.get("parents", []),
         )
 
@@ -171,24 +223,24 @@ class BitbucketCommit(ApiModel):
 class BitbucketPullRequest(ApiModel, TimestampMixin):
     """Model representing a Bitbucket pull request."""
 
-    id_: int | None = Field(alias="id")
-    version: int | None
-    title: str | None
-    description: str | None
-    state: str | None
+    id_: int | None = Field(default=None, alias="id")
+    version: int | None = None
+    title: str | None = None
+    description: str | None = None
+    state: str | None = None
     open: bool | None = False
     draft: bool | None = False
     closed: bool | None = False
-    created_date: int | None
-    updated_date: int | None
-    closed_date: int | None
-    from_ref: dict[str, Any] | None
-    to_ref: dict[str, Any] | None
+    created_date: int | str | None = None
+    updated_date: int | str | None = None
+    closed_date: int | str | None = None
+    from_ref: dict[str, Any] | None = None
+    to_ref: dict[str, Any] | None = None
     locked: bool | None = False
-    author: dict[str, Any] | None
-    reviewers: list[dict] | None
-    participants: list[dict] | None
-    links: dict[str, Any] | None
+    author: dict[str, Any] | None = None
+    reviewers: list[dict[str, Any]] | None = None
+    participants: list[dict[str, Any]] | None = None
+    links: dict[str, Any] | None = None
 
     @classmethod
     def from_api_response(
@@ -198,21 +250,22 @@ class BitbucketPullRequest(ApiModel, TimestampMixin):
         if not data:
             return cls()
 
+        state = data.get("state")
         return cls(
             id=data.get("id"),
             version=data.get("version"),
             title=data.get("title", UNKNOWN),
             description=data.get("description"),
             state=data.get("state"),
-            open=data.get("open", False),
+            open=data.get("open", state == "OPEN"),
             draft=data.get("draft", False),
-            closed=data.get("closed", False),
+            closed=data.get("closed", state in {"MERGED", "DECLINED", "SUPERSEDED"}),
             author=data.get("author"),
-            created_date=data.get("createdDate"),
-            updated_date=data.get("updatedDate"),
-            closed_date=data.get("closedDate"),
-            from_ref=data.get("fromRef"),
-            to_ref=data.get("toRef"),
+            created_date=data.get("createdDate") or data.get("created_on"),
+            updated_date=data.get("updatedDate") or data.get("updated_on"),
+            closed_date=data.get("closedDate") or data.get("closed_on"),
+            from_ref=data.get("fromRef") or data.get("source"),
+            to_ref=data.get("toRef") or data.get("destination"),
             locked=data.get("locked"),
             reviewers=data.get("reviewers", []),
             participants=data.get("participants", []),
@@ -221,25 +274,33 @@ class BitbucketPullRequest(ApiModel, TimestampMixin):
 
 
 class CommitChange(ApiModel):
-    content_id: str | None
-    from_content_id: str | None
-    path: dict[str, Any] | None
-    executable: bool | None
-    percent_unchanged: int | None
-    type: str | None
-    node_type: str | None
-    src_executable: bool | None
-    links: dict[str, Any] | None
-    properties: dict[str, Any] | None
+    content_id: str | None = None
+    from_content_id: str | None = None
+    path: dict[str, Any] | None = None
+    executable: bool | None = None
+    percent_unchanged: int | None = None
+    type: str | None = None
+    node_type: str | None = None
+    src_executable: bool | None = None
+    links: dict[str, Any] | None = None
+    properties: dict[str, Any] | None = None
+    status: str | None = None
+    old: dict[str, Any] | None = None
+    new: dict[str, Any] | None = None
+    lines_added: int | None = None
+    lines_removed: int | None = None
 
     @classmethod
     def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "CommitChange":
         if not data:
             return cls()
+        old = data.get("old") if isinstance(data.get("old"), dict) else None
+        new = data.get("new") if isinstance(data.get("new"), dict) else None
+        path = data.get("path") or new or old
         return cls(
             content_id=data.get("contentId"),
             from_content_id=data.get("fromContentId"),
-            path=data.get("path"),
+            path=path,
             executable=data.get("executable"),
             percent_unchanged=data.get("percentUnchanged"),
             type=data.get("type"),
@@ -247,19 +308,24 @@ class CommitChange(ApiModel):
             src_executable=data.get("srcExecutable"),
             links=data.get("links"),
             properties=data.get("properties"),
+            status=data.get("status"),
+            old=old,
+            new=new,
+            lines_added=data.get("lines_added"),
+            lines_removed=data.get("lines_removed"),
         )
 
 
 class CommitChanges(ApiModel):
-    from_hash: str | None
-    to_hash: str | None
-    properties: dict[str, Any] | None
-    values: list[CommitChange] | None
-    size: int | None
-    is_last_page: bool | None
+    from_hash: str | None = None
+    to_hash: str | None = None
+    properties: dict[str, Any] | None = None
+    values: list[CommitChange] | None = None
+    size: int | None = None
+    is_last_page: bool | None = None
     start: int | None = 0
     limit: int | None = 25
-    next_page_start: int | None
+    next_page_start: int | None = None
 
     @classmethod
     def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "CommitChanges":
@@ -274,8 +340,8 @@ class CommitChanges(ApiModel):
             ]
             if data.get("values")
             else None,
-            size=data.get("size"),
-            is_last_page=data.get("isLastPage"),
+            size=data.get("size", len(data.get("values", []))),
+            is_last_page=data.get("isLastPage", not bool(data.get("next"))),
             start=data.get("start", 0),
             limit=data.get("limit", 25),
             next_page_start=data.get("nextPageStart"),

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -791,9 +791,9 @@ class UserTokenMiddleware:
 main_mcp = AtlassianMCP(name="Atlassian MCP")
 # Set the lifespan after construction to avoid deprecation warnings
 main_mcp._lifespan = main_lifespan
-main_mcp.mount(jira_mcp, prefix="jira")
-main_mcp.mount(confluence_mcp, prefix="confluence")
-main_mcp.mount(bitbucket_mcp, prefix="bitbucket")
+main_mcp.mount(server=jira_mcp, prefix="jira")
+main_mcp.mount(server=confluence_mcp, prefix="confluence")
+main_mcp.mount(server=bitbucket_mcp, prefix="bitbucket")
 
 
 @main_mcp.custom_route("/healthz", methods=["GET"], include_in_schema=False)

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -151,7 +151,6 @@ def get_available_services(
                 os.getenv("ATLASSIAN_OAUTH_CLIENT_SECRET"),
                 os.getenv("ATLASSIAN_OAUTH_REDIRECT_URI"),
                 os.getenv("ATLASSIAN_OAUTH_SCOPE"),
-                os.getenv("ATLASSIAN_OAUTH_CLOUD_ID"),
             ]
         ):
             bitbucket_is_setup = True
@@ -170,14 +169,15 @@ def get_available_services(
                 "with provided access token"
             )
         elif is_cloud:  # Cloud non-OAuth
-            if all(
-                [
-                    os.getenv("BITBUCKET_USERNAME"),
-                    os.getenv("BITBUCKET_APP_PASSWORD"),
-                ]
-            ):
+            cloud_basic_token = os.getenv("BITBUCKET_API_TOKEN") or os.getenv(
+                "BITBUCKET_APP_PASSWORD"
+            )
+            if os.getenv("BITBUCKET_USERNAME") and cloud_basic_token:
                 bitbucket_is_setup = True
-                logger.info("Using Bitbucket Cloud Basic Authentication (App Password)")
+                logger.info("Using Bitbucket Cloud Basic Authentication (API token)")
+            elif os.getenv("BITBUCKET_PERSONAL_TOKEN"):
+                bitbucket_is_setup = True
+                logger.info("Using Bitbucket Cloud Bearer token authentication")
         else:  # Server/Data Center non-OAuth
             if os.getenv("BITBUCKET_PERSONAL_TOKEN") or (
                 os.getenv("BITBUCKET_USERNAME") and os.getenv("BITBUCKET_APP_PASSWORD")

--- a/tests/unit/bitbucket/test_client.py
+++ b/tests/unit/bitbucket/test_client.py
@@ -1,418 +1,205 @@
-"""Tests for the Bitbucket client module."""
+"""Tests for selecting and configuring Bitbucket API clients."""
 
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from mcp_atlassian.bitbucket.client import BitbucketClient
+from mcp_atlassian.bitbucket.cloud import BitbucketCloudClient
 from mcp_atlassian.bitbucket.config import BitbucketConfig
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.utils.oauth import OAuthConfig
 
 
 class TestBitbucketClient:
-    """Test cases for BitbucketClient class."""
+    """Test the Cloud versus Server/Data Center client boundary."""
 
     @pytest.fixture
     def basic_auth_config(self):
-        """Create a basic auth configuration for testing."""
         return BitbucketConfig(
-            url="https://api.bitbucket.org/2.0",
+            url="https://bitbucket.org",
             auth_type="basic",
             username="test@example.com",
-            app_password="app_password",
+            api_token="api-token",
         )
 
     @pytest.fixture
-    def pat_config(self):
-        """Create a PAT configuration for testing."""
+    def server_pat_config(self):
         return BitbucketConfig(
             url="https://bitbucket.company.com",
             auth_type="pat",
             username="testuser",
-            personal_token="pat_token",
+            personal_token="pat-token",
         )
 
     @pytest.fixture
     def oauth_config(self):
-        """Create an OAuth configuration for testing."""
-        oauth_conf = OAuthConfig(
-            client_id="client_id",
-            client_secret="client_secret",
+        oauth = OAuthConfig(
+            client_id="client-id",
+            client_secret="client-secret",
             redirect_uri="http://localhost:8080/callback",
-            scope="read",
-            cloud_id="cloud_id",
+            scope="repository",
+            cloud_id=None,
+            access_token="oauth-token",
         )
         return BitbucketConfig(
-            url="https://api.bitbucket.org/2.0",
+            url="https://api.bitbucket.org",
             auth_type="oauth",
-            oauth_config=oauth_conf,
+            oauth_config=oauth,
         )
 
-    @patch("mcp_atlassian.bitbucket.client.Bitbucket")
     @patch("mcp_atlassian.bitbucket.client.configure_ssl_verification")
-    def test_init_basic_auth_cloud(
-        self, mock_ssl_config, mock_bitbucket, basic_auth_config
+    @patch("mcp_atlassian.bitbucket.client.Session")
+    def test_cloud_basic_auth_uses_native_client(
+        self, mock_session, mock_ssl, basic_auth_config
     ):
-        """Test initialization with basic auth for cloud."""
-        mock_bb_instance = MagicMock()
-        mock_bb_instance._session = MagicMock()
-        mock_bb_instance._session.proxies = {}
-        mock_bb_instance._session.headers = {}
-        mock_bitbucket.return_value = mock_bb_instance
+        session = MagicMock()
+        session.headers = {}
+        session.proxies = {}
+        mock_session.return_value = session
 
         client = BitbucketClient(basic_auth_config)
 
-        assert client.config == basic_auth_config
-        mock_bitbucket.assert_called_once_with(
-            url="https://api.bitbucket.org/2.0",
-            username="test@example.com",
-            password="app_password",
-            cloud=True,
-            verify_ssl=True,
-        )
-        mock_ssl_config.assert_called_once()
+        assert isinstance(client.bitbucket, BitbucketCloudClient)
+        assert client.bitbucket.base_url == "https://api.bitbucket.org/2.0"
+        assert session.auth == ("test@example.com", "api-token")
+        mock_ssl.assert_called_once()
 
-    @patch("mcp_atlassian.bitbucket.client.Bitbucket")
     @patch("mcp_atlassian.bitbucket.client.configure_ssl_verification")
-    def test_init_pat_server(self, mock_ssl_config, mock_bitbucket, pat_config):
-        """Test initialization with PAT for server."""
-        mock_bb_instance = MagicMock()
-        mock_bb_instance._session = MagicMock()
-        mock_bb_instance._session.proxies = {}
-        mock_bb_instance._session.headers = {}
-        mock_bitbucket.return_value = mock_bb_instance
+    @patch("mcp_atlassian.bitbucket.client.Bitbucket")
+    def test_server_pat_keeps_legacy_client(
+        self, mock_bitbucket, mock_ssl, server_pat_config
+    ):
+        legacy = MagicMock()
+        legacy._session = MagicMock()
+        legacy._session.headers = {}
+        legacy._session.proxies = {}
+        mock_bitbucket.return_value = legacy
 
-        client = BitbucketClient(pat_config)
+        client = BitbucketClient(server_pat_config)
 
-        assert client.config == pat_config
+        assert client.bitbucket is legacy
         mock_bitbucket.assert_called_once_with(
             url="https://bitbucket.company.com",
             cloud=False,
             verify_ssl=True,
-            token="pat_token",  # PAT goes in token field
+            token="pat-token",
         )
-        mock_ssl_config.assert_called_once()
+        mock_ssl.assert_called_once()
 
-    @patch("mcp_atlassian.bitbucket.client.Bitbucket")
     @patch("mcp_atlassian.bitbucket.client.configure_ssl_verification")
     @patch("mcp_atlassian.bitbucket.client.configure_oauth_session")
     @patch("mcp_atlassian.bitbucket.client.Session")
-    def test_init_oauth(
-        self,
-        mock_session,
-        mock_oauth_config,
-        mock_ssl_config,
-        mock_bitbucket,
-        oauth_config,
+    def test_cloud_oauth_uses_direct_api_without_cloud_id(
+        self, mock_session, mock_configure_oauth, mock_ssl, oauth_config
     ):
-        """Test initialization with OAuth."""
-        mock_session_instance = MagicMock()
-        mock_session.return_value = mock_session_instance
-        mock_oauth_config.return_value = True
-
-        mock_bb_instance = MagicMock()
-        mock_bb_instance._session = mock_session_instance
-        mock_bitbucket.return_value = mock_bb_instance
+        session = MagicMock()
+        session.headers = {}
+        session.proxies = {}
+        mock_session.return_value = session
+        mock_configure_oauth.return_value = True
 
         client = BitbucketClient(oauth_config)
 
-        assert client.config == oauth_config
-        mock_session.assert_called_once()
-        mock_oauth_config.assert_called_once_with(
-            mock_session_instance, oauth_config.oauth_config
-        )
-
-        expected_url = "https://api.atlassian.com/ex/bitbucket/cloud_id"
-        mock_bitbucket.assert_called_once_with(
-            url=expected_url, session=mock_session_instance, cloud=True, verify_ssl=True
-        )
+        assert isinstance(client.bitbucket, BitbucketCloudClient)
+        assert client.bitbucket.base_url == "https://api.bitbucket.org/2.0"
+        mock_configure_oauth.assert_called_once_with(session, oauth_config.oauth_config)
+        mock_ssl.assert_called_once()
 
     @patch("mcp_atlassian.bitbucket.client.configure_oauth_session")
     @patch("mcp_atlassian.bitbucket.client.Session")
-    def test_init_oauth_missing_cloud_id(
-        self, mock_session, mock_oauth_config, oauth_config
+    def test_oauth_configuration_failure_is_explicit(
+        self, mock_session, mock_configure_oauth, oauth_config
     ):
-        """Test OAuth initialization fails with missing cloud_id."""
-        oauth_config.oauth_config.cloud_id = None
+        mock_configure_oauth.return_value = False
 
         with pytest.raises(
-            ValueError, match="OAuth authentication requires a valid cloud_id"
+            MCPAtlassianAuthenticationError,
+            match="Failed to configure OAuth session",
         ):
             BitbucketClient(oauth_config)
 
-    @patch("mcp_atlassian.bitbucket.client.configure_oauth_session")
+    @patch("mcp_atlassian.bitbucket.client.configure_ssl_verification")
     @patch("mcp_atlassian.bitbucket.client.Session")
-    def test_init_oauth_session_config_fails(
-        self, mock_session, mock_oauth_config, oauth_config
-    ):
-        """Test OAuth initialization fails when session configuration fails."""
-        mock_session_instance = MagicMock()
-        mock_session.return_value = mock_session_instance
-        mock_oauth_config.return_value = False
-
-        with pytest.raises(
-            MCPAtlassianAuthenticationError, match="Failed to configure OAuth session"
-        ):
-            BitbucketClient(oauth_config)
-
-    @patch("mcp_atlassian.bitbucket.client.BitbucketConfig")
-    @patch("mcp_atlassian.bitbucket.client.Bitbucket")
-    @patch("mcp_atlassian.bitbucket.client.configure_ssl_verification")
-    def test_init_without_config_uses_env(
-        self, mock_ssl_config, mock_bitbucket, mock_config_class
-    ):
-        """Test initialization without config uses environment variables."""
-        mock_config_instance = MagicMock()
-        mock_config_instance.auth_type = "basic"
-        mock_config_instance.url = "https://api.bitbucket.org/2.0"
-        mock_config_instance.username = "test@example.com"
-        mock_config_instance.app_password = "password"
-        mock_config_instance.is_cloud = True
-        mock_config_instance.ssl_verify = True
-        mock_config_class.from_env.return_value = mock_config_instance
-
-        mock_bb_instance = MagicMock()
-        mock_bb_instance._session = MagicMock()
-        mock_bitbucket.return_value = mock_bb_instance
-
-        client = BitbucketClient()
-
-        mock_config_class.from_env.assert_called_once()
-        assert client.config == mock_config_instance
-
-    @patch("mcp_atlassian.bitbucket.client.Bitbucket")
-    @patch("mcp_atlassian.bitbucket.client.configure_ssl_verification")
-    def test_ssl_verification_disabled(self, mock_ssl_config, mock_bitbucket):
-        """Test client with SSL verification disabled."""
+    def test_cloud_bearer_token(self, mock_session, mock_ssl):
+        session = MagicMock()
+        session.headers = {}
+        session.proxies = {}
+        mock_session.return_value = session
         config = BitbucketConfig(
-            url="https://api.bitbucket.org/2.0",
-            auth_type="basic",
-            username="test@example.com",
-            app_password="password",
-            ssl_verify=False,
+            url="https://api.bitbucket.org",
+            auth_type="pat",
+            personal_token="workspace-token",
         )
 
-        mock_bb_instance = MagicMock()
-        mock_bb_instance._session = MagicMock()
-        mock_bb_instance._session.proxies = {}
-        mock_bb_instance._session.headers = {}
-        mock_bitbucket.return_value = mock_bb_instance
+        BitbucketClient(config)
 
-        client = BitbucketClient(config)
+        assert session.headers["Authorization"] == "Bearer workspace-token"
+        mock_ssl.assert_called_once()
 
-        mock_bitbucket.assert_called_once_with(
-            url="https://api.bitbucket.org/2.0",
-            username="test@example.com",
-            password="password",
-            cloud=True,
-            verify_ssl=False,
-        )
-
-    @patch("mcp_atlassian.bitbucket.client.Bitbucket")
     @patch("mcp_atlassian.bitbucket.client.configure_ssl_verification")
-    def test_proxy_configuration(self, mock_ssl_config, mock_bitbucket):
-        """Test client with proxy configuration."""
+    @patch("mcp_atlassian.bitbucket.client.Session")
+    def test_proxy_and_custom_header_configuration(self, mock_session, mock_ssl):
+        session = MagicMock()
+        session.headers = {}
+        session.proxies = {}
+        mock_session.return_value = session
         config = BitbucketConfig(
-            url="https://api.bitbucket.org/2.0",
+            url="https://api.bitbucket.org",
             auth_type="basic",
             username="test@example.com",
-            app_password="password",
+            api_token="token",
             http_proxy="http://proxy:8080",
-            https_proxy="https://proxy:8080",
-            no_proxy="localhost,127.0.0.1",
-        )
-
-        mock_bb_instance = MagicMock()
-        mock_session = MagicMock()
-        mock_session.proxies = {}
-        mock_session.headers = {}
-        mock_bb_instance._session = mock_session
-        mock_bitbucket.return_value = mock_bb_instance
-
-        client = BitbucketClient(config)
-
-        # Check that proxies were configured
-        expected_proxies = {"http": "http://proxy:8080", "https": "https://proxy:8080"}
-        # Check the final state of proxies instead of mocking the update call
-        assert mock_session.proxies == expected_proxies
-
-    @patch("mcp_atlassian.bitbucket.client.Bitbucket")
-    @patch("mcp_atlassian.bitbucket.client.configure_ssl_verification")
-    def test_socks_proxy_configuration(self, mock_ssl_config, mock_bitbucket):
-        """Test client with SOCKS proxy configuration."""
-        config = BitbucketConfig(
-            url="https://api.bitbucket.org/2.0",
-            auth_type="basic",
-            username="test@example.com",
-            app_password="password",
-            socks_proxy="socks5://proxy:1080",
-        )
-
-        mock_bb_instance = MagicMock()
-        mock_session = MagicMock()
-        mock_session.proxies = {}
-        mock_session.headers = {}
-        mock_bb_instance._session = mock_session
-        mock_bitbucket.return_value = mock_bb_instance
-
-        client = BitbucketClient(config)
-
-        # Check that SOCKS proxy was configured
-        expected_proxies = {
-            "http": "socks5://proxy:1080",
-            "https": "socks5://proxy:1080",
-        }
-        # Check the final state of proxies instead of mocking the update call
-        assert mock_session.proxies == expected_proxies
-
-    @patch("mcp_atlassian.bitbucket.client.Bitbucket")
-    @patch("mcp_atlassian.bitbucket.client.configure_ssl_verification")
-    def test_custom_headers_configuration(self, mock_ssl_config, mock_bitbucket):
-        """Test client with custom headers configuration."""
-        config = BitbucketConfig(
-            url="https://api.bitbucket.org/2.0",
-            auth_type="basic",
-            username="test@example.com",
-            app_password="password",
+            https_proxy="https://proxy:8443",
             custom_headers={"X-Custom": "value"},
         )
 
-        mock_bb_instance = MagicMock()
-        mock_session = MagicMock()
-        mock_session.proxies = {}
-        mock_session.headers = {}
-        mock_bb_instance._session = mock_session
-        mock_bitbucket.return_value = mock_bb_instance
+        BitbucketClient(config)
 
-        client = BitbucketClient(config)
+        assert session.proxies == {
+            "http": "http://proxy:8080",
+            "https": "https://proxy:8443",
+        }
+        assert session.headers["X-Custom"] == "value"
+        mock_ssl.assert_called_once()
 
-        # Check that custom headers were configured
-        # Check the final state of headers instead of mocking the update call
-        assert "X-Custom" in mock_session.headers
-        assert mock_session.headers["X-Custom"] == "value"
+    @patch("mcp_atlassian.bitbucket.client.configure_ssl_verification")
+    @patch("mcp_atlassian.bitbucket.client.Session")
+    def test_cloud_activities_delegate_to_native_client(
+        self, mock_session, mock_ssl, basic_auth_config
+    ):
+        session = MagicMock()
+        session.headers = {}
+        session.proxies = {}
+        mock_session.return_value = session
+        client = BitbucketClient(basic_auth_config)
+        client.bitbucket.get_pull_request_activities = MagicMock(
+            return_value=[{"id": 1}]
+        )
 
-    def test_client_has_bitbucket_attribute(self, basic_auth_config):
-        """Test that client has bitbucket attribute after initialization."""
-        with patch("mcp_atlassian.bitbucket.client.Bitbucket") as mock_bitbucket:
-            mock_bb_instance = MagicMock()
-            mock_bb_instance._session = MagicMock()
-            mock_bitbucket.return_value = mock_bb_instance
+        result = client.get_pull_request_activities("workspace", "repo", 1)
 
-            with patch("mcp_atlassian.bitbucket.client.configure_ssl_verification"):
-                client = BitbucketClient(basic_auth_config)
+        assert result == [{"id": 1}]
+        client.bitbucket.get_pull_request_activities.assert_called_once_with(
+            "workspace", "repo", 1
+        )
 
-            assert hasattr(client, "bitbucket")
-            assert client.bitbucket == mock_bb_instance
+    @patch("mcp_atlassian.bitbucket.client.configure_ssl_verification")
+    @patch("mcp_atlassian.bitbucket.client.Bitbucket")
+    def test_server_activities_use_server_endpoint(
+        self, mock_bitbucket, mock_ssl, server_pat_config
+    ):
+        legacy = MagicMock()
+        legacy._session = MagicMock()
+        legacy._session.headers = {}
+        legacy._session.proxies = {}
+        legacy.get.return_value = {"values": [{"id": 1}]}
+        mock_bitbucket.return_value = legacy
+        client = BitbucketClient(server_pat_config)
 
-    def test_client_logging_basic_auth(self, basic_auth_config):
-        """Test that appropriate logging occurs for basic auth."""
-        with patch("mcp_atlassian.bitbucket.client.Bitbucket") as mock_bitbucket:
-            mock_bb_instance = MagicMock()
-            mock_bb_instance._session = MagicMock()
-            mock_bitbucket.return_value = mock_bb_instance
+        result = client.get_pull_request_activities("project", "repo", 1)
 
-            with patch("mcp_atlassian.bitbucket.client.configure_ssl_verification"):
-                with patch("mcp_atlassian.bitbucket.client.logger") as mock_logger:
-                    client = BitbucketClient(basic_auth_config)
-
-                    # Should log debug messages
-                    assert mock_logger.debug.called
-
-    def test_client_logging_pat_auth(self, pat_config):
-        """Test that appropriate logging occurs for PAT auth."""
-        with patch("mcp_atlassian.bitbucket.client.Bitbucket") as mock_bitbucket:
-            mock_bb_instance = MagicMock()
-            mock_bb_instance._session = MagicMock()
-            mock_bitbucket.return_value = mock_bb_instance
-
-            with patch("mcp_atlassian.bitbucket.client.configure_ssl_verification"):
-                with patch("mcp_atlassian.bitbucket.client.logger") as mock_logger:
-                    client = BitbucketClient(pat_config)
-
-                    # Should log debug messages with masked PAT
-                    assert mock_logger.debug.called
-                    # Verify PAT is masked in logs
-                    log_calls = [
-                        call.args[0] for call in mock_logger.debug.call_args_list
-                    ]
-                    pat_logged_directly = any(
-                        "pat_token" in str(call) for call in log_calls
-                    )
-                    assert not pat_logged_directly, "PAT should be masked in logs"
-
-    def test_get_pull_request_activities_cloud_success(self, basic_auth_config):
-        """Test successful retrieval of pull request activities for cloud."""
-        with patch("mcp_atlassian.bitbucket.client.Bitbucket") as mock_bitbucket:
-            with patch("mcp_atlassian.bitbucket.client.configure_ssl_verification"):
-                mock_bb_instance = MagicMock()
-                mock_bb_instance._session = MagicMock()
-                mock_bb_instance._session.proxies = {}
-                mock_bb_instance._session.headers = {}
-                mock_bb_instance.get.return_value = {
-                    "values": [{"id": 1, "content": "test comment"}]
-                }
-                mock_bitbucket.return_value = mock_bb_instance
-
-                client = BitbucketClient(basic_auth_config)
-                result = client.get_pull_request_activities("workspace", "repo", 1)
-
-                assert result == [{"id": 1, "content": "test comment"}]
-                mock_bb_instance.get.assert_called_once_with(
-                    "repositories/workspace/repo/pullrequests/1/activities"
-                )
-
-    def test_get_pull_request_activities_server_success(self, pat_config):
-        """Test successful retrieval of pull request activities for server."""
-        with patch("mcp_atlassian.bitbucket.client.Bitbucket") as mock_bitbucket:
-            with patch("mcp_atlassian.bitbucket.client.configure_ssl_verification"):
-                mock_bb_instance = MagicMock()
-                mock_bb_instance._session = MagicMock()
-                mock_bb_instance._session.proxies = {}
-                mock_bb_instance._session.headers = {}
-                mock_bb_instance.get.return_value = [
-                    {"id": 1, "content": "test comment"}
-                ]
-                mock_bitbucket.return_value = mock_bb_instance
-
-                client = BitbucketClient(pat_config)
-                result = client.get_pull_request_activities("workspace", "repo", 1)
-
-                assert result == [{"id": 1, "content": "test comment"}]
-                mock_bb_instance.get.assert_called_once_with(
-                    "projects/workspace/repos/repo/pull-requests/1/activities"
-                )
-
-    def test_get_pull_request_activities_empty_response(self, basic_auth_config):
-        """Test pull request activities with empty response."""
-        with patch("mcp_atlassian.bitbucket.client.Bitbucket") as mock_bitbucket:
-            with patch("mcp_atlassian.bitbucket.client.configure_ssl_verification"):
-                mock_bb_instance = MagicMock()
-                mock_bb_instance._session = MagicMock()
-                mock_bb_instance._session.proxies = {}
-                mock_bb_instance._session.headers = {}
-                mock_bb_instance.get.return_value = None
-                mock_bitbucket.return_value = mock_bb_instance
-
-                client = BitbucketClient(basic_auth_config)
-                result = client.get_pull_request_activities("workspace", "repo", 1)
-
-                assert result == []
-
-    def test_get_pull_request_activities_exception_handling(self, basic_auth_config):
-        """Test exception handling in get_pull_request_activities."""
-        with patch("mcp_atlassian.bitbucket.client.Bitbucket") as mock_bitbucket:
-            with patch("mcp_atlassian.bitbucket.client.configure_ssl_verification"):
-                mock_bb_instance = MagicMock()
-                mock_bb_instance._session = MagicMock()
-                mock_bb_instance._session.proxies = {}
-                mock_bb_instance._session.headers = {}
-                mock_bb_instance.get.side_effect = Exception("API error")
-                mock_bitbucket.return_value = mock_bb_instance
-
-                client = BitbucketClient(basic_auth_config)
-
-                with pytest.raises(Exception) as exc_info:
-                    client.get_pull_request_activities("workspace", "repo", 1)
-
-                assert "API error" in str(exc_info.value)
+        assert result == [{"id": 1}]
+        legacy.get.assert_called_once_with(
+            "projects/project/repos/repo/pull-requests/1/activities"
+        )

--- a/tests/unit/bitbucket/test_cloud.py
+++ b/tests/unit/bitbucket/test_cloud.py
@@ -56,8 +56,27 @@ def client(session):
 def test_workspace_pagination_follows_next_link(client, session):
     next_url = f"{API}/user/workspaces?page=2"
     session.request.side_effect = [
-        make_response({"values": [{"slug": "one"}], "next": next_url}),
-        make_response({"values": [{"slug": "two"}]}),
+        make_response(
+            {
+                "values": [
+                    {
+                        "type": "workspace_access",
+                        "workspace": {"slug": "one"},
+                    }
+                ],
+                "next": next_url,
+            }
+        ),
+        make_response(
+            {
+                "values": [
+                    {
+                        "type": "workspace_access",
+                        "workspace": {"slug": "two"},
+                    }
+                ]
+            }
+        ),
     ]
 
     result = client.project_list()
@@ -76,8 +95,14 @@ def test_repository_routes_enumerate_accessible_workspaces(client, session):
         make_response(
             {
                 "values": [
-                    {"slug": "workspace-one"},
-                    {"uuid": "{workspace-two}"},
+                    {
+                        "type": "workspace_access",
+                        "workspace": {"slug": "workspace-one"},
+                    },
+                    {
+                        "type": "workspace_access",
+                        "workspace": {"uuid": "{workspace-two}"},
+                    },
                 ]
             }
         ),

--- a/tests/unit/bitbucket/test_cloud.py
+++ b/tests/unit/bitbucket/test_cloud.py
@@ -1,0 +1,343 @@
+"""Contract tests for the native Bitbucket Cloud REST API client."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from requests import Request, Response, Session
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.bitbucket.cloud import BitbucketCloudClient
+from mcp_atlassian.models.bitbucket.common import (
+    BitbucketBranch,
+    BitbucketCommit,
+    BitbucketPullRequest,
+    BitbucketRepository,
+    BitbucketUser,
+    BitbucketWorkspace,
+    CommitChanges,
+)
+
+API = "https://api.bitbucket.org/2.0"
+
+
+def make_response(
+    payload=None,
+    *,
+    status: int = 200,
+    url: str = API,
+    content: bytes | None = None,
+):
+    """Create a real requests response suitable for client contract tests."""
+    response = Response()
+    response.status_code = status
+    response.url = url
+    response.request = Request("GET", url).prepare()
+    response.headers["Content-Type"] = "application/json"
+    if content is not None:
+        response._content = content
+    elif payload is None:
+        response._content = b""
+    else:
+        response._content = json.dumps(payload).encode()
+    return response
+
+
+@pytest.fixture
+def session():
+    return MagicMock(spec=Session)
+
+
+@pytest.fixture
+def client(session):
+    return BitbucketCloudClient(session, "https://bitbucket.org")
+
+
+def test_workspace_pagination_follows_next_link(client, session):
+    next_url = f"{API}/workspaces?page=2"
+    session.request.side_effect = [
+        make_response({"values": [{"slug": "one"}], "next": next_url}),
+        make_response({"values": [{"slug": "two"}]}),
+    ]
+
+    result = client.project_list()
+
+    assert [item["slug"] for item in result] == ["one", "two"]
+    assert session.request.call_args_list[0].args == ("GET", f"{API}/workspaces")
+    assert session.request.call_args_list[0].kwargs["params"] == {"pagelen": 50}
+    assert session.request.call_args_list[1].args == ("GET", next_url)
+
+
+def test_repository_routes_and_global_role_filter(client, session):
+    session.request.side_effect = [
+        make_response({"values": [{"slug": "global"}]}),
+        make_response({"values": [{"slug": "scoped"}]}),
+        make_response({"slug": "repo"}),
+    ]
+
+    assert client.get_repositories() == [{"slug": "global"}]
+    assert client.get_repositories("my workspace") == [{"slug": "scoped"}]
+    assert client.get_repo("my workspace", "a/repo") == {"slug": "repo"}
+
+    assert session.request.call_args_list[0].args == ("GET", f"{API}/repositories")
+    assert session.request.call_args_list[0].kwargs["params"] == {
+        "role": "member",
+        "pagelen": 50,
+    }
+    assert (
+        session.request.call_args_list[1]
+        .args[1]
+        .endswith("/repositories/my%20workspace")
+    )
+    assert (
+        session.request.call_args_list[2]
+        .args[1]
+        .endswith("/repositories/my%20workspace/a%2Frepo")
+    )
+
+
+def test_file_and_directory_routes(client, session):
+    session.request.side_effect = [
+        make_response(content=b"hello"),
+        make_response({"values": [{"path": "src/main.py"}]}),
+    ]
+
+    content = client.get_content_of_file(
+        "workspace", "repo", "src/main.py", "feature/test"
+    )
+    entries = client.get_file_list("workspace", "repo", "src", "main")
+
+    assert content == b"hello"
+    assert entries == [{"path": "src/main.py"}]
+    assert (
+        session.request.call_args_list[0]
+        .args[1]
+        .endswith("/repositories/workspace/repo/src/feature%2Ftest/src/main.py")
+    )
+    assert (
+        session.request.call_args_list[1]
+        .args[1]
+        .endswith("/repositories/workspace/repo/src/main/src")
+    )
+
+
+def test_branch_routes_filter_and_default_branch(client, session):
+    session.request.side_effect = [
+        make_response(
+            {
+                "values": [
+                    {"name": "main"},
+                    {"name": "feature/cloud"},
+                    {"name": "feature/other"},
+                ]
+            }
+        ),
+        make_response({"mainbranch": {"name": "main", "target": {"hash": "abc"}}}),
+    ]
+
+    branches = client.get_branches(
+        "workspace", "repo", filter="feature", start=1, limit=1
+    )
+    default = client.get_default_branch("workspace", "repo")
+
+    assert branches == [{"name": "feature/other"}]
+    assert default["name"] == "main"
+    assert default["isDefault"] is True
+    assert (
+        session.request.call_args_list[0]
+        .args[1]
+        .endswith("/repositories/workspace/repo/refs/branches")
+    )
+
+
+def test_commit_and_diffstat_routes(client, session):
+    session.request.side_effect = [
+        make_response({"values": [{"hash": "abc"}, {"hash": "def"}]}),
+        make_response({"values": [{"status": "modified"}]}),
+    ]
+
+    commits = client.get_commits(
+        "workspace", "repo", limit=1, until="main", since="base"
+    )
+    changes = client.get_commit_changes(
+        project_key="workspace",
+        repository_slug="repo",
+        commit_id="abc",
+        hash_newest="def",
+    )
+
+    assert commits == [{"hash": "abc"}]
+    assert changes["values"] == [{"status": "modified"}]
+    assert session.request.call_args_list[0].kwargs["params"] == {
+        "include": "main",
+        "exclude": "base",
+        "pagelen": 50,
+    }
+    assert (
+        session.request.call_args_list[1]
+        .args[1]
+        .endswith("/repositories/workspace/repo/diffstat/abc..def")
+    )
+
+
+def test_create_branch_resolves_source_hash(client, session):
+    session.request.side_effect = [
+        make_response({"target": {"hash": "abc123"}}),
+        make_response({"name": "feature/cloud"}),
+    ]
+
+    result = client.create_branch("workspace", "repo", "feature/cloud", "main")
+
+    assert result == {"name": "feature/cloud"}
+    assert session.request.call_args_list[0].args[0] == "GET"
+    assert session.request.call_args_list[1].args == (
+        "POST",
+        f"{API}/repositories/workspace/repo/refs/branches",
+    )
+    assert session.request.call_args_list[1].kwargs["json"] == {
+        "name": "feature/cloud",
+        "target": {"hash": "abc123"},
+    }
+
+
+def test_pull_request_read_routes(client, session):
+    session.request.side_effect = [
+        make_response({"values": [{"id": 1}]}),
+        make_response({"id": 1}),
+        make_response({"values": [{"hash": "abc"}]}),
+        make_response({"values": [{"approval": {}}]}),
+    ]
+
+    assert client.get_pull_requests("workspace", "repo") == [{"id": 1}]
+    assert client.get_pull_request("workspace", "repo", 1) == {"id": 1}
+    assert client.get_pull_requests_commits("workspace", "repo", 1) == [{"hash": "abc"}]
+    assert client.get_pull_request_activities("workspace", "repo", 1) == [
+        {"approval": {}}
+    ]
+    assert session.request.call_args_list[0].kwargs["params"] == {
+        "state": "OPEN",
+        "pagelen": 50,
+    }
+    assert (
+        session.request.call_args_list[3].args[1].endswith("/pullrequests/1/activity")
+    )
+
+
+def test_create_pull_request_translates_server_payload(client, session):
+    session.request.return_value = make_response({"id": 9})
+    payload = {
+        "title": "Cloud support",
+        "description": "Native routes",
+        "fromRef": {"id": "refs/heads/feature/cloud"},
+        "toRef": {"id": "refs/heads/main"},
+        "state": "OPEN",
+    }
+
+    assert client.create_pull_request("workspace", "repo", payload) == {"id": 9}
+    assert session.request.call_args.kwargs["json"] == {
+        "title": "Cloud support",
+        "description": "Native routes",
+        "source": {"branch": {"name": "feature/cloud"}},
+        "destination": {"branch": {"name": "main"}},
+    }
+
+
+def test_comment_uses_cloud_content_schema(client, session):
+    session.request.side_effect = [
+        make_response({"id": 5}),
+        make_response({"id": 6, "state": "UNRESOLVED"}),
+    ]
+
+    result = client.add_pull_request_comment("workspace", "repo", 1, "Looks good")
+
+    assert result == {"id": 5}
+    assert session.request.call_args.kwargs["json"] == {
+        "content": {"raw": "Looks good"}
+    }
+    task = client.add_pull_request_blocker_comment(
+        "workspace", "repo", 1, "Block this", "BLOCKER"
+    )
+    assert task == {"id": 6, "state": "UNRESOLVED"}
+    assert session.request.call_args.args[1].endswith("/pullrequests/1/tasks")
+    assert session.request.call_args.kwargs["json"] == {
+        "content": {"raw": "Block this"}
+    }
+
+
+def test_cloud_error_includes_nested_message(client, session):
+    session.request.return_value = make_response(
+        {"type": "error", "error": {"message": "Repository not found"}},
+        status=404,
+        url=f"{API}/repositories/workspace/missing",
+    )
+
+    with pytest.raises(HTTPError, match="HTTP 404: Repository not found"):
+        client.get_repo("workspace", "missing")
+
+
+def test_cloud_models_normalize_response_shapes():
+    workspace = BitbucketWorkspace.from_api_response(
+        {"name": "Team", "slug": "team", "uuid": "{ws}", "is_private": True}
+    )
+    repository = BitbucketRepository.from_api_response(
+        {
+            "name": "Repo",
+            "slug": "repo",
+            "uuid": "{repo}",
+            "full_name": "team/repo",
+            "is_private": False,
+            "mainbranch": {"name": "main"},
+        }
+    )
+    branch = BitbucketBranch.from_api_response(
+        {"name": "main", "target": {"hash": "abc"}}
+    )
+    commit = BitbucketCommit.from_api_response(
+        {
+            "hash": "abc",
+            "message": "Initial",
+            "date": "2026-08-20T10:00:00+00:00",
+            "author": {"raw": "Test User <test@example.com>"},
+        }
+    )
+    pull_request = BitbucketPullRequest.from_api_response(
+        {
+            "id": 1,
+            "title": "Cloud",
+            "state": "OPEN",
+            "source": {"branch": {"name": "feature"}},
+            "destination": {"branch": {"name": "main"}},
+            "created_on": "2026-08-20T10:00:00+00:00",
+        }
+    )
+    changes = CommitChanges.from_api_response(
+        {
+            "fromHash": "abc",
+            "toHash": "def",
+            "values": [
+                {
+                    "status": "modified",
+                    "lines_added": 2,
+                    "lines_removed": 1,
+                    "new": {"path": "src/main.py"},
+                }
+            ],
+        }
+    )
+    user = BitbucketUser.from_api_response(
+        {"display_name": "Test User", "nickname": "test", "uuid": "{user}"}
+    )
+
+    assert (workspace.slug, workspace.uuid, workspace.public) == (
+        "team",
+        "{ws}",
+        False,
+    )
+    assert (repository.full_name, repository.public) == ("team/repo", True)
+    assert (branch.name, branch.latest_commit) == ("main", "abc")
+    assert commit.id_ == "abc"
+    assert commit.author and commit.author.email == "test@example.com"
+    assert pull_request.open is True
+    assert pull_request.from_ref == {"branch": {"name": "feature"}}
+    assert changes.values and changes.values[0].lines_added == 2
+    assert (user.display_name, user.nickname) == ("Test User", "test")

--- a/tests/unit/bitbucket/test_cloud.py
+++ b/tests/unit/bitbucket/test_cloud.py
@@ -411,3 +411,15 @@ def test_cloud_models_normalize_response_shapes():
     assert pull_request.from_ref == {"branch": {"name": "feature"}}
     assert changes.values and changes.values[0].lines_added == 2
     assert (user.display_name, user.nickname) == ("Test User", "test")
+
+
+def test_cloud_workspace_uses_slug_as_display_name_when_name_is_absent():
+    workspace = BitbucketWorkspace.from_api_response(
+        {
+            "type": "workspace_base",
+            "slug": "puratos-aem",
+            "uuid": "{workspace}",
+        }
+    )
+
+    assert workspace.name == "puratos-aem"

--- a/tests/unit/bitbucket/test_cloud.py
+++ b/tests/unit/bitbucket/test_cloud.py
@@ -54,7 +54,7 @@ def client(session):
 
 
 def test_workspace_pagination_follows_next_link(client, session):
-    next_url = f"{API}/workspaces?page=2"
+    next_url = f"{API}/user/workspaces?page=2"
     session.request.side_effect = [
         make_response({"values": [{"slug": "one"}], "next": next_url}),
         make_response({"values": [{"slug": "two"}]}),
@@ -63,34 +63,56 @@ def test_workspace_pagination_follows_next_link(client, session):
     result = client.project_list()
 
     assert [item["slug"] for item in result] == ["one", "two"]
-    assert session.request.call_args_list[0].args == ("GET", f"{API}/workspaces")
+    assert session.request.call_args_list[0].args == (
+        "GET",
+        f"{API}/user/workspaces",
+    )
     assert session.request.call_args_list[0].kwargs["params"] == {"pagelen": 50}
     assert session.request.call_args_list[1].args == ("GET", next_url)
 
 
-def test_repository_routes_and_global_role_filter(client, session):
+def test_repository_routes_enumerate_accessible_workspaces(client, session):
     session.request.side_effect = [
-        make_response({"values": [{"slug": "global"}]}),
+        make_response(
+            {
+                "values": [
+                    {"slug": "workspace-one"},
+                    {"uuid": "{workspace-two}"},
+                ]
+            }
+        ),
+        make_response({"values": [{"slug": "global-one"}]}),
+        make_response({"values": [{"slug": "global-two"}]}),
         make_response({"values": [{"slug": "scoped"}]}),
         make_response({"slug": "repo"}),
     ]
 
-    assert client.get_repositories() == [{"slug": "global"}]
+    assert client.get_repositories() == [
+        {"slug": "global-one"},
+        {"slug": "global-two"},
+    ]
     assert client.get_repositories("my workspace") == [{"slug": "scoped"}]
     assert client.get_repo("my workspace", "a/repo") == {"slug": "repo"}
 
-    assert session.request.call_args_list[0].args == ("GET", f"{API}/repositories")
-    assert session.request.call_args_list[0].kwargs["params"] == {
-        "role": "member",
-        "pagelen": 50,
-    }
+    assert session.request.call_args_list[0].args == (
+        "GET",
+        f"{API}/user/workspaces",
+    )
+    assert session.request.call_args_list[1].args == (
+        "GET",
+        f"{API}/repositories/workspace-one",
+    )
+    assert session.request.call_args_list[2].args == (
+        "GET",
+        f"{API}/repositories/%7Bworkspace-two%7D",
+    )
     assert (
-        session.request.call_args_list[1]
+        session.request.call_args_list[3]
         .args[1]
         .endswith("/repositories/my%20workspace")
     )
     assert (
-        session.request.call_args_list[2]
+        session.request.call_args_list[4]
         .args[1]
         .endswith("/repositories/my%20workspace/a%2Frepo")
     )
@@ -100,15 +122,18 @@ def test_file_and_directory_routes(client, session):
     session.request.side_effect = [
         make_response(content=b"hello"),
         make_response({"values": [{"path": "src/main.py"}]}),
+        make_response({"values": [{"path": "README.md"}]}),
     ]
 
     content = client.get_content_of_file(
         "workspace", "repo", "src/main.py", "feature/test"
     )
     entries = client.get_file_list("workspace", "repo", "src", "main")
+    root_entries = client.get_file_list("workspace", "repo", "", "main")
 
     assert content == b"hello"
     assert entries == [{"path": "src/main.py"}]
+    assert root_entries == [{"path": "README.md"}]
     assert (
         session.request.call_args_list[0]
         .args[1]
@@ -118,6 +143,11 @@ def test_file_and_directory_routes(client, session):
         session.request.call_args_list[1]
         .args[1]
         .endswith("/repositories/workspace/repo/src/main/src")
+    )
+    assert (
+        session.request.call_args_list[2]
+        .args[1]
+        .endswith("/repositories/workspace/repo/src/main/")
     )
 
 
@@ -133,6 +163,7 @@ def test_branch_routes_filter_and_default_branch(client, session):
             }
         ),
         make_response({"mainbranch": {"name": "main", "target": {"hash": "abc"}}}),
+        make_response({"mainbranch": {"name": "main", "target": {"hash": "abc"}}}),
     ]
 
     branches = client.get_branches(
@@ -140,7 +171,7 @@ def test_branch_routes_filter_and_default_branch(client, session):
     )
     default = client.get_default_branch("workspace", "repo")
 
-    assert branches == [{"name": "feature/other"}]
+    assert branches == [{"name": "feature/other", "isDefault": False}]
     assert default["name"] == "main"
     assert default["isDefault"] is True
     assert (
@@ -148,6 +179,20 @@ def test_branch_routes_filter_and_default_branch(client, session):
         .args[1]
         .endswith("/repositories/workspace/repo/refs/branches")
     )
+
+
+def test_branch_routes_mark_repository_default_branch(client, session):
+    session.request.side_effect = [
+        make_response({"values": [{"name": "main"}, {"name": "develop"}]}),
+        make_response({"mainbranch": {"name": "main"}}),
+    ]
+
+    branches = client.get_branches("workspace", "repo")
+
+    assert branches == [
+        {"name": "main", "isDefault": True},
+        {"name": "develop", "isDefault": False},
+    ]
 
 
 def test_commit_and_diffstat_routes(client, session):

--- a/tests/unit/bitbucket/test_config.py
+++ b/tests/unit/bitbucket/test_config.py
@@ -92,6 +92,23 @@ class TestBitbucketConfig:
     @patch.dict(
         os.environ,
         {
+            "BITBUCKET_URL": "https://api.bitbucket.org",
+            "BITBUCKET_USERNAME": "test@example.com",
+            "BITBUCKET_API_TOKEN": "api_token",
+        },
+        clear=True,
+    )
+    def test_from_env_api_token_cloud(self):
+        """Test the current Bitbucket Cloud API token configuration."""
+        config = BitbucketConfig.from_env()
+
+        assert config.auth_type == "basic"
+        assert config.api_token == "api_token"
+        assert config.cloud_api_token == "api_token"
+
+    @patch.dict(
+        os.environ,
+        {
             "BITBUCKET_URL": "https://bitbucket.company.com",
             "BITBUCKET_USERNAME": "testuser",
             "BITBUCKET_PERSONAL_TOKEN": "pat_token",
@@ -138,7 +155,7 @@ class TestBitbucketConfig:
         """Test that missing credentials raises ValueError."""
         with pytest.raises(
             ValueError,
-            match="For Bitbucket Cloud, either provide.*BITBUCKET_PERSONAL_TOKEN.*or.*BITBUCKET_USERNAME.*BITBUCKET_APP_PASSWORD",
+            match="For Bitbucket Cloud.*BITBUCKET_API_TOKEN.*BITBUCKET_PERSONAL_TOKEN",
         ):
             BitbucketConfig.from_env()
 
@@ -154,7 +171,7 @@ class TestBitbucketConfig:
         """Test that incomplete basic auth credentials raises ValueError."""
         with pytest.raises(
             ValueError,
-            match="For Bitbucket Cloud, either provide.*BITBUCKET_PERSONAL_TOKEN.*or.*BITBUCKET_USERNAME.*BITBUCKET_APP_PASSWORD",
+            match="For Bitbucket Cloud.*BITBUCKET_API_TOKEN.*BITBUCKET_PERSONAL_TOKEN",
         ):
             BitbucketConfig.from_env()
 

--- a/tests/unit/bitbucket/test_repositories.py
+++ b/tests/unit/bitbucket/test_repositories.py
@@ -85,7 +85,7 @@ class TestRepositoriesMixin:
 
         result = repositories_mixin.get_all_repositories("test-workspace")
 
-        assert result == sample_repository_data
+        assert [repository.name for repository in result] == ["repo1", "repo2"]
         repositories_mixin.bitbucket.get_repositories.assert_called_once_with(
             "test-workspace"
         )
@@ -100,7 +100,7 @@ class TestRepositoriesMixin:
 
         result = repositories_mixin.get_all_repositories()
 
-        assert result == sample_repository_data
+        assert [repository.name for repository in result] == ["repo1", "repo2"]
         repositories_mixin.bitbucket.get_repositories.assert_called_once_with(None)
 
     def test_get_all_repositories_http_401_error(self, repositories_mixin):

--- a/tests/unit/jira/test_jira_client.py
+++ b/tests/unit/jira/test_jira_client.py
@@ -44,6 +44,8 @@ def test_init_with_basic_auth():
             password="test_token",
             cloud=True,
             verify_ssl=True,
+            backoff_and_retry=True,
+            retry_status_codes=[429, 500, 502, 503, 504],
         )
 
         # Verify SSL verification was configured

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -52,69 +52,95 @@ class TestSearchMixin:
             "maxResults": 50,
         }
 
-    @pytest.mark.parametrize(
-        "is_cloud, expected_method_name",
-        [
-            (True, "enhanced_jql_get_list_of_tickets"),  # Cloud scenario
-            (False, "jql"),  # Server/DC scenario
-        ],
-    )
-    def test_search_issues_calls_correct_method(
-        self,
-        search_mixin: SearchMixin,
-        mock_issues_response,
-        is_cloud,
-        expected_method_name,
+    def test_search_issues_calls_cloud_endpoint(
+        self, search_mixin: SearchMixin, mock_issues_response
     ):
-        """Test that the correct Jira API method is called based on Cloud/Server setting."""
-        # Setup: Mock config.is_cloud
-        search_mixin.config.is_cloud = is_cloud
-        search_mixin.config.projects_filter = None  # No filter for this test
-        search_mixin.config.url = (
-            "https://test.example.com"  # Model creation needs this
-        )
+        """Ensure Jira Cloud uses the enhanced /search/jql endpoint."""
+        search_mixin.config.is_cloud = True
+        search_mixin.config.projects_filter = None
+        search_mixin.config.url = "https://test.example.com"
 
-        # Setup: Mock response for both API methods
-        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
-            return_value=mock_issues_response["issues"]
-        )
-        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
+        cloud_response = {
+            "issues": mock_issues_response["issues"],
+            "nextPageToken": None,
+            "isLast": True,
+        }
 
-        # Determine other method name for assertion
-        other_method_name = (
-            "jql"
-            if expected_method_name == "enhanced_jql_get_list_of_tickets"
-            else "enhanced_jql_get_list_of_tickets"
-        )
+        search_mixin.jira.resource_url.side_effect = lambda path: path
+        search_mixin.jira.get.reset_mock()
+        search_mixin.jira.get.return_value = cloud_response
 
-        # Act
         jql_query = "project = TEST"
         result = search_mixin.search_issues(jql_query, limit=10, start=0)
 
-        # Assert: Basic result verification
         assert isinstance(result, JiraSearchResult)
-        assert len(result.issues) > 0  # Based on mocked response
+        assert len(result.issues) == len(mock_issues_response["issues"])
+        assert result.next_page_token is None
+        assert result.is_last is True
 
-        # Assert: Correct method call verification
-        expected_method_mock = getattr(search_mixin.jira, expected_method_name)
+        search_mixin.jira.get.assert_called_once()
+        called_path = search_mixin.jira.get.call_args[0][0]
+        params = search_mixin.jira.get.call_args[1]["params"]
 
-        # Define expected kwargs based on whether it's Cloud or Server
-        expected_kwargs = {
-            "limit": 10,
-            "expand": None,
+        assert called_path == "search/jql"
+        assert params["jql"] == jql_query
+        assert params["maxResults"] == 10
+        assert "fields" in params
+
+        search_mixin.jira.jql.assert_not_called()
+
+    def test_search_issues_calls_server_endpoint(
+        self, search_mixin: SearchMixin, mock_issues_response
+    ):
+        """Ensure Jira Server/Data Center uses the classic search endpoint."""
+        search_mixin.config.is_cloud = False
+        search_mixin.config.projects_filter = None
+        search_mixin.config.url = "https://test.example.com"
+
+        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
+
+        jql_query = "project = TEST"
+        result = search_mixin.search_issues(jql_query, limit=10, start=0)
+
+        assert isinstance(result, JiraSearchResult)
+        assert len(result.issues) == len(mock_issues_response["issues"])
+
+        search_mixin.jira.jql.assert_called_once_with(
+            jql_query, fields=ANY, start=0, limit=10, expand=None
+        )
+        search_mixin.jira.get.assert_not_called()
+
+    def test_search_issues_cloud_handles_pagination(self, search_mixin: SearchMixin):
+        """Verify Cloud pagination stops at the requested limit and tracks tokens."""
+        search_mixin.config.is_cloud = True
+        search_mixin.config.projects_filter = None
+        search_mixin.config.url = "https://test.example.com"
+        search_mixin.jira.resource_url.side_effect = lambda path: path
+
+        page_one_issue = {
+            "id": "10001",
+            "key": "TEST-1",
+            "fields": {"summary": "Issue one"},
+        }
+        page_two_issue = {
+            "id": "10002",
+            "key": "TEST-2",
+            "fields": {"summary": "Issue two"},
         }
 
-        # Add start param only for Server/DC
-        if not is_cloud:
-            expected_kwargs["start"] = 0
+        search_mixin.jira.get.side_effect = [
+            {"issues": [page_one_issue], "nextPageToken": "token-123", "isLast": False},
+            {"issues": [page_two_issue], "nextPageToken": None, "isLast": True},
+        ]
 
-        expected_method_mock.assert_called_once_with(
-            jql_query, fields=ANY, **expected_kwargs
-        )
+        result = search_mixin.search_issues("project = TEST", limit=2)
 
-        # Assert: Other method was not called
-        other_method_mock = getattr(search_mixin.jira, other_method_name)
-        other_method_mock.assert_not_called()
+        assert isinstance(result, JiraSearchResult)
+        assert len(result.issues) == 2
+        assert result.next_page_token is None
+        assert result.is_last is True
+        assert result.total == 2
+        assert search_mixin.jira.get.call_count == 2
 
     def test_search_issues_basic(self, search_mixin: SearchMixin):
         """Test basic search functionality."""
@@ -255,7 +281,7 @@ class TestSearchMixin:
         # Verify results
         assert isinstance(result, JiraSearchResult)
         assert len(result.issues) == 0
-        assert result.total == -1
+        assert result.total == 0
 
     def test_search_issues_with_error(self, search_mixin: SearchMixin):
         """Test search with API error."""
@@ -503,7 +529,7 @@ class TestSearchMixin:
 
         with pytest.raises(Exception) as e:
             search_mixin.get_board_issues("1000", jql="", limit=20)
-        assert "API Error content" in str(e.value)
+        assert str(e.value).startswith("Error searching issues for board with JQL")
 
     def test_get_sprint_issues(self, search_mixin: SearchMixin):
         """Test get_sprint_issues method."""
@@ -566,7 +592,7 @@ class TestSearchMixin:
 
         with pytest.raises(Exception) as e:
             search_mixin.get_sprint_issues("10001")
-        assert "API Error content" in str(e.value)
+        assert str(e.value).startswith("Error searching issues for sprint")
 
     @pytest.mark.parametrize("is_cloud", [True, False])
     def test_search_issues_with_projects_filter_jql_construction(
@@ -580,52 +606,45 @@ class TestSearchMixin:
         )
         search_mixin.config.url = "https://test.example.com"
 
-        # Setup mock response for both API methods
-        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
-            return_value=mock_issues_response["issues"]
-        )
-        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
-        api_method_mock = getattr(
-            search_mixin.jira, "enhanced_jql_get_list_of_tickets" if is_cloud else "jql"
-        )
+        if is_cloud:
+            search_mixin.jira.resource_url.side_effect = lambda path: path
+            search_mixin.jira.get = MagicMock(
+                return_value={
+                    "issues": mock_issues_response["issues"],
+                    "nextPageToken": None,
+                    "isLast": True,
+                }
+            )
+        else:
+            search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
 
-        # Act: Single project filter
+        def assert_called_with_jql(expected_jql: str) -> None:
+            if is_cloud:
+                assert search_mixin.jira.get.called
+                _, kwargs = search_mixin.jira.get.call_args
+                params = kwargs["params"]
+                assert params["jql"] == expected_jql
+            else:
+                search_mixin.jira.jql.assert_called_with(
+                    expected_jql, fields=ANY, start=ANY, limit=ANY, expand=ANY
+                )
+
         search_mixin.search_issues("text ~ 'test'", projects_filter="TEST")
+        assert_called_with_jql("(text ~ 'test') AND project = \"TEST\"")
+        if is_cloud:
+            search_mixin.jira.get.reset_mock()
+        else:
+            search_mixin.jira.jql.reset_mock()
 
-        # Define expected kwargs based on is_cloud
-        expected_kwargs = {
-            "fields": ANY,
-            "limit": ANY,
-            "expand": ANY,
-        }
-        # Add start parameter only for Server/DC
-        if not is_cloud:
-            expected_kwargs["start"] = ANY
-
-        # Assert: JQL verification
-        api_method_mock.assert_called_with(
-            "(text ~ 'test') AND project = \"TEST\"",  # Check constructed JQL
-            **expected_kwargs,
-        )
-
-        # Reset mock for next call
-        api_method_mock.reset_mock()
-
-        # Act: Multiple projects filter
         search_mixin.search_issues("text ~ 'test'", projects_filter="TEST, DEV")
-        # Assert: JQL verification
-        api_method_mock.assert_called_with(
-            '(text ~ \'test\') AND project IN ("TEST", "DEV")',  # Check constructed JQL
-            **expected_kwargs,
-        )
+        assert_called_with_jql('(text ~ \'test\') AND project IN ("TEST", "DEV")')
+        if is_cloud:
+            search_mixin.jira.get.reset_mock()
+        else:
+            search_mixin.jira.jql.reset_mock()
 
-        # Reset mock for next call
-        api_method_mock.reset_mock()
-
-        # Act: Call with both JQL and filter
         search_mixin.search_issues("project = OTHER", projects_filter="TEST")
-        # Assert: JQL verification (existing JQL has priority)
-        api_method_mock.assert_called_with("project = OTHER", **expected_kwargs)
+        assert_called_with_jql("project = OTHER")
 
     @pytest.mark.parametrize("is_cloud", [True, False])
     def test_search_issues_with_config_projects_filter_jql_construction(
@@ -637,41 +656,37 @@ class TestSearchMixin:
         search_mixin.config.projects_filter = "CONF1,CONF2"  # Set config filter
         search_mixin.config.url = "https://test.example.com"
 
-        # Setup mock response for both API methods
-        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
-            return_value=mock_issues_response["issues"]
-        )
-        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
-        api_method_mock = getattr(
-            search_mixin.jira, "enhanced_jql_get_list_of_tickets" if is_cloud else "jql"
-        )
+        if is_cloud:
+            search_mixin.jira.resource_url.side_effect = lambda path: path
+            search_mixin.jira.get = MagicMock(
+                return_value={
+                    "issues": mock_issues_response["issues"],
+                    "nextPageToken": None,
+                    "isLast": True,
+                }
+            )
+        else:
+            search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
 
-        # Define expected kwargs based on is_cloud
-        expected_kwargs = {
-            "fields": ANY,
-            "limit": ANY,
-            "expand": ANY,
-        }
-        # Add start parameter only for Server/DC
-        if not is_cloud:
-            expected_kwargs["start"] = ANY
+        def assert_called(expected_jql: str) -> None:
+            if is_cloud:
+                assert search_mixin.jira.get.called
+                _, kwargs = search_mixin.jira.get.call_args
+                assert kwargs["params"]["jql"] == expected_jql
+            else:
+                search_mixin.jira.jql.assert_called_with(
+                    expected_jql, fields=ANY, start=ANY, limit=ANY, expand=ANY
+                )
 
-        # Act: Use config filter
         search_mixin.search_issues("text ~ 'test'")
-        # Assert: JQL verification
-        api_method_mock.assert_called_with(
-            '(text ~ \'test\') AND project IN ("CONF1", "CONF2")', **expected_kwargs
-        )
+        assert_called('(text ~ \'test\') AND project IN ("CONF1", "CONF2")')
+        if is_cloud:
+            search_mixin.jira.get.reset_mock()
+        else:
+            search_mixin.jira.jql.reset_mock()
 
-        # Reset mock for next call
-        api_method_mock.reset_mock()
-
-        # Act: Override config filter with parameter
         search_mixin.search_issues("text ~ 'test'", projects_filter="OVERRIDE")
-        # Assert: JQL verification
-        api_method_mock.assert_called_with(
-            "(text ~ 'test') AND project = \"OVERRIDE\"", **expected_kwargs
-        )
+        assert_called("(text ~ 'test') AND project = \"OVERRIDE\"")
 
     @pytest.mark.parametrize("is_cloud", [True, False])
     def test_search_issues_with_empty_jql_and_projects_filter(
@@ -683,44 +698,44 @@ class TestSearchMixin:
         search_mixin.config.projects_filter = None
         search_mixin.config.url = "https://test.example.com"
 
-        # Setup mock response for both API methods
-        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
-            return_value=mock_issues_response["issues"]
-        )
-        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
-        api_method_mock = getattr(
-            search_mixin.jira, "enhanced_jql_get_list_of_tickets" if is_cloud else "jql"
-        )
+        if is_cloud:
+            search_mixin.jira.resource_url.side_effect = lambda path: path
+            search_mixin.jira.get = MagicMock(
+                return_value={
+                    "issues": mock_issues_response["issues"],
+                    "nextPageToken": None,
+                    "isLast": True,
+                }
+            )
+        else:
+            search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
 
-        # Define expected kwargs based on is_cloud
-        expected_kwargs = {
-            "fields": ANY,
-            "limit": ANY,
-            "expand": ANY,
-        }
-        # Add start parameter only for Server/DC
-        if not is_cloud:
-            expected_kwargs["start"] = ANY
+        def assert_called(expected_jql: str) -> None:
+            if is_cloud:
+                assert search_mixin.jira.get.called
+                _, kwargs = search_mixin.jira.get.call_args
+                assert kwargs["params"]["jql"] == expected_jql
+            else:
+                search_mixin.jira.jql.assert_called_with(
+                    expected_jql, fields=ANY, start=ANY, limit=ANY, expand=ANY
+                )
 
-        # Test 1: Empty string JQL with single project
         search_mixin.search_issues("", projects_filter="PROJ1")
-        api_method_mock.assert_called_with('project = "PROJ1"', **expected_kwargs)
+        assert_called('project = "PROJ1"')
+        if is_cloud:
+            search_mixin.jira.get.reset_mock()
+        else:
+            search_mixin.jira.jql.reset_mock()
 
-        # Reset mock
-        api_method_mock.reset_mock()
-
-        # Test 2: Empty string JQL with multiple projects
         search_mixin.search_issues("", projects_filter="PROJ1,PROJ2")
-        api_method_mock.assert_called_with(
-            'project IN ("PROJ1", "PROJ2")', **expected_kwargs
-        )
+        assert_called('project IN ("PROJ1", "PROJ2")')
+        if is_cloud:
+            search_mixin.jira.get.reset_mock()
+        else:
+            search_mixin.jira.jql.reset_mock()
 
-        # Reset mock
-        api_method_mock.reset_mock()
-
-        # Test 3: None JQL with projects filter
         result = search_mixin.search_issues(None, projects_filter="PROJ1")
-        api_method_mock.assert_called_with('project = "PROJ1"', **expected_kwargs)
+        assert_called('project = "PROJ1"')
         assert isinstance(result, JiraSearchResult)
 
     @pytest.mark.parametrize("is_cloud", [True, False])
@@ -733,58 +748,52 @@ class TestSearchMixin:
         search_mixin.config.projects_filter = None
         search_mixin.config.url = "https://test.example.com"
 
-        # Setup mock response for both API methods
-        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
-            return_value=mock_issues_response["issues"]
-        )
-        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
-        api_method_mock = getattr(
-            search_mixin.jira, "enhanced_jql_get_list_of_tickets" if is_cloud else "jql"
-        )
+        if is_cloud:
+            search_mixin.jira.resource_url.side_effect = lambda path: path
+            search_mixin.jira.get = MagicMock(
+                return_value={
+                    "issues": mock_issues_response["issues"],
+                    "nextPageToken": None,
+                    "isLast": True,
+                }
+            )
+        else:
+            search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
 
-        # Define expected kwargs based on is_cloud
-        expected_kwargs = {
-            "fields": ANY,
-            "limit": ANY,
-            "expand": ANY,
-        }
-        # Add start parameter only for Server/DC
-        if not is_cloud:
-            expected_kwargs["start"] = ANY
+        def assert_order_by(expected_jql: str) -> None:
+            if is_cloud:
+                assert search_mixin.jira.get.called
+                _, kwargs = search_mixin.jira.get.call_args
+                assert kwargs["params"]["jql"] == expected_jql
+            else:
+                search_mixin.jira.jql.assert_called_with(
+                    expected_jql, fields=ANY, start=ANY, limit=ANY, expand=ANY
+                )
 
-        # Test 1: ORDER BY with single project
         search_mixin.search_issues("ORDER BY created DESC", projects_filter="PROJ1")
-        api_method_mock.assert_called_with(
-            'project = "PROJ1" ORDER BY created DESC', **expected_kwargs
-        )
+        assert_order_by('project = "PROJ1" ORDER BY created DESC')
+        if is_cloud:
+            search_mixin.jira.get.reset_mock()
+        else:
+            search_mixin.jira.jql.reset_mock()
 
-        # Reset mock
-        api_method_mock.reset_mock()
-
-        # Test 2: ORDER BY with multiple projects
         search_mixin.search_issues(
             "ORDER BY created DESC", projects_filter="PROJ1,PROJ2"
         )
-        api_method_mock.assert_called_with(
-            'project IN ("PROJ1", "PROJ2") ORDER BY created DESC', **expected_kwargs
-        )
+        assert_order_by('project IN ("PROJ1", "PROJ2") ORDER BY created DESC')
+        if is_cloud:
+            search_mixin.jira.get.reset_mock()
+        else:
+            search_mixin.jira.jql.reset_mock()
 
-        # Reset mock
-        api_method_mock.reset_mock()
-
-        # Test 3: Case insensitive ORDER BY
         search_mixin.search_issues("order by updated ASC", projects_filter="PROJ1")
-        api_method_mock.assert_called_with(
-            'project = "PROJ1" order by updated ASC', **expected_kwargs
-        )
+        assert_order_by('project = "PROJ1" order by updated ASC')
+        if is_cloud:
+            search_mixin.jira.get.reset_mock()
+        else:
+            search_mixin.jira.jql.reset_mock()
 
-        # Reset mock
-        api_method_mock.reset_mock()
-
-        # Test 4: ORDER BY with extra spaces
         search_mixin.search_issues(
             "  ORDER BY priority DESC  ", projects_filter="PROJ1"
         )
-        api_method_mock.assert_called_with(
-            'project = "PROJ1"   ORDER BY priority DESC  ', **expected_kwargs
-        )
+        assert_order_by('project = "PROJ1"   ORDER BY priority DESC  ')

--- a/tests/unit/models/test_jira_models.py
+++ b/tests/unit/models/test_jira_models.py
@@ -1092,10 +1092,12 @@ class TestJiraSearchResult:
         api_data.pop("maxResults", None)
 
         search_result = JiraSearchResult.from_api_response(api_data)
-        # Verify that -1 is used for missing metadata
-        assert search_result.total == -1
-        assert search_result.start_at == -1
+        # Verify that sensible defaults are used for missing metadata
+        assert search_result.total == 1  # Falls back to number of returned issues
+        assert search_result.start_at == 0
         assert search_result.max_results == -1
+        assert search_result.next_page_token is None
+        assert search_result.is_last is None
         assert len(search_result.issues) == 1  # Assuming mock data has issues
 
     def test_to_simplified_dict(self, jira_search_data):
@@ -1109,11 +1111,15 @@ class TestJiraSearchResult:
         assert "start_at" in simplified
         assert "max_results" in simplified
         assert "issues" in simplified
+        assert "next_page_token" in simplified
+        assert "is_last" in simplified
 
         # Verify metadata values
         assert simplified["total"] == 34
         assert simplified["start_at"] == 0
         assert simplified["max_results"] == 5
+        assert simplified["next_page_token"] is None
+        assert simplified["is_last"] is None
 
         # Verify issues array
         assert isinstance(simplified["issues"], list)
@@ -1145,6 +1151,8 @@ class TestJiraSearchResult:
         assert simplified["start_at"] == 0
         assert simplified["max_results"] == 0
         assert simplified["issues"] == []
+        assert simplified["next_page_token"] is None
+        assert simplified["is_last"] is None
 
     def test_to_simplified_dict_with_multiple_issues(self):
         """Test converting JiraSearchResult with multiple issues to a simplified dictionary."""


### PR DESCRIPTION
* fix: migrate jira search to enhanced /search/jql endpoint for cloud resource

## Description

- Migrated the search endpoint from /search to /search/jql. This applies for cloud jira resources only.
- This is needed because Atlassian moved `/search` cloud endpoint to `/search/jql`, this change impacted `jira_search` and `jira_get_project_issues` tools --> <https://developer.atlassian.com/changelog/#CHANGE-2046>

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: 
  <img width="530" height="489" alt="image" src="https://github.com/user-attachments/assets/e1f3db38-281c-4690-89b3-57fa81ef95c5" />

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
