### PR TITLE
fix: don't discard env config when specifying PAT headers

### DIFF
--- a/src/mcp_atlassian/bitbucket/config.py
+++ b/src/mcp_atlassian/bitbucket/config.py
@@ -81,8 +81,14 @@ class BitbucketConfig:
         return False
 
     @classmethod
-    def from_env(cls) -> "BitbucketConfig":
+    def from_env(
+        cls, url: str | None = None, personal_token: str | None = None
+    ) -> "BitbucketConfig":
         """Create configuration from environment variables.
+
+        Args:
+            url: An optional override for the url.
+            personal_token: An optional orverride for the personal_token.
 
         Returns:
             BitbucketConfig with values from environment variables
@@ -90,7 +96,7 @@ class BitbucketConfig:
         Raises:
             ValueError: If required environment variables are missing or invalid
         """
-        url = os.getenv("BITBUCKET_URL")
+        url = url or os.getenv("BITBUCKET_URL")
         if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
             error_msg = "Missing required BITBUCKET_URL environment variable"
             raise ValueError(error_msg)
@@ -98,7 +104,7 @@ class BitbucketConfig:
         # Determine authentication type based on available environment variables
         username = os.getenv("BITBUCKET_USERNAME")
         app_password = os.getenv("BITBUCKET_APP_PASSWORD")
-        personal_token = os.getenv("BITBUCKET_PERSONAL_TOKEN")
+        personal_token = personal_token or os.getenv("BITBUCKET_PERSONAL_TOKEN")
 
         # Check for OAuth configuration
         oauth_config = get_oauth_config_from_env()

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -67,8 +67,14 @@ class ConfluenceConfig:
         return self.ssl_verify
 
     @classmethod
-    def from_env(cls) -> "ConfluenceConfig":
+    def from_env(
+        cls, url: str | None = None, personal_token: str | None = None
+    ) -> "ConfluenceConfig":
         """Create configuration from environment variables.
+
+        Args:
+            url: An optional override for the url.
+            personal_token: An optional orverride for the personal_token.
 
         Returns:
             ConfluenceConfig with values from environment variables
@@ -76,7 +82,7 @@ class ConfluenceConfig:
         Raises:
             ValueError: If any required environment variable is missing
         """
-        url = os.getenv("CONFLUENCE_URL")
+        url = url or os.getenv("CONFLUENCE_URL")
         if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
             error_msg = "Missing required CONFLUENCE_URL environment variable"
             raise ValueError(error_msg)
@@ -84,7 +90,7 @@ class ConfluenceConfig:
         # Determine authentication type based on available environment variables
         username = os.getenv("CONFLUENCE_USERNAME")
         api_token = os.getenv("CONFLUENCE_API_TOKEN")
-        personal_token = os.getenv("CONFLUENCE_PERSONAL_TOKEN")
+        personal_token = personal_token or os.getenv("CONFLUENCE_PERSONAL_TOKEN")
 
         # Check for OAuth configuration
         oauth_config = get_oauth_config_from_env()

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -67,8 +67,14 @@ class JiraConfig:
         return self.ssl_verify
 
     @classmethod
-    def from_env(cls) -> "JiraConfig":
+    def from_env(
+        cls, url: str | None = None, personal_token: str | None = None
+    ) -> "JiraConfig":
         """Create configuration from environment variables.
+
+        Args:
+            url: An optional override for the url.
+            personal_token: An optional orverride for the personal_token.
 
         Returns:
             JiraConfig with values from environment variables
@@ -76,7 +82,7 @@ class JiraConfig:
         Raises:
             ValueError: If required environment variables are missing or invalid
         """
-        url = os.getenv("JIRA_URL")
+        url = url or os.getenv("JIRA_URL")
         if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
             error_msg = "Missing required JIRA_URL environment variable"
             raise ValueError(error_msg)
@@ -84,7 +90,7 @@ class JiraConfig:
         # Determine authentication type based on available environment variables
         username = os.getenv("JIRA_USERNAME")
         api_token = os.getenv("JIRA_API_TOKEN")
-        personal_token = os.getenv("JIRA_PERSONAL_TOKEN")
+        personal_token = personal_token or os.getenv("JIRA_PERSONAL_TOKEN")
 
         # Check for OAuth configuration
         oauth_config = get_oauth_config_from_env()

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -205,31 +205,21 @@ async def get_jira_fetcher(ctx: Context) -> JiraFetcher:
         user_auth_type = getattr(request.state, "user_atlassian_auth_type", None)
         logger.debug(f"get_jira_fetcher: User auth type: {user_auth_type}")
 
+        # Try get the credentials from the http headers.
         service_headers = getattr(request.state, "atlassian_service_headers", {})
-        jira_url_header = service_headers.get("X-Atlassian-Jira-Url")
-        jira_token_header = service_headers.get("X-Atlassian-Jira-Personal-Token")
-
         if (
             user_auth_type == "pat"
-            and jira_url_header
-            and jira_token_header
+            and (url := service_headers.get("X-Atlassian-Jira-Url"))
+            and (
+                personal_token := service_headers.get("X-Atlassian-Jira-Personal-Token")
+            )
             and not hasattr(request.state, "user_atlassian_token")
         ):
             logger.info(
-                f"Creating header-based JiraFetcher with URL: {jira_url_header} and PAT token"
+                f"Creating header-based JiraFetcher with URL: {url} and PAT token"
             )
