### PR TITLE
fix: pass lifespan to FastMCP constructor

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -788,9 +788,7 @@ class UserTokenMiddleware:
             raise
 
 
-main_mcp = AtlassianMCP(name="Atlassian MCP")
-# Set the lifespan after construction to avoid deprecation warnings
-main_mcp._lifespan = main_lifespan
+main_mcp = AtlassianMCP(name="Atlassian MCP", lifespan=main_lifespan)
 main_mcp.mount(jira_mcp, prefix="jira")
 main_mcp.mount(confluence_mcp, prefix="confluence")
 main_mcp.mount(bitbucket_mcp, prefix="bitbucket")


### PR DESCRIPTION
## Problem

The `main_lifespan` function was not being executed during server startup, causing the lifespan context to be unavailable. This resulted in errors when trying to use Jira tools:

```
ValueError: Jira global configuration (URL, SSL) is not available from lifespan context.
```

### Root Cause

This is a **regression introduced in PR #7** (https://github.com/SharkyND/mcp-atlassian/pull/7).

In that PR, the lifespan was changed from being passed to the constructor to being assigned to the private `_lifespan` attribute after instance creation:

```python
main_mcp = AtlassianMCP(name="Atlassian MCP")
# Set the lifespan after construction to avoid deprecation warnings
main_mcp._lifespan = main_lifespan
```

However, **FastMCP requires the `lifespan` parameter to be passed during instantiation** to properly register and execute the lifespan hooks. Assigning to `_lifespan` afterwards does not trigger the proper initialization sequence.

### Evidence

Looking at the server logs:
- **Before fix**: No lifespan logs appear (no "Main Atlassian MCP server lifespan starting..." message)
- **After fix**: All expected lifespan initialization logs are present

## Solution

Pass the `lifespan` parameter to the `AtlassianMCP` constructor, following the same pattern used in the test files:

```python
main_mcp = AtlassianMCP(name="Atlassian MCP", lifespan=main_lifespan)
```

This ensures the lifespan context manager executes properly, making the configuration available to all tools.

## Testing

Verified that after the fix:
1. The `main_lifespan` function executes on server startup
2. Configuration logs appear in the output
3. Jira tools work correctly without "lifespan context" errors

## Related

Fixes #19 