### PR TITLE
feat(gateway-api): Added gateway API implementation

### DIFF
--- a/charts/mcp-atlassian/README.md
+++ b/charts/mcp-atlassian/README.md
@@ -68,6 +68,19 @@ The following table lists the configurable parameters and their default values.
 | `ingress.hosts` | Ingress hosts configuration | `[{host: "mcp-atlassian.local", paths: [{path: "/", pathType: "Prefix"}]}]` |
 | `ingress.tls` | Ingress TLS configuration | `[]` |
 
+### Gateway API Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|--------|
+| `gatewayApi.enabled` | Enable Gateway API HTTPRoute | `false` |
+| `gatewayApi.gatewayName` | Name of the Gateway to attach to | `""` |
+| `gatewayApi.gatewayNamespace` | Namespace of the Gateway (if different) | `""` |
+| `gatewayApi.sectionName` | Listener section name on the Gateway | `""` |
+| `gatewayApi.annotations` | HTTPRoute annotations | `{}` |
+| `gatewayApi.hostnames` | Hostnames to match | `[]` |
+| `gatewayApi.parentRefs` | Override parentRefs entirely | `[]` |
+| `gatewayApi.rules` | Override routing rules entirely | `[]` |
+
 ### High Availability Configuration
 
 | Parameter | Description | Default |
@@ -294,6 +307,19 @@ securityContext:
   capabilities:
     drop:
     - ALL
+```
+
+### Gateway API Deployment
+
+```yaml
+# Use Gateway API instead of Ingress
+# Requires a Gateway API controller and Gateway resource
+gatewayApi:
+  enabled: true
+  gatewayName: my-gateway
+  gatewayNamespace: gateway-system
+  hostnames:
+    - mcp-atlassian.yourdomain.com
 
 resources:
   limits:

--- a/charts/mcp-atlassian/templates/NOTES.txt
+++ b/charts/mcp-atlassian/templates/NOTES.txt
@@ -1,5 +1,15 @@
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
+{{- if .Values.gatewayApi.enabled }}
+  Your HTTPRoute is attached to Gateway "{{ .Values.gatewayApi.gatewayName }}".
+  {{- if .Values.gatewayApi.hostnames }}
+  {{- range .Values.gatewayApi.hostnames }}
+  http://{{ . }}
+  {{- end }}
+  {{- else }}
+  Check your Gateway for the assigned address:
+  kubectl get gateway {{ .Values.gatewayApi.gatewayName }} {{- if .Values.gatewayApi.gatewayNamespace }} -n {{ .Values.gatewayApi.gatewayNamespace }}{{ end }}
+  {{- end }}
+{{- else if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}

--- a/charts/mcp-atlassian/templates/httproute.yaml
+++ b/charts/mcp-atlassian/templates/httproute.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.gatewayApi.enabled -}}
+{{- $fullName := include "mcp-atlassian.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mcp-atlassian.labels" . | nindent 4 }}
+  {{- with .Values.gatewayApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.gatewayApi.gatewayNamespace }}
+  parentRefs:
+    - name: {{ .Values.gatewayApi.gatewayName }}
+      namespace: {{ .Values.gatewayApi.gatewayNamespace }}
+      {{- if .Values.gatewayApi.sectionName }}
+      sectionName: {{ .Values.gatewayApi.sectionName }}
+      {{- end }}
+  {{- else }}
+  parentRefs:
+    - name: {{ .Values.gatewayApi.gatewayName }}
+      {{- if .Values.gatewayApi.sectionName }}
+      sectionName: {{ .Values.gatewayApi.sectionName }}
+      {{- end }}
+  {{- end }}
+  {{- with .Values.gatewayApi.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gatewayApi.rules }}
+    - matches:
+        {{- range .matches }}
+        - path:
+            {{- if .path.type }}
+            type: {{ .path.type }}
+            {{- end }}
+            {{- if .path.value }}
+            value: {{ .path.value }}
+            {{- end }}
+        {{- end }}
+      {{- if $.Values.gatewayApi.filters }}
+      filters:
+        {{- toYaml $.Values.gatewayApi.filters | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.gatewayApi.timeouts }}
+      timeouts:
+        {{- if $.Values.gatewayApi.timeouts.request }}
+        request: {{ $.Values.gatewayApi.timeouts.request }}
+        {{- end }}
+        {{- if $.Values.gatewayApi.timeouts.backendRequest }}
+        backendRequest: {{ $.Values.gatewayApi.timeouts.backendRequest }}
+        {{- end }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/charts/mcp-atlassian/values.yaml
+++ b/charts/mcp-atlassian/values.yaml
@@ -79,6 +79,43 @@ ingress:
   #    hosts:
   #      - mcp-atlassian.local
 
+# Gateway API configuration (replacement for Ingress)
+# Requires a Gateway API controller (e.g., Envoy Gateway, Istio, Cilium) and
+# a Gateway resource to be deployed in the cluster.
+gatewayApi:
+  enabled: false
+  # Name of the Gateway resource to attach to
+  gatewayName: ""
+  # Namespace of the Gateway resource (if different from release namespace)
+  gatewayNamespace: ""
+  # Listener section name on the Gateway (optional)
+  sectionName: ""
+  # Annotations to add to the HTTPRoute
+  annotations: {}
+  # Hostnames to match (optional, defaults to all hostnames on the listener)
+  hostnames: []
+  #  - mcp-atlassian.yourdomain.com
+
+  # Routing rules (required)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+  # Filters to apply to all rules (optional)
+  # filters:
+  #   - type: RequestHeaderModifier
+  #     requestHeaderModifier:
+  #       set:
+  #         - name: X-Custom-Header
+  #           value: custom-value
+
+  # Timeouts for backend requests (optional)
+  # timeouts:
+  #   request: "60s"
+  #   backendRequest: "60s"
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Description

Add Gateway API (HTTPRoute) support to the Helm chart as an alternative to the existing nginx Ingress, which is being deprecated in favor of Gateway API controllers (Envoy Gateway, Istio, Cilium, etc.).

## Changes

- **New template**: `httproute.yaml` — renders a `gateway.networking.k8s.io/v1` HTTPRoute resource with support for `parentRefs`, `hostnames`, `rules`, `filters`, and `timeouts`
- **Updated `values.yaml`**: Added `gatewayApi` section with configurable gateway name, namespace, section name, annotations, hostnames, routing rules, filters, and timeouts
- **Updated `NOTES.txt`**: Displays Gateway API route info when `gatewayApi.enabled` is true
- **Updated `README.md`**: Added Gateway API configuration table and example deployment section
- **Added `xena-values.yaml`**: Example overlay for deploying with Envoy Gateway

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed:
  - `helm lint` passes cleanly
  - `helm template` renders correct HTTPRoute with all combinations: basic, with filters, with timeouts, with/without sectionName and gatewayNamespace
  - Deployed to EKS cluster with Envoy Gateway — HTTPRoute accepted (Accepted: True, ResolvedRefs: True)
  - Verified end-to-end connectivity via HTTPS from both in-cluster and VPN

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).