### PR TITLE
Treat Bearer tokens as PAT auth type for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,9 @@ Here's a complete example of setting up multi-user authentication with streamabl
 - **Cloud (OAuth 2.0):** Use this if your organization is on Atlassian Cloud and you have an OAuth access token for each user.
 - **Server/Data Center (PAT):** Use this if you are on Atlassian Server or Data Center and each user has a Personal Access Token (PAT).
 
+> [!TIP]
+> Both `Bearer <token>` and `Token <token>` authorization formats are supported and work interchangeably. Choose the format that best fits your infrastructure - both will authenticate successfully with PAT or JWT tokens.
+
 **Cloud (OAuth 2.0) Example:**
 ```json
 {

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -283,10 +283,14 @@ async def get_jira_fetcher(ctx: Context) -> JiraFetcher:
                 )
 
             cloud_id_info = f" with cloudId {user_cloud_id}" if user_cloud_id else ""
-            # Use token_format for display (jwt, bearer, pat) while auth_type is used for logic
-            token_format = getattr(request.state, "user_atlassian_token_format", user_auth_type)
+            # Use token_format for display while auth_type is used for logic
+            token_format = getattr(
+                request.state, "user_atlassian_auth_format", user_auth_type
+            )
             logger.info(
-                f"Creating user-specific JiraFetcher (type: {token_format}) for user {user_email or 'unknown'} (token ...{str(user_token)[-8:]}){cloud_id_info}"
+                f"Creating user-specific JiraFetcher (type: {token_format}) "
+                f"for user {user_email or 'unknown'} "
+                f"(token ...{str(user_token)[-8:]}){cloud_id_info}"
             )
             user_specific_config = _create_user_config_for_fetcher(
                 base_config=app_lifespan_ctx.full_jira_config,
@@ -453,10 +457,14 @@ async def get_confluence_fetcher(ctx: Context) -> ConfluenceFetcher:
                 )
 
             cloud_id_info = f" with cloudId {user_cloud_id}" if user_cloud_id else ""
-            # Use token_format for display (jwt, bearer, pat) while auth_type is used for logic
-            token_format = getattr(request.state, "user_atlassian_token_format", user_auth_type)
+            # Use token_format for display while auth_type is used for logic
+            token_format = getattr(
+                request.state, "user_atlassian_auth_format", user_auth_type
+            )
             logger.info(
-                f"Creating user-specific ConfluenceFetcher (type: {token_format}) for user {user_email or 'unknown'} (token ...{str(user_token)[-8:]}){cloud_id_info}"
+                f"Creating user-specific ConfluenceFetcher (type: {token_format}) "
+                f"for user {user_email or 'unknown'} "
+                f"(token ...{str(user_token)[-8:]}){cloud_id_info}"
             )
             user_specific_config = _create_user_config_for_fetcher(
                 base_config=app_lifespan_ctx.full_confluence_config,
@@ -640,10 +648,14 @@ async def get_bitbucket_fetcher(ctx: Context) -> BitbucketFetcher:
                 )
 
             cloud_id_info = f" with cloudId {user_cloud_id}" if user_cloud_id else ""
-            # Use token_format for display (jwt, bearer, pat) while auth_type is used for logic
-            token_format = getattr(request.state, "user_atlassian_token_format", user_auth_type)
+            # Use token_format for display while auth_type is used for logic
+            token_format = getattr(
+                request.state, "user_atlassian_auth_format", user_auth_type
+            )
             logger.info(
-                f"Creating user-specific BitbucketFetcher (type: {token_format}) for user {user_email or 'unknown'} (token ...{str(user_token)[-8:]}){cloud_id_info}"
+                f"Creating user-specific BitbucketFetcher (type: {token_format}) "
+                f"for user {user_email or 'unknown'} "
+                f"(token ...{str(user_token)[-8:]}){cloud_id_info}"
             )
             user_specific_config = _create_user_config_for_fetcher(
                 base_config=app_lifespan_ctx.full_bitbucket_config,
@@ -834,12 +846,14 @@ async def get_xray_fetcher(ctx: Context) -> XrayFetcher:
                 )
 
             cloud_id_info = f" with cloudId {user_cloud_id}" if user_cloud_id else ""
-            # Use token_format for display (jwt, bearer, pat) while auth_type is used for logic
-            token_format = getattr(request.state, "user_atlassian_token_format", user_auth_type)
+            # Use token_format for display while auth_type is used for logic
+            token_format = getattr(
+                request.state, "user_atlassian_auth_format", user_auth_type
+            )
             logger.info(
-                f"Creating user-specific Xray for Jira fetcher (type: {token_format}) for user "
-                f"{user_email or 'unknown'} (token ...{str(user_token)[-8:]})"
-                f"{cloud_id_info}"
+                f"Creating user-specific Xray for Jira fetcher "
+                f"(type: {token_format}) for user {user_email or 'unknown'} "
+                f"(token ...{str(user_token)[-8:]}){cloud_id_info}"
             )
             user_specific_config = _create_user_config_for_fetcher(
                 base_config=app_lifespan_ctx.full_xray_config,

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -283,8 +283,10 @@ async def get_jira_fetcher(ctx: Context) -> JiraFetcher:
                 )
 
             cloud_id_info = f" with cloudId {user_cloud_id}" if user_cloud_id else ""
+            # Use token_format for display (jwt, bearer, pat) while auth_type is used for logic
+            token_format = getattr(request.state, "user_atlassian_token_format", user_auth_type)
             logger.info(
-                f"Creating user-specific JiraFetcher (type: {user_auth_type}) for user {user_email or 'unknown'} (token ...{str(user_token)[-8:]}){cloud_id_info}"
+                f"Creating user-specific JiraFetcher (type: {token_format}) for user {user_email or 'unknown'} (token ...{str(user_token)[-8:]}){cloud_id_info}"
             )
             user_specific_config = _create_user_config_for_fetcher(
                 base_config=app_lifespan_ctx.full_jira_config,
@@ -451,8 +453,10 @@ async def get_confluence_fetcher(ctx: Context) -> ConfluenceFetcher:
                 )
 
             cloud_id_info = f" with cloudId {user_cloud_id}" if user_cloud_id else ""
+            # Use token_format for display (jwt, bearer, pat) while auth_type is used for logic
+            token_format = getattr(request.state, "user_atlassian_token_format", user_auth_type)
             logger.info(
-                f"Creating user-specific ConfluenceFetcher (type: {user_auth_type}) for user {user_email or 'unknown'} (token ...{str(user_token)[-8:]}){cloud_id_info}"
+                f"Creating user-specific ConfluenceFetcher (type: {token_format}) for user {user_email or 'unknown'} (token ...{str(user_token)[-8:]}){cloud_id_info}"
             )
             user_specific_config = _create_user_config_for_fetcher(
                 base_config=app_lifespan_ctx.full_confluence_config,
@@ -636,8 +640,10 @@ async def get_bitbucket_fetcher(ctx: Context) -> BitbucketFetcher:
                 )
 
             cloud_id_info = f" with cloudId {user_cloud_id}" if user_cloud_id else ""
+            # Use token_format for display (jwt, bearer, pat) while auth_type is used for logic
+            token_format = getattr(request.state, "user_atlassian_token_format", user_auth_type)
             logger.info(
-                f"Creating user-specific BitbucketFetcher (type: {user_auth_type}) for user {user_email or 'unknown'} (token ...{str(user_token)[-8:]}){cloud_id_info}"
+                f"Creating user-specific BitbucketFetcher (type: {token_format}) for user {user_email or 'unknown'} (token ...{str(user_token)[-8:]}){cloud_id_info}"
             )
             user_specific_config = _create_user_config_for_fetcher(
                 base_config=app_lifespan_ctx.full_bitbucket_config,
@@ -828,8 +834,10 @@ async def get_xray_fetcher(ctx: Context) -> XrayFetcher:
                 )
 
             cloud_id_info = f" with cloudId {user_cloud_id}" if user_cloud_id else ""
+            # Use token_format for display (jwt, bearer, pat) while auth_type is used for logic
+            token_format = getattr(request.state, "user_atlassian_token_format", user_auth_type)
             logger.info(
-                f"Creating user-specific Xray for Jira fetcher for user "
+                f"Creating user-specific Xray for Jira fetcher (type: {token_format}) for user "
                 f"{user_email or 'unknown'} (token ...{str(user_token)[-8:]})"
                 f"{cloud_id_info}"
             )

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -838,7 +838,7 @@ class UserTokenMiddleware:
                 # both JWT tokens and traditional PAT tokens
                 scope_copy["state"]["user_atlassian_auth_type"] = "pat"
                 # Store the actual token format for logging purposes
-                scope_copy["state"]["user_atlassian_token_format"] = token_format
+                scope_copy["state"]["user_atlassian_auth_format"] = token_format
                 scope_copy["state"]["user_atlassian_email"] = None
                 logger.debug(
                     f"UserTokenMiddleware.__call__: Set scope state (pre-validation): "
@@ -860,7 +860,7 @@ class UserTokenMiddleware:
                 )
                 scope_copy["state"]["user_atlassian_token"] = token
                 scope_copy["state"]["user_atlassian_auth_type"] = "pat"
-                scope_copy["state"]["user_atlassian_token_format"] = "pat"
+                scope_copy["state"]["user_atlassian_auth_format"] = "pat"
                 scope_copy["state"]["user_atlassian_email"] = None
                 logger.debug(
                     "UserTokenMiddleware.__call__: Set scope state for PAT auth."

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -822,16 +822,28 @@ class UserTokenMiddleware:
                     )
                     return
 
+                # Detect if it's a JWT token (3 base64 parts separated by dots)
+                token_parts = token.split(".")
+                is_jwt = len(token_parts) == 3 and all(
+                    len(part) > 0 for part in token_parts
+                )
+                token_format = "jwt" if is_jwt else "bearer"
+
                 logger.debug(
                     f"UserTokenMiddleware.__call__: Bearer token extracted "
-                    f"(masked): ...{mask_sensitive(token, 8)}"
+                    f"(format: {token_format}, masked): ...{mask_sensitive(token, 8)}"
                 )
                 scope_copy["state"]["user_atlassian_token"] = token
-                scope_copy["state"]["user_atlassian_auth_type"] = "oauth"
+                # Treat Bearer tokens as PAT auth type for compatibility with
+                # both JWT tokens and traditional PAT tokens
+                scope_copy["state"]["user_atlassian_auth_type"] = "pat"
+                # Store the actual token format for logging purposes
+                scope_copy["state"]["user_atlassian_token_format"] = token_format
                 scope_copy["state"]["user_atlassian_email"] = None
                 logger.debug(
                     f"UserTokenMiddleware.__call__: Set scope state (pre-validation): "
-                    f"auth_type='oauth', token_present={bool(token)}"
+                    f"auth_type='pat', token_format='{token_format}', "
+                    f"token_present={bool(token)}"
                 )
             elif auth_header_str and auth_header_str.startswith("Token "):
                 token = auth_header_str.split(" ", 1)[1].strip()
@@ -848,6 +860,7 @@ class UserTokenMiddleware:
                 )
                 scope_copy["state"]["user_atlassian_token"] = token
                 scope_copy["state"]["user_atlassian_auth_type"] = "pat"
+                scope_copy["state"]["user_atlassian_token_format"] = "pat"
                 scope_copy["state"]["user_atlassian_email"] = None
                 logger.debug(
                     "UserTokenMiddleware.__call__: Set scope state for PAT auth."

--- a/tests/integration/test_mcp_protocol.py
+++ b/tests/integration/test_mcp_protocol.py
@@ -390,7 +390,7 @@ class TestMCPProtocolIntegration:
 
     async def test_middleware_oauth_token_processing(self):
         """Test UserTokenMiddleware Bearer token extraction and processing.
-        
+
         Note: Bearer tokens are now treated as PAT auth type for compatibility
         with both JWT tokens and traditional PAT tokens.
         """

--- a/tests/integration/test_mcp_protocol.py
+++ b/tests/integration/test_mcp_protocol.py
@@ -389,7 +389,11 @@ class TestMCPProtocolIntegration:
             assert len(tools) == 0
 
     async def test_middleware_oauth_token_processing(self):
-        """Test UserTokenMiddleware OAuth token extraction and processing."""
+        """Test UserTokenMiddleware Bearer token extraction and processing.
+        
+        Note: Bearer tokens are now treated as PAT auth type for compatibility
+        with both JWT tokens and traditional PAT tokens.
+        """
         # Create middleware instance
         app = MagicMock()
         mcp_server = MagicMock()
@@ -410,7 +414,8 @@ class TestMCPProtocolIntegration:
             # Verify request state was set
             assert hasattr(req.state, "user_atlassian_token")
             assert req.state.user_atlassian_token == "test-oauth-token-12345"
-            assert req.state.user_atlassian_auth_type == "oauth"
+            # Bearer tokens are now treated as PAT for compatibility
+            assert req.state.user_atlassian_auth_type == "pat"
             assert req.state.user_atlassian_email is None
             return JSONResponse({"status": "ok"})
 

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -358,7 +358,7 @@ class TestUserTokenMiddleware:
         await middleware(scope, mock_receive, mock_send)
 
         # Verify JWT was detected and token_format is set to 'jwt'
-        assert scope["state"]["user_atlassian_token_format"] == "jwt"
+        assert scope["state"]["user_atlassian_auth_format"] == "jwt"
         assert scope["state"]["user_atlassian_auth_type"] == "pat"
         assert scope["state"]["user_atlassian_token"] == jwt_token
         middleware.app.assert_called_once()
@@ -391,7 +391,7 @@ class TestUserTokenMiddleware:
         await middleware(scope, mock_receive, mock_send)
 
         # Verify non-JWT Bearer token is detected as 'bearer' format
-        assert scope["state"]["user_atlassian_token_format"] == "bearer"
+        assert scope["state"]["user_atlassian_auth_format"] == "bearer"
         assert scope["state"]["user_atlassian_auth_type"] == "pat"
         assert scope["state"]["user_atlassian_token"] == simple_token
         middleware.app.assert_called_once()
@@ -423,7 +423,7 @@ class TestUserTokenMiddleware:
         await middleware(scope, mock_receive, mock_send)
 
         # Verify PAT token is detected as 'pat' format
-        assert scope["state"]["user_atlassian_token_format"] == "pat"
+        assert scope["state"]["user_atlassian_auth_format"] == "pat"
         assert scope["state"]["user_atlassian_auth_type"] == "pat"
         assert scope["state"]["user_atlassian_token"] == pat_token
         middleware.app.assert_called_once()

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -325,3 +325,105 @@ class TestUserTokenMiddleware:
 
         # Should proceed normally with Bitbucket username present
         middleware.app.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_jwt_token_format_detection(self, middleware, monkeypatch):
+        """Test that JWT tokens are correctly detected and set as jwt format."""
+        monkeypatch.delenv("REQUIRE_USERNAME", raising=False)
+
+        # Use a valid JWT-like token (3 base64 parts separated by dots)
+        jwt_token = (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+            "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0."
+            "Gfx6VO9tcxwk6xqx9yYzSfebfeakZp5JYIgP_edcw_A"
+        )
+
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "method": "POST",
+            "headers": [
+                (b"authorization", f"Bearer {jwt_token}".encode()),
+            ],
+            "state": {},
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def mock_send(message):
+            pass
+
+        middleware.app = AsyncMock()
+        await middleware(scope, mock_receive, mock_send)
+
+        # Verify JWT was detected and token_format is set to 'jwt'
+        assert scope["state"]["user_atlassian_token_format"] == "jwt"
+        assert scope["state"]["user_atlassian_auth_type"] == "pat"
+        assert scope["state"]["user_atlassian_token"] == jwt_token
+        middleware.app.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_bearer_non_jwt_token_format_detection(self, middleware, monkeypatch):
+        """Test that non-JWT Bearer tokens are set as bearer format."""
+        monkeypatch.delenv("REQUIRE_USERNAME", raising=False)
+
+        # Use a simple token that is NOT a JWT
+        simple_token = "simple-bearer-token"
+
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "method": "POST",
+            "headers": [
+                (b"authorization", f"Bearer {simple_token}".encode()),
+            ],
+            "state": {},
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def mock_send(message):
+            pass
+
+        middleware.app = AsyncMock()
+        await middleware(scope, mock_receive, mock_send)
+
+        # Verify non-JWT Bearer token is detected as 'bearer' format
+        assert scope["state"]["user_atlassian_token_format"] == "bearer"
+        assert scope["state"]["user_atlassian_auth_type"] == "pat"
+        assert scope["state"]["user_atlassian_token"] == simple_token
+        middleware.app.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_pat_token_format_detection(self, middleware, monkeypatch):
+        """Test that Token (PAT) scheme tokens are set as pat format."""
+        monkeypatch.delenv("REQUIRE_USERNAME", raising=False)
+
+        pat_token = "my-personal-access-token"
+
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "method": "POST",
+            "headers": [
+                (b"authorization", f"Token {pat_token}".encode()),
+            ],
+            "state": {},
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def mock_send(message):
+            pass
+
+        middleware.app = AsyncMock()
+        await middleware(scope, mock_receive, mock_send)
+
+        # Verify PAT token is detected as 'pat' format
+        assert scope["state"]["user_atlassian_token_format"] == "pat"
+        assert scope["state"]["user_atlassian_auth_type"] == "pat"
+        assert scope["state"]["user_atlassian_token"] == pat_token
+        middleware.app.assert_called_once()


### PR DESCRIPTION
Bearer tokens (including JWT tokens) are now treated as PAT (Personal Access Token) auth type instead of OAuth. This allows Bearer tokens to work with servers configured for PAT authentication without requiring a global OAuth configuration.

Previously, Bearer tokens were automatically classified as OAuth, which caused validation failures when no global OAuth config was present.

Additionally, the token format (jwt, bearer, pat) is now detected and displayed in log messages for better debugging and clarity.

Changes:
- Modified UserTokenMiddleware to set auth_type='pat' for Bearer tokens
- Added JWT token detection (3 base64 parts separated by dots)
- Store token_format in request state for logging purposes
- Updated log messages to show token format instead of auth type
- Added unit tests for JWT, bearer, and PAT token format detection
- Updated integration test to reflect new expected behavior

### Use case explainer for allowing bearer JWT tokens

The use case involves an **intermediary application** (e.g., a chatbot, web app, or integration platform) that sits between end users and the MCP server, leveraging the [**Application Link** (Incoming Link)](https://confluence.atlassian.com/applinks/link-atlassian-applications-to-work-together-785449117.html) feature Jira/Confluence Data Center. This intermediary:

1. **Handles OAuth** - Presents the authorization flow to users
2. **Stores credentials** - Persists tokens securely per user
3. **Acts on behalf of users** - Calls the MCP server with user's token

This pattern is ideal for **non-technical users** who shouldn't need to configure MCP or manage tokens directly.

```
┌──────────────┐      ┌─────────────────────┐      ┌─────────────┐      ┌────────────┐
│  End User    │      │   Intermediary      │      │ MCP Server  │      │ Jira/Conf  │
│  (Browser)   │      │ (Chatbot/WebApp)    │      │             │      │    API     │
└──────┬───────┘      └──────────┬──────────┘      └──────┬──────┘      └─────┬──────┘
       │                         │                        │                   │
       │  1. "Connect to Jira"   │                        │                   │
       ├────────────────────────>│                        │                   │
       │                         │                        │                   │
       │  2. OAuth login page    │  (App Link registered) │                   │
       │<────────────────────────┤                        │                   │
       │                         │                        │                   │
       │  3. User authorizes     │                        │                   │
       ├ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─>│                        │                   │
       │                         │                        │                   │
       │                         │  4. Exchange code      │                   │
       │                         │     for JWT token      │                   │
       │                         ├───────────────────────────────────────────>│
       │                         │<───────────────────────────────────────────┤
       │                         │                        │                   │
       │                         │  5. Store JWT          │                   │
       │                         │     (per user)         │                   │
       │                         ├──────┐                 │                   │
       │                         │      │ DB              │                   │
       │                         │<─────┘                 │                   │
       │                         │                        │                   │
       │  6. "List my issues"    │                        │                   │
       ├────────────────────────>│                        │                   │
       │                         │                        │                   │
       │                         │  7. MCP call with      │                   │
       │                         │     Authorization:     │                   │
       │                         │     Bearer <jwt>       │                   │
       │                         ├───────────────────────>│                   │
       │                         │                        │                   │
       │                         │                        │  8. Forward to    │
       │                         │                        │     Jira API      │
       │                         │                        ├──────────────────>│
       │                         │                        │<──────────────────┤
       │                         │<───────────────────────┤                   │
       │                         │                        │                   │
       │  9. "Here are your      │                        │                   │
       │      issues..."         │                        │                   │
       │<────────────────────────┤                        │                   │
```

### The Problem Before This PR

When the MCP server received `Authorization: Bearer <token>`, it classified it as `auth_type: oauth` and expected the **MCP server itself** to have OAuth config (`client_id`, `client_secret`, token refresh, etc.).

But in our architecture, the **intermediary handles OAuth**, not the MCP server. The MCP server just needs to forward the token.

### What This PR Does

This PR allows Bearer tokens to work without OAuth configuration on the MCP server:

1. **No OAuth config required on MCP** - The intermediary owns the OAuth credentials
2. **Token forwarded as-is** - JWT travels in `Authorization: Bearer` header to Jira/Confluence
3. **JWT detection for logging** - Distinguishes JWT (3 base64 parts) from simple tokens