### PR TITLE
feat(gateway-api): added the backendtrafficpolicy

### DIFF
--- a/charts/mcp-atlassian/README.md
+++ b/charts/mcp-atlassian/README.md
@@ -78,8 +78,15 @@ The following table lists the configurable parameters and their default values.
 | `gatewayApi.sectionName` | Listener section name on the Gateway | `""` |
 | `gatewayApi.annotations` | HTTPRoute annotations | `{}` |
 | `gatewayApi.hostnames` | Hostnames to match | `[]` |
-| `gatewayApi.parentRefs` | Override parentRefs entirely | `[]` |
-| `gatewayApi.rules` | Override routing rules entirely | `[]` |
+| `gatewayApi.rules` | Routing rules | `[{matches: [{path: {type: PathPrefix, value: /}}]}]` |
+| `gatewayApi.filters` | Filters to apply to all rules | `[]` |
+| `gatewayApi.timeouts.request` | Request timeout | `""` |
+| `gatewayApi.timeouts.backendRequest` | Backend request timeout | `""` |
+| `gatewayApi.sessionPersistence.enabled` | Enable sticky sessions (Envoy Gateway BackendTrafficPolicy) | `false` |
+| `gatewayApi.sessionPersistence.type` | Session persistence type: `Header` or `Cookie` | `Header` |
+| `gatewayApi.sessionPersistence.headerName` | Header name for header-based affinity | `x-session-id` |
+| `gatewayApi.sessionPersistence.absoluteTimeout` | Cookie timeout (Cookie type only) | `3600s` |
+| `gatewayApi.sessionPersistence.cookieLifetimeType` | Cookie lifetime: `Permanent` or `Session` | `Permanent` |
 
 ### High Availability Configuration
 
@@ -320,6 +327,11 @@ gatewayApi:
   gatewayNamespace: gateway-system
   hostnames:
     - mcp-atlassian.yourdomain.com
+  # Enable sticky sessions (Envoy Gateway only)
+  sessionPersistence:
+    enabled: true
+    type: Header
+    headerName: x-session-id
 
 resources:
   limits:

--- a/charts/mcp-atlassian/templates/NOTES.txt
+++ b/charts/mcp-atlassian/templates/NOTES.txt
@@ -9,6 +9,9 @@
   Check your Gateway for the assigned address:
   kubectl get gateway {{ .Values.gatewayApi.gatewayName }} {{- if .Values.gatewayApi.gatewayNamespace }} -n {{ .Values.gatewayApi.gatewayNamespace }}{{ end }}
   {{- end }}
+  {{- if .Values.gatewayApi.sessionPersistence.enabled }}
+  Session persistence enabled ({{ .Values.gatewayApi.sessionPersistence.type | default "Header" }}) via BackendTrafficPolicy.
+  {{- end }}
 {{- else if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}

--- a/charts/mcp-atlassian/templates/backendtrafficpolicy.yaml
+++ b/charts/mcp-atlassian/templates/backendtrafficpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.gatewayApi.enabled .Values.gatewayApi.sessionPersistence.enabled -}}
+{{- $fullName := include "mcp-atlassian.fullname" . -}}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mcp-atlassian.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ $fullName }}
+  sessionPersistence:
+    type: {{ .Values.gatewayApi.sessionPersistence.type | default "Header" }}
+    {{- if eq ((.Values.gatewayApi.sessionPersistence.type | default "Header")) "Header" }}
+    header:
+      name: {{ .Values.gatewayApi.sessionPersistence.headerName | default "x-session-id" }}
+    {{- end }}
+    {{- if eq ((.Values.gatewayApi.sessionPersistence.type | default "Header")) "Cookie" }}
+    absoluteTimeout: {{ .Values.gatewayApi.sessionPersistence.absoluteTimeout | default "3600s" }}
+    cookieConfig:
+      lifetimeType: {{ .Values.gatewayApi.sessionPersistence.cookieLifetimeType | default "Permanent" }}
+    {{- end }}
+{{- end }}

--- a/charts/mcp-atlassian/values.yaml
+++ b/charts/mcp-atlassian/values.yaml
@@ -116,6 +116,17 @@ gatewayApi:
   #   request: "60s"
   #   backendRequest: "60s"
 
+  # Session persistence (sticky sessions) via Envoy Gateway BackendTrafficPolicy
+  sessionPersistence:
+    enabled: false
+    # Type: "Header" or "Cookie"
+    type: Header
+    # Header name for header-based session affinity
+    headerName: x-session-id
+    # Cookie settings (only used when type: Cookie)
+    # absoluteTimeout: "3600s"
+    # cookieLifetimeType: Permanent
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Description

Adds session persistence (sticky sessions) support to the Helm chart via Envoy Gateway's `BackendTrafficPolicy` CRD. This enables consistent routing of requests from the same client to the same backend pod, which is important for stateful MCP transport sessions (SSE/streamable-http).

Follows up on #40 (Gateway API implementation).

## Changes

- Added `backendtrafficpolicy.yaml` template that creates an Envoy Gateway `BackendTrafficPolicy` targeting the HTTPRoute
- Supports two session persistence types: `Header` (using a configurable header name) and `Cookie` (with configurable timeout and lifetime)
- Added `sessionPersistence` configuration block to `values.yaml` (disabled by default)
- Updated `NOTES.txt` to display session persistence status on install/upgrade
- Updated `README.md` with session persistence parameters and Gateway API deployment example

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed:
  - `helm lint` passes with 0 failures
  - `helm template` renders correctly for Header type with proper `header.name` field
  - `helm template` renders correctly for Cookie type with `absoluteTimeout` and `cookieConfig.lifetimeType`
  - Template produces no output when `sessionPersistence.enabled: false` (default)
  - Full chart render with all templates works without errors

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).