-            header_config = JiraConfig(
-                url=jira_url_header,
-                auth_type="pat",
-                personal_token=jira_token_header,
-                ssl_verify=True,
-                projects_filter=None,
-                http_proxy=None,
-                https_proxy=None,
-                no_proxy=None,
-                socks_proxy=None,
-                custom_headers=None,
-            )
+            header_config = JiraConfig.from_env(url=url, personal_token=personal_token)
+
             try:
                 header_jira_fetcher = JiraFetcher(config=header_config)
                 current_user_id = header_jira_fetcher.get_current_user_account_id()
@@ -355,33 +345,21 @@ async def get_confluence_fetcher(ctx: Context) -> ConfluenceFetcher:
         user_auth_type = getattr(request.state, "user_atlassian_auth_type", None)
         logger.debug(f"get_confluence_fetcher: User auth type: {user_auth_type}")
 
-        service_headers = getattr(request.state, "atlassian_service_headers", {})
-        confluence_url_header = service_headers.get("X-Atlassian-Confluence-Url")
-        confluence_token_header = service_headers.get(
-            "X-Atlassian-Confluence-Personal-Token"
-        )
-
+        # Try get the credentials from the http headers.
+        headers = getattr(request.state, "atlassian_service_headers", {})
         if (
             user_auth_type == "pat"
-            and confluence_url_header
-            and confluence_token_header
+            and (url := headers.get("X-Atlassian-Confluence-Url"))
+            and (personal_token := headers.get("X-Atlassian-Confluence-Personal-Token"))
             and not hasattr(request.state, "user_atlassian_token")
         ):
             logger.info(
-                f"Creating header-based ConfluenceFetcher with URL: {confluence_url_header} and PAT token"
+                f"Creating header-based ConfluenceFetcher with URL: {url} and PAT token"
             )
-            header_config = ConfluenceConfig(
-                url=confluence_url_header,
-                auth_type="pat",
-                personal_token=confluence_token_header,
-                ssl_verify=True,
-                spaces_filter=None,
-                http_proxy=None,
-                https_proxy=None,
-                no_proxy=None,
-                socks_proxy=None,
-                custom_headers=None,
+            header_config = ConfluenceConfig.from_env(
+                url=url, personal_token=personal_token
             )
+
             try:
                 header_confluence_fetcher = ConfluenceFetcher(config=header_config)
                 current_user_data = header_confluence_fetcher.get_current_user_info()
@@ -540,33 +518,21 @@ async def get_bitbucket_fetcher(ctx: Context) -> BitbucketFetcher:
         user_auth_type = getattr(request.state, "user_atlassian_auth_type", None)
         logger.debug(f"get_bitbucket_fetcher: User auth type: {user_auth_type}")
 
-        service_headers = getattr(request.state, "atlassian_service_headers", {})
-        bitbucket_url_header = service_headers.get("X-Atlassian-Bitbucket-Url")
-        bitbucket_token_header = service_headers.get(
-            "X-Atlassian-Bitbucket-Personal-Token"
-        )
-
+        # Try get the credentials from the http headers.
+        headers = getattr(request.state, "atlassian_service_headers", {})
         if (
             user_auth_type == "pat"
-            and bitbucket_url_header
-            and bitbucket_token_header
+            and (url := headers.get("X-Atlassian-Bitbucket-Url"))
+            and (personal_token := headers.get("X-Atlassian-Bitbucket-Personal-Token"))
             and not hasattr(request.state, "user_atlassian_token")
         ):
             logger.info(
-                f"Creating header-based BitbucketFetcher with URL: {bitbucket_url_header} and PAT token"
+                f"Creating header-based BitbucketFetcher with URL: {url} and PAT token"
             )
-            header_config = BitbucketConfig(
-                url=bitbucket_url_header,
-                auth_type="pat",
-                username=None,
-                personal_token=bitbucket_token_header,
-                ssl_verify=True,
-                http_proxy=None,
-                https_proxy=None,
-                no_proxy=None,
-                socks_proxy=None,
-                custom_headers=None,
+            header_config = BitbucketConfig.from_env(
+                url=url, personal_token=personal_token
             )
+
             try:
                 header_bitbucket_fetcher = BitbucketFetcher(config=header_config)
                 current_user_data = header_bitbucket_fetcher.get_current_user_info()


### PR DESCRIPTION
## Description

When headers specify the service personal access tokens and URL's, before this change 

## Changes

- Merge http headers with `JiraConfig.from_env`
- Merge http headers with `ConfluenceConfig.from_env`
- Merge http headers with `BitbucketConfig.from_env`

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: 
  - Create Jira Service with tickets `FOO-001` and `BAR-001`
  - Configure atlassian-mcp with env var `JIRA_PROJECTS_FILTER=FOO`
  - Set up LibreChat with this MCP server, specify URL and personal access token in LibreChat, not on the MCP server
  - Check that the following prompts in librechat work as expected
    - `Tell me the title of FOO-001` should succeed
    - `Tell me the title of BAR-001` should not succeed. Before this change, this was not filtered.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally. (getting window related errors on `main` branch)
- [ ] Documentation updated (if needed).
