### PR TITLE
Feature/attachment-tool-read-only-flag-pr-comments-without-pat-start

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,7 @@ repos:
             "--disable-error-code=var-annotated",
             "--disable-error-code=no-untyped-def",
             "--disable-error-code=annotation-unchecked",
+            "--disable-error-code=type-arg",
         ]
         additional_dependencies: [
             'types-beautifulsoup4',

--- a/README.md
+++ b/README.md
@@ -160,12 +160,16 @@ For **Xray for Jira authentication**:
       "X-Atlassian-Confluence-Url": "https://your-confluence-instance.com",
       "X-Atlassian-Bitbucket-Personal-Token": "your_bitbucket_pat_or_app_password",
       "X-Atlassian-Bitbucket-Url": "https://your-bitbucket-instance.com",
-      "X-Atlassian-Read-Only-Mode": "true"
+      "X-Atlassian-Read-Only-Mode": "true",
+      "X-Atlassian-Jira-Read-Only-Mode": "false"
     },
     "type": "http"
   }
 }
 ```
+
+> [!TIP]
+> Per-product headers override the global `X-Atlassian-Read-Only-Mode` header for that product. In the example above the global flag enables read-only for Confluence and Bitbucket, while Jira remains in read/write mode.
 
 > [!TIP]
 > **Multi-Cloud OAuth Support**: If you're building a multi-tenant application where users provide their own OAuth tokens, see the [Multi-Cloud OAuth Support](#multi-cloud-oauth-support) section for minimal configuration setup.
@@ -204,11 +208,13 @@ There are three main approaches to configure the Docker container:
 >
 > - `CONFLUENCE_SPACES_FILTER`: Filter by space keys (e.g., "DEV,TEAM,DOC")
 > - `JIRA_PROJECTS_FILTER`: Filter by project keys (e.g., "PROJ,DEV,SUPPORT")
-> - `READ_ONLY_MODE`: Set to "true" to disable write operations
+> - `READ_ONLY_MODE`: Set to `true` to disable write operations for **all** products
+> - `JIRA_READ_ONLY_MODE`: Set to `true` to disable write operations for Jira only
+> - `CONFLUENCE_READ_ONLY_MODE`: Set to `true` to disable write operations for Confluence only
+> - `BITBUCKET_READ_ONLY_MODE`: Set to `true` to disable write operations for Bitbucket only
 > - `MCP_VERBOSE`: Set to "true" for more detailed logging
 > - `MCP_LOGGING_STDOUT`: Set to "true" to log to stdout instead of stderr
 > - `ENABLED_TOOLS`: Comma-separated list of tool names to enable (e.g., "confluence_search,jira_get_issue")
-> - `MCP_SERVER_BASE_URL`: Base URL used when generating temporary upload/download helper URLs (defaults to `http://localhost:8932`)
 >
 > **Header-Based Authentication** (no environment variables needed):
 > - `X-Atlassian-Jira-Personal-Token`: Jira PAT/API token (passed as HTTP header), used for XRay as well
@@ -217,9 +223,11 @@ There are three main approaches to configure the Docker container:
 > - `X-Atlassian-Confluence-Url`: Confluence instance URL (passed as HTTP header)
 > - `X-Atlassian-Bitbucket-Url`: Bitbucket URL (passed as HTTP header)
 > - `X-Atlassian-Bitbucket-Personal-Token`: Bitbucket PAT token (passed as HTTP header)
-> - `X-Atlassian-Read-Only-Mode`: Per-request read-only mode (passed as HTTP header)
+> - `X-Atlassian-Read-Only-Mode`: Global per-request read-only mode — applies to all products (passed as HTTP header)
+> - `X-Atlassian-Jira-Read-Only-Mode`: Per-request read-only mode for Jira only (passed as HTTP header)
+> - `X-Atlassian-Confluence-Read-Only-Mode`: Per-request read-only mode for Confluence only (passed as HTTP header)
+> - `X-Atlassian-Bitbucket-Read-Only-Mode`: Per-request read-only mode for Bitbucket only (passed as HTTP header)
 > - `X-Atlassian-Enable-Xray`: Enable/disable Xray for Jira tools (disabled by default)
-> - `X-MCP-Upload-Base-URL`: Per-request override for generated upload/download helper URLs
 >
 > See the [.env.example](https://github.com/SharkyND/mcp-atlassian/blob/main/.env.example) file for all available options.
 
@@ -445,6 +453,7 @@ Configure your MCP client to send authentication headers with each request:
     "url": "http://localhost:8000/mcp",
     "headers": {
       "X-Atlassian-Read-Only-Mode": "true",
+      "X-Atlassian-Jira-Read-Only-Mode": "false",
       "X-Atlassian-Jira-Personal-Token": "your_jira_pat_or_api_token",
       "X-Atlassian-Jira-Url": "https://your-jira-instance.com",
       "X-Atlassian-Confluence-Personal-Token": "your_confluence_pat_or_api_token",
@@ -454,6 +463,9 @@ Configure your MCP client to send authentication headers with each request:
   }
 }
 ```
+
+> [!NOTE]
+> In the example above, `X-Atlassian-Read-Only-Mode: true` sets the global default (Confluence and Bitbucket become read-only), but `X-Atlassian-Jira-Read-Only-Mode: false` overrides that for Jira, keeping it in read/write mode.
 
 **Optional Docker Configuration with Read-Only Mode:**
 
@@ -913,95 +925,77 @@ Returns 400 error if missing when enabled.
 
 ## Read-Only Mode
 
-Read-only mode removes all tools tagged with `write` from tool discovery and blocks direct calls to write handlers. Unless configured, the server runs in read/write mode. The effective state is recalculated on every request using this priority:
+Read-only mode removes all tools tagged with `write` from tool discovery and blocks direct calls to write handlers. Unless configured, the server runs in read/write mode.
 
-1. **HTTP header** `X-Atlassian-Read-Only-Mode` &mdash; highest precedence per request. Truthy strings (`true`, `1`, `yes`, `on`) enable read-only; falsy strings (`false`, `0`, `no`, `off`) force read/write even if other controls enabled.
-2. **Environment variable** `READ_ONLY_MODE` &mdash; process-wide default when the header is absent.
-3. **CLI flag** `--read-only` &mdash; fallback applied only when header and env variable are not provided.
+Read-only mode can be controlled **globally** (all products) or **per-product** (Jira, Confluence, Bitbucket independently). The effective state is recalculated on every request using this priority (highest first):
 
-When enabled, write operations are hidden in `tools/list`, and the `@check_write_access` decorator raises `ValueError` if a client tries to invoke one directly.
+| Priority | Scope | Mechanism |
+|---|---|---|
+| 1 | Per-product | HTTP header `X-Atlassian-<Product>-Read-Only-Mode` |
+| 2 | Global | HTTP header `X-Atlassian-Read-Only-Mode` |
+| 3 | Per-product | Environment variable `<PRODUCT>_READ_ONLY_MODE` |
+| 4 | Global | Environment variable `READ_ONLY_MODE` |
+| 5 | Per-product | CLI flag `--<product>-read-only` |
+| 6 | Global | CLI flag `--read-only` |
 
-### Enabling examples
+Truthy values: `true`, `1`, `yes`, `on`. Falsy values: `false`, `0`, `no`, `off`. A falsy value at a higher priority overrides a truthy value at a lower priority.
+
+When enabled for a product, its write tools are hidden in `tools/list`, and the `@check_write_access` decorator raises `ValueError` if a client tries to invoke one directly.
+
+### CLI flags
 
 ```bash
-# CLI flag
+# All products read-only
 uv run mcp-atlassian --transport streamable-http --port 8889 --read-only
+
+# Per-product: only Jira is read-only
+uv run mcp-atlassian --transport streamable-http --port 8889 --jira-read-only
+
+# Combined: Jira and Confluence read-only, Bitbucket stays read/write
+uv run mcp-atlassian --transport streamable-http --port 8889 --jira-read-only --confluence-read-only
 ```
 
+### Environment variables
+
 ```bash
-# Environment variable
-set READ_ONLY_MODE=true            # Windows CMD
-$Env:READ_ONLY_MODE = "true"       # PowerShell
-export READ_ONLY_MODE=true         # macOS/Linux
+# Global — all products
+set READ_ONLY_MODE=true               # Windows CMD
+$Env:READ_ONLY_MODE = "true"          # PowerShell
+export READ_ONLY_MODE=true            # macOS/Linux
+
+# Per-product overrides
+$Env:JIRA_READ_ONLY_MODE = "true"      # Jira only
+$Env:CONFLUENCE_READ_ONLY_MODE = "true" # Confluence only
+$Env:BITBUCKET_READ_ONLY_MODE = "true" # Bitbucket only
+
+# Example: global read-only, but Jira stays read/write
+$Env:READ_ONLY_MODE = "true"
+$Env:JIRA_READ_ONLY_MODE = "false"
 ```
+
+### HTTP headers (per-request)
+
+Headers let you override the server defaults on a per-request basis without restarting.
 
 ```json
 {
   "headers": {
-    "X-Atlassian-Read-Only-Mode": "false"
+    "X-Atlassian-Read-Only-Mode": "true",
+    "X-Atlassian-Jira-Read-Only-Mode": "false",
+    "X-Atlassian-Confluence-Read-Only-Mode": "true",
+    "X-Atlassian-Bitbucket-Read-Only-Mode": "false"
   }
 }
 ```
 
-Use the header to temporarily override server defaults for a single client request without restarting.
+| Header | Scope |
+|---|---|
+| `X-Atlassian-Read-Only-Mode` | All products (global fallback) |
+| `X-Atlassian-Jira-Read-Only-Mode` | Jira only |
+| `X-Atlassian-Confluence-Read-Only-Mode` | Confluence only |
+| `X-Atlassian-Bitbucket-Read-Only-Mode` | Bitbucket only |
 
-## Jira Attachment Helpers
-
-The Jira attachment flow supports server-local downloads, MCP resource access, short-lived HTTP download URLs, and staged uploads from a local client.
-
-### Download Attachments To A Server-Local Directory
-
-Use `jira_download_attachments` with `target_dir` when the files should be written to the machine running the MCP server.
-
-```json
-{
-  "issue_key": "PROJ-123",
-  "target_dir": "/tmp/downloads"
-}
-```
-
-This writes files locally on the server host. It does not create a browser-download URL for a remote client.
-
-### Cache Attachments As MCP Resources
-
-Use `jira_download_attachments` without `target_dir` to cache attachments in memory and expose them as MCP resources.
-
-```json
-{
-  "issue_key": "PROJ-123"
-}
-```
-
-The response includes resource URIs such as `jira://attachments/PROJ-123/report.pdf`, which MCP-aware clients can open directly. Cached attachments expire automatically after 10 minutes.
-
-### Generate A Short-Lived HTTP Download URL
-
-If a client needs a regular HTTP download link instead of an MCP resource URI, first cache the attachment with `jira_download_attachments`, then call `construct_download_endpoint`.
-
-```json
-{
-  "issue_key": "PROJ-123",
-  "filename": "report.pdf",
-  "ttl_minutes": 5
-}
-```
-
-The response includes a temporary URL like `http://localhost:8932/download/<token>`. Important constraints:
-
-- The attachment must already be cached in memory.
-- The generated URL expires automatically.
-- The URL lifetime cannot exceed the cache lifetime.
-- The base URL comes from `X-MCP-Upload-Base-URL` when provided on the request, otherwise `MCP_SERVER_BASE_URL`, otherwise `http://localhost:8932`.
-
-### Upload Local Files To Jira
-
-Client-side upload uses a staged upload flow:
-
-1. Call `construct_upload_endpoint` to get `upload_url` and `session_id`.
-2. `POST` the file bytes to `/upload` with the `Mcp-Session-Id` header.
-3. Pass the returned `upload://...` URIs to `jira_upload_attachment`.
-
-Upload sessions are short-lived and validated server-side before files are accepted.
+A per-product header always takes precedence over the global header for that product. In the example above, the global flag enables read-only for all products, but the Jira and Bitbucket headers override it back to read/write.
 
 ## Tools
 
@@ -1015,11 +1009,6 @@ Upload sessions are short-lived and validated server-side before files are accep
 - `jira_update_issue`: Update an existing issue
 - `jira_transition_issue`: Transition an issue to a new status
 - `jira_add_comment`: Add a comment to an issue
-- `jira_download_attachments`: Download attachments locally or cache them as MCP resources
-- `list_cached_attachments`: List cached Jira attachments and their resource URIs
-- `construct_download_endpoint`: Create a short-lived HTTP download URL for a cached attachment
-- `construct_upload_endpoint`: Create a short-lived upload session and upload URL
-- `jira_upload_attachment`: Upload staged local files to a Jira issue
 
 #### Confluence Tools
 
@@ -1046,6 +1035,7 @@ Upload sessions are short-lived and validated server-side before files are accep
 - `create_branch`: Create a new branch in a repository
 - `add_pull_request_blocker_comment`: Add a blocking comment to a pull request
 - `add_pull_request_comment`: Add a regular comment to a pull request
+- `add_pull_request_inline_comment`: Add an inline comment on a specific line of a file in a pull request
 
 #### Xray Tools
 
@@ -1079,10 +1069,9 @@ Upload sessions are short-lived and validated server-side before files are accep
 |           | `jira_batch_get_changelogs`*  |                                |                                    | `get_tests_with_test_set`         |
 |           | `jira_get_user_profile`       |                                |                                    | `get_tests_with_test_plan`        |
 |           | `jira_download_attachments`   |                                |                                    | `get_test_executions_with_test_plan` |
-|           | `list_cached_attachments`     |                                |                                    | `get_tests_with_test_execution`   |
-|           | `construct_download_endpoint` |                                |                                    | `get_test_run`                    |
-|           | `construct_upload_endpoint`   |                                |                                    | `get_test_run_assignee`           |
 |           | `jira_get_project_versions`   |                                |                                    | `get_tests_with_test_execution`   |
+|           |                               |                                |                                    | `get_test_run`                    |
+|           |                               |                                |                                    | `get_test_run_assignee`           |
 |           |                               |                                |                                    | `get_test_run_iteration`          |
 |           |                               |                                |                                    | `get_test_run_status`             |
 |           |                               |                                |                                    | `get_test_run_defects`            |
@@ -1095,11 +1084,10 @@ Upload sessions are short-lived and validated server-side before files are accep
 |           | `jira_update_issue`           | `confluence_update_page`       | `create_branch`                    | `update_test_step`                |
 |           | `jira_delete_issue`           | `confluence_delete_page`       | `add_pull_request_blocker_comment` | `delete_test_step`                |
 |           | `jira_batch_create_issues`    | `confluence_add_label`         | `add_pull_request_comment`         | `update_precondition`             |
-|           | `jira_add_comment`            | `confluence_add_comment`       |                                    | `delete_test_from_precondition`   |
+|           | `jira_add_comment`            | `confluence_add_comment`       | `add_pull_request_inline_comment`  | `delete_test_from_precondition`   |
 |           | `jira_transition_issue`       |                                |                                    | `update_test_set`                 |
 |           | `jira_add_worklog`            |                                |                                    | `delete_test_from_test_set`       |
 |           | `jira_link_to_epic`           |                                |                                    | `update_test_plan`                |
-|           | `jira_upload_attachment`      |                                |                                    | `delete_test_from_test_plan`      |
 |           | `jira_create_sprint`          |                                |                                    | `delete_test_from_test_plan`      |
 |           | `jira_update_sprint`          |                                |                                    | `update_test_plan_test_executions` |
 |           | `jira_create_issue_link`      |                                |                                    | `delete_test_execution_from_test_plan` |

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ There are three main approaches to configure the Docker container:
 > - `MCP_VERBOSE`: Set to "true" for more detailed logging
 > - `MCP_LOGGING_STDOUT`: Set to "true" to log to stdout instead of stderr
 > - `ENABLED_TOOLS`: Comma-separated list of tool names to enable (e.g., "confluence_search,jira_get_issue")
+> - `MCP_SERVER_BASE_URL`: Base URL used when generating temporary upload/download helper URLs (defaults to `http://localhost:8932`)
 >
 > **Header-Based Authentication** (no environment variables needed):
 > - `X-Atlassian-Jira-Personal-Token`: Jira PAT/API token (passed as HTTP header), used for XRay as well
@@ -218,6 +219,7 @@ There are three main approaches to configure the Docker container:
 > - `X-Atlassian-Bitbucket-Personal-Token`: Bitbucket PAT token (passed as HTTP header)
 > - `X-Atlassian-Read-Only-Mode`: Per-request read-only mode (passed as HTTP header)
 > - `X-Atlassian-Enable-Xray`: Enable/disable Xray for Jira tools (disabled by default)
+> - `X-MCP-Upload-Base-URL`: Per-request override for generated upload/download helper URLs
 >
 > See the [.env.example](https://github.com/SharkyND/mcp-atlassian/blob/main/.env.example) file for all available options.
 
@@ -943,6 +945,64 @@ export READ_ONLY_MODE=true         # macOS/Linux
 
 Use the header to temporarily override server defaults for a single client request without restarting.
 
+## Jira Attachment Helpers
+
+The Jira attachment flow supports server-local downloads, MCP resource access, short-lived HTTP download URLs, and staged uploads from a local client.
+
+### Download Attachments To A Server-Local Directory
+
+Use `jira_download_attachments` with `target_dir` when the files should be written to the machine running the MCP server.
+
+```json
+{
+  "issue_key": "PROJ-123",
+  "target_dir": "/tmp/downloads"
+}
+```
+
+This writes files locally on the server host. It does not create a browser-download URL for a remote client.
+
+### Cache Attachments As MCP Resources
+
+Use `jira_download_attachments` without `target_dir` to cache attachments in memory and expose them as MCP resources.
+
+```json
+{
+  "issue_key": "PROJ-123"
+}
+```
+
+The response includes resource URIs such as `jira://attachments/PROJ-123/report.pdf`, which MCP-aware clients can open directly. Cached attachments expire automatically after 10 minutes.
+
+### Generate A Short-Lived HTTP Download URL
+
+If a client needs a regular HTTP download link instead of an MCP resource URI, first cache the attachment with `jira_download_attachments`, then call `construct_download_endpoint`.
+
+```json
+{
+  "issue_key": "PROJ-123",
+  "filename": "report.pdf",
+  "ttl_minutes": 5
+}
+```
+
+The response includes a temporary URL like `http://localhost:8932/download/<token>`. Important constraints:
+
+- The attachment must already be cached in memory.
+- The generated URL expires automatically.
+- The URL lifetime cannot exceed the cache lifetime.
+- The base URL comes from `X-MCP-Upload-Base-URL` when provided on the request, otherwise `MCP_SERVER_BASE_URL`, otherwise `http://localhost:8932`.
+
+### Upload Local Files To Jira
+
+Client-side upload uses a staged upload flow:
+
+1. Call `construct_upload_endpoint` to get `upload_url` and `session_id`.
+2. `POST` the file bytes to `/upload` with the `Mcp-Session-Id` header.
+3. Pass the returned `upload://...` URIs to `jira_upload_attachment`.
+
+Upload sessions are short-lived and validated server-side before files are accepted.
+
 ## Tools
 
 ### Key Tools
@@ -955,6 +1015,11 @@ Use the header to temporarily override server defaults for a single client reque
 - `jira_update_issue`: Update an existing issue
 - `jira_transition_issue`: Transition an issue to a new status
 - `jira_add_comment`: Add a comment to an issue
+- `jira_download_attachments`: Download attachments locally or cache them as MCP resources
+- `list_cached_attachments`: List cached Jira attachments and their resource URIs
+- `construct_download_endpoint`: Create a short-lived HTTP download URL for a cached attachment
+- `construct_upload_endpoint`: Create a short-lived upload session and upload URL
+- `jira_upload_attachment`: Upload staged local files to a Jira issue
 
 #### Confluence Tools
 
@@ -1014,9 +1079,10 @@ Use the header to temporarily override server defaults for a single client reque
 |           | `jira_batch_get_changelogs`*  |                                |                                    | `get_tests_with_test_set`         |
 |           | `jira_get_user_profile`       |                                |                                    | `get_tests_with_test_plan`        |
 |           | `jira_download_attachments`   |                                |                                    | `get_test_executions_with_test_plan` |
+|           | `list_cached_attachments`     |                                |                                    | `get_tests_with_test_execution`   |
+|           | `construct_download_endpoint` |                                |                                    | `get_test_run`                    |
+|           | `construct_upload_endpoint`   |                                |                                    | `get_test_run_assignee`           |
 |           | `jira_get_project_versions`   |                                |                                    | `get_tests_with_test_execution`   |
-|           |                               |                                |                                    | `get_test_run`                    |
-|           |                               |                                |                                    | `get_test_run_assignee`           |
 |           |                               |                                |                                    | `get_test_run_iteration`          |
 |           |                               |                                |                                    | `get_test_run_status`             |
 |           |                               |                                |                                    | `get_test_run_defects`            |
@@ -1033,6 +1099,7 @@ Use the header to temporarily override server defaults for a single client reque
 |           | `jira_transition_issue`       |                                |                                    | `update_test_set`                 |
 |           | `jira_add_worklog`            |                                |                                    | `delete_test_from_test_set`       |
 |           | `jira_link_to_epic`           |                                |                                    | `update_test_plan`                |
+|           | `jira_upload_attachment`      |                                |                                    | `delete_test_from_test_plan`      |
 |           | `jira_create_sprint`          |                                |                                    | `delete_test_from_test_plan`      |
 |           | `jira_update_sprint`          |                                |                                    | `update_test_plan_test_executions` |
 |           | `jira_create_issue_link`      |                                |                                    | `delete_test_execution_from_test_plan` |

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -110,7 +110,22 @@ logger = setup_logging(logging_level, logging_stream)
 @click.option(
     "--read-only",
     is_flag=True,
-    help="Run in read-only mode (disables all write operations)",
+    help="Run in read-only mode (disables all write operations for all products)",
+)
+@click.option(
+    "--jira-read-only",
+    is_flag=True,
+    help="Run Jira in read-only mode (disables Jira write operations)",
+)
+@click.option(
+    "--confluence-read-only",
+    is_flag=True,
+    help="Run Confluence in read-only mode (disables Confluence write operations)",
+)
+@click.option(
+    "--bitbucket-read-only",
+    is_flag=True,
+    help="Run Bitbucket in read-only mode (disables Bitbucket write operations)",
 )
 @click.option(
     "--enabled-tools",
@@ -162,6 +177,9 @@ def main(
     jira_ssl_verify: bool,
     jira_projects_filter: str | None,
     read_only: bool,
+    jira_read_only: bool,
+    confluence_read_only: bool,
+    bitbucket_read_only: bool,
     enabled_tools: str | None,
     oauth_client_id: str | None,
     oauth_client_secret: str | None,
@@ -267,6 +285,14 @@ def main(
     cli_read_only_value = str(read_only).lower()
     os.environ["CLI_READ_ONLY_MODE"] = cli_read_only_value
 
+    # Per-product CLI read_only flags
+    if jira_read_only:
+        os.environ["CLI_JIRA_READ_ONLY_MODE"] = "true"
+    if confluence_read_only:
+        os.environ["CLI_CONFLUENCE_READ_ONLY_MODE"] = "true"
+    if bitbucket_read_only:
+        os.environ["CLI_BITBUCKET_READ_ONLY_MODE"] = "true"
+
     # Set env vars for downstream config
     if click_ctx and was_option_provided(click_ctx, "enabled_tools"):
         os.environ["ENABLED_TOOLS"] = enabled_tools
@@ -301,6 +327,15 @@ def main(
     if click_ctx and was_option_provided(click_ctx, "read_only"):
         if os.getenv("READ_ONLY_MODE") is None:
             os.environ["READ_ONLY_MODE"] = cli_read_only_value
+    if click_ctx and was_option_provided(click_ctx, "jira_read_only"):
+        if os.getenv("JIRA_READ_ONLY_MODE") is None:
+            os.environ["JIRA_READ_ONLY_MODE"] = str(jira_read_only).lower()
+    if click_ctx and was_option_provided(click_ctx, "confluence_read_only"):
+        if os.getenv("CONFLUENCE_READ_ONLY_MODE") is None:
+            os.environ["CONFLUENCE_READ_ONLY_MODE"] = str(confluence_read_only).lower()
+    if click_ctx and was_option_provided(click_ctx, "bitbucket_read_only"):
+        if os.getenv("BITBUCKET_READ_ONLY_MODE") is None:
+            os.environ["BITBUCKET_READ_ONLY_MODE"] = str(bitbucket_read_only).lower()
     if click_ctx and was_option_provided(click_ctx, "confluence_ssl_verify"):
         os.environ["CONFLUENCE_SSL_VERIFY"] = str(confluence_ssl_verify).lower()
     if click_ctx and was_option_provided(click_ctx, "confluence_spaces_filter"):

--- a/src/mcp_atlassian/bitbucket/client.py
+++ b/src/mcp_atlassian/bitbucket/client.py
@@ -1,5 +1,6 @@
 """Base client module for Bitbucket API interactions."""
 
+import json
 import logging
 from typing import Any
 
@@ -162,5 +163,40 @@ class BitbucketClient:
         except Exception as e:
             logger.error(
                 f"Failed to get pull request comments for {workspace}/{repository}/PR-{pull_request_id}: {e}"
+            )
+            raise
+
+    def get_pull_request_diff(
+        self, workspace: str, repository: str, pull_request_id: int
+    ) -> str:
+        """Get the unified diff for a pull request.
+
+        Args:
+            workspace: Workspace name (Cloud) or project key (Server/DC)
+            repository: Repository name
+            pull_request_id: Pull request ID
+
+        Returns:
+            Unified diff string showing code changes in the PR
+        """
+        try:
+            if self.config.is_cloud:
+                endpoint = f"repositories/{workspace}/{repository}/pullrequests/{pull_request_id}/diff"
+            else:
+                endpoint = f"projects/{workspace}/repos/{repository}/pull-requests/{pull_request_id}/diff"
+
+            response = self.bitbucket.get(endpoint)
+
+            # Cloud returns raw diff text; Server may return a dict with diffs
+            if isinstance(response, str):
+                return response
+            elif isinstance(response, dict):
+                # Server/DC returns structured diff — serialize back to a readable form
+                return json.dumps(response, indent=2)
+            else:
+                return str(response)
+        except Exception as e:
+            logger.error(
+                f"Failed to get diff for PR {pull_request_id} in {workspace}/{repository}: {e}"
             )
             raise

--- a/src/mcp_atlassian/bitbucket/pullrequests.py
+++ b/src/mcp_atlassian/bitbucket/pullrequests.py
@@ -317,6 +317,118 @@ class PullRequestsMixin(BitbucketClient):
             msg = f"Error adding PR comment: {str(e)}"
             raise Exception(msg) from e
 
+    def add_pull_request_inline_comment(
+        self,
+        workspace: str,
+        repository: str,
+        pull_request_id: int,
+        comment: str,
+        file_path: str,
+        line: int,
+        line_type: str = "ADDED",
+    ) -> dict[str, Any]:
+        """
+        Add an inline comment on a specific line of a file in a pull request.
+
+        Args:
+            workspace: Workspace name (Cloud) or project key (Server/DC)
+            repository: Repository name
+            pull_request_id: Pull request ID
+            comment: Comment text
+            file_path: Path to the file being commented on
+            line: Line number to attach the comment to
+            line_type: Line type for Server/DC ('ADDED', 'REMOVED', or 'CONTEXT').
+                       Ignored for Cloud (always targets the destination-side line).
+
+        Returns:
+            Created comment data
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails (401/403)
+        """
+        try:
+            if self.config.is_cloud:
+                endpoint = f"repositories/{workspace}/{repository}/pullrequests/{pull_request_id}/comments"
+                body: dict[str, Any] = {
+                    "content": {"raw": comment},
+                    "inline": {"to": line, "path": file_path},
+                }
+            else:
+                endpoint = f"projects/{workspace}/repos/{repository}/pull-requests/{pull_request_id}/comments"
+                valid_line_types = {"ADDED", "REMOVED", "CONTEXT"}
+                if line_type not in valid_line_types:
+                    line_type = "ADDED"
+
+                file_type = "FROM" if line_type == "REMOVED" else "TO"
+                body = {
+                    "text": comment,
+                    "anchor": {
+                        "diffType": "EFFECTIVE",
+                        "line": line,
+                        "lineType": line_type,
+                        "fileType": file_type,
+                        "path": file_path,
+                    },
+                }
+            return self.bitbucket.post(endpoint, data=body)
+        except HTTPError as http_err:
+            if http_err.response is not None and http_err.response.status_code in [
+                401,
+                403,
+            ]:
+                error_msg = (
+                    f"Authentication failed for Bitbucket API ({http_err.response.status_code}). "
+                    "Token may be expired or invalid. Please verify credentials."
+                )
+                logger.error(error_msg)
+                raise MCPAtlassianAuthenticationError(error_msg) from http_err
+            else:
+                logger.error(f"HTTP error during API call: {http_err}", exc_info=False)
+                raise http_err
+        except Exception as e:
+            error_msg = f"Error adding inline comment to PR {pull_request_id} in {workspace}/{repository}: {str(e)}"
+            logger.error(error_msg)
+            msg = f"Error adding inline PR comment: {str(e)}"
+            raise Exception(msg) from e
+
+    def get_pull_request_diff(
+        self, workspace: str, repository: str, pull_request_id: int
+    ) -> str:
+        """Get the unified diff for a pull request showing all code changes.
+
+        Args:
+            workspace: Workspace name (Cloud) or project key (Server/DC)
+            repository: Repository name
+            pull_request_id: Pull request ID
+
+        Returns:
+            Unified diff string (or structured JSON for Server/DC) showing code changes
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails with the Bitbucket API (401/403)
+        """
+        try:
+            return super().get_pull_request_diff(workspace, repository, pull_request_id)
+        except HTTPError as http_err:
+            if http_err.response is not None and http_err.response.status_code in [
+                401,
+                403,
+            ]:
+                error_msg = (
+                    f"Authentication failed for Bitbucket API ({http_err.response.status_code}). "
+                    "Token may be expired or invalid. Please verify credentials."
+                )
+                logger.error(error_msg)
+                raise MCPAtlassianAuthenticationError(error_msg) from http_err
+            else:
+                logger.error(f"HTTP error during API call: {http_err}", exc_info=False)
+                raise http_err
+        except Exception as e:
+            error_msg = f"Error getting diff for PR {pull_request_id} in {workspace}/{repository}: {str(e)}"
+            logger.error(error_msg)
+            msg = f"Error getting PR diff: {str(e)}"
+            raise Exception(msg) from e
+
     def add_pull_request_blocker_comment(
         self,
         workspace: str,

--- a/src/mcp_atlassian/jira/attachment_cache.py
+++ b/src/mcp_atlassian/jira/attachment_cache.py
@@ -1,0 +1,327 @@
+"""In-memory cache for Jira attachments to expose via MCP resources."""
+
+import hashlib
+import logging
+import secrets
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+logger = logging.getLogger("mcp-jira")
+
+
+def _utcnow() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+class AttachmentCache:
+    """Thread-safe in-memory cache for storing attachment data temporarily."""
+
+    def __init__(self, ttl_minutes: int = 10, max_size_mb: int = 100) -> None:
+        """
+        Initialize the attachment cache.
+
+        Args:
+            ttl_minutes: Time-to-live for cached items in minutes (default: 10)
+            max_size_mb: Maximum total cache size in MB (default: 100)
+        """
+        self._cache: dict[str, dict[str, Any]] = {}
+        self._ttl_minutes = ttl_minutes
+        self._max_size_bytes = max_size_mb * 1024 * 1024
+        self._current_size_bytes = 0
+        self._remove_listeners: list[Callable[[str, str], None]] = []
+        self._download_tokens: dict[str, dict[str, Any]] = {}
+
+    def add_remove_listener(self, listener: Callable[[str, str], None]) -> None:
+        """Register a callback for when the last cached copy of a file is removed."""
+        if listener not in self._remove_listeners:
+            self._remove_listeners.append(listener)
+
+    def _generate_key(self, issue_key: str, filename: str) -> str:
+        """Generate a unique cache key for an attachment."""
+        content = f"{issue_key}:{filename}:{_utcnow().isoformat()}"
+        return hashlib.sha256(content.encode()).hexdigest()[:16]
+
+    def _evict_expired(self) -> None:
+        """Remove expired entries from cache."""
+        now = _utcnow()
+        expired_keys = [
+            key for key, value in self._cache.items() if now > value["expires_at"]
+        ]
+        for key in expired_keys:
+            self._remove(key)
+
+        expired_tokens = [
+            token
+            for token, value in self._download_tokens.items()
+            if now > value["expires_at"]
+        ]
+        for token in expired_tokens:
+            del self._download_tokens[token]
+
+    def _evict_lru(self) -> None:
+        """Remove least recently used entries to free space."""
+        if not self._cache:
+            return
+
+        # Sort by last accessed time
+        sorted_items = sorted(self._cache.items(), key=lambda x: x[1]["last_accessed"])
+
+        # Remove oldest 20% of items
+        to_remove = max(1, len(sorted_items) // 5)
+        for key, _ in sorted_items[:to_remove]:
+            self._remove(key)
+
+    def _remove(self, key: str) -> None:
+        """Remove an item from cache."""
+        if key in self._cache:
+            item = self._cache[key]
+            issue_key = item["issue_key"]
+            filename = item["filename"]
+            self._current_size_bytes -= len(item["content"])
+            del self._cache[key]
+            logger.debug(f"Removed cached attachment: {key}")
+
+            has_remaining_copy = any(
+                cached_item["issue_key"] == issue_key
+                and cached_item["filename"] == filename
+                for cached_item in self._cache.values()
+            )
+            if not has_remaining_copy:
+                self._revoke_download_tokens(issue_key, filename)
+                for listener in self._remove_listeners:
+                    try:
+                        listener(issue_key, filename)
+                    except Exception as exc:
+                        logger.warning(
+                            "Attachment cache remove listener failed for %s/%s: %s",
+                            issue_key,
+                            filename,
+                            exc,
+                        )
+
+    def _get_latest_match(
+        self, issue_key: str, filename: str
+    ) -> tuple[str, dict[str, Any]] | None:
+        """Return the newest cached entry for an issue/filename pair."""
+        self._evict_expired()
+
+        matches = [
+            (key, item)
+            for key, item in self._cache.items()
+            if item["issue_key"] == issue_key and item["filename"] == filename
+        ]
+
+        if not matches:
+            logger.debug(f"Cache miss for issue={issue_key}, filename={filename}")
+            return None
+
+        matches.sort(key=lambda x: x[1]["created_at"], reverse=True)
+        return matches[0]
+
+    def _revoke_download_tokens(self, issue_key: str, filename: str) -> None:
+        """Remove outstanding download tokens for a cached attachment."""
+        matching_tokens = [
+            token
+            for token, value in self._download_tokens.items()
+            if value["issue_key"] == issue_key and value["filename"] == filename
+        ]
+        for token in matching_tokens:
+            del self._download_tokens[token]
+
+    def store(
+        self, issue_key: str, filename: str, content: bytes, mime_type: str
+    ) -> str:
+        """
+        Store attachment content in cache.
+
+        Args:
+            issue_key: The Jira issue key
+            filename: The attachment filename
+            content: The binary content of the attachment
+            mime_type: The MIME type of the attachment
+
+        Returns:
+            The cache key/ID for retrieving the attachment
+        """
+        # Clean up expired entries first
+        self._evict_expired()
+
+        # Check if we need to make space
+        content_size = len(content)
+        while (
+            self._current_size_bytes + content_size > self._max_size_bytes
+            and self._cache
+        ):
+            self._evict_lru()
+
+        # If still too large after eviction, reject
+        if content_size > self._max_size_bytes:
+            logger.error(
+                f"Attachment {filename} is too large ({content_size} bytes) for cache"
+            )
+            raise ValueError(
+                f"Attachment size ({content_size} bytes) exceeds cache limit"
+            )
+
+        # Generate unique key and store
+        cache_key = self._generate_key(issue_key, filename)
+        expires_at = _utcnow() + timedelta(minutes=self._ttl_minutes)
+
+        self._cache[cache_key] = {
+            "issue_key": issue_key,
+            "filename": filename,
+            "content": content,
+            "mime_type": mime_type,
+            "created_at": _utcnow(),
+            "last_accessed": _utcnow(),
+            "expires_at": expires_at,
+            "size": content_size,
+        }
+
+        self._current_size_bytes += content_size
+        logger.info(
+            f"Cached attachment {filename} from {issue_key} (key: {cache_key}, "
+            f"size: {content_size} bytes, cache usage: {self._current_size_bytes}/{self._max_size_bytes})"
+        )
+
+        return cache_key
+
+    def get_by_issue_and_filename(
+        self, issue_key: str, filename: str
+    ) -> dict[str, Any] | None:
+        """
+        Retrieve the most recently cached attachment by issue key and filename.
+
+        Args:
+            issue_key: The Jira issue key
+            filename: The attachment filename
+
+        Returns:
+            Dictionary with 'content', 'mime_type', 'filename', 'issue_key' or None if not found
+        """
+        match = self._get_latest_match(issue_key, filename)
+
+        if not match:
+            return None
+
+        key, item = match
+        item["last_accessed"] = _utcnow()
+
+        logger.debug(
+            f"Cache hit for issue={issue_key}, filename={filename} (key: {key})"
+        )
+        return {
+            "content": item["content"],
+            "mime_type": item["mime_type"],
+            "filename": item["filename"],
+            "issue_key": item["issue_key"],
+        }
+
+    def create_download_token(
+        self, issue_key: str, filename: str, ttl_minutes: int = 5
+    ) -> dict[str, Any]:
+        """Create a short-lived token for downloading a cached attachment over HTTP."""
+        match = self._get_latest_match(issue_key, filename)
+        if not match:
+            raise ValueError(
+                f"Attachment '{filename}' for issue '{issue_key}' is not cached. "
+                "Run jira_download_attachments with return_content=true first."
+            )
+
+        _, item = match
+        requested_expiry = _utcnow() + timedelta(minutes=ttl_minutes)
+        expires_at = min(requested_expiry, item["expires_at"])
+        token = secrets.token_urlsafe(24)
+
+        self._download_tokens[token] = {
+            "issue_key": issue_key,
+            "filename": filename,
+            "expires_at": expires_at,
+        }
+
+        return {
+            "token": token,
+            "expires_at": expires_at,
+            "mime_type": item["mime_type"],
+            "filename": item["filename"],
+            "issue_key": item["issue_key"],
+        }
+
+    def get_by_download_token(self, token: str) -> dict[str, Any] | None:
+        """Resolve a download token to the current cached attachment content."""
+        self._evict_expired()
+        token_data = self._download_tokens.get(token)
+        if not token_data:
+            logger.debug(f"Download token miss: {token}")
+            return None
+
+        attachment = self.get_by_issue_and_filename(
+            token_data["issue_key"], token_data["filename"]
+        )
+        if not attachment:
+            del self._download_tokens[token]
+            return None
+
+        return {
+            **attachment,
+            "expires_at": token_data["expires_at"],
+        }
+
+    def get(self, cache_key: str) -> dict[str, Any] | None:
+        """
+        Retrieve attachment content from cache.
+
+        Args:
+            cache_key: The cache key returned from store()
+
+        Returns:
+            Dictionary with 'content', 'mime_type', 'filename', 'issue_key' or None if not found
+        """
+        self._evict_expired()
+
+        if cache_key not in self._cache:
+            logger.debug(f"Cache miss for key: {cache_key}")
+            return None
+
+        item = self._cache[cache_key]
+        item["last_accessed"] = _utcnow()
+
+        logger.debug(f"Cache hit for key: {cache_key} (file: {item['filename']})")
+        return {
+            "content": item["content"],
+            "mime_type": item["mime_type"],
+            "filename": item["filename"],
+            "issue_key": item["issue_key"],
+        }
+
+    def clear(self) -> None:
+        """Clear all cached attachments."""
+        count = len(self._cache)
+        for key in list(self._cache):
+            self._remove(key)
+        logger.info(f"Cleared attachment cache ({count} items)")
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get cache statistics."""
+        self._evict_expired()
+        return {
+            "item_count": len(self._cache),
+            "total_size_bytes": self._current_size_bytes,
+            "max_size_bytes": self._max_size_bytes,
+            "utilization_percent": round(
+                (self._current_size_bytes / self._max_size_bytes) * 100, 2
+            )
+            if self._max_size_bytes > 0
+            else 0,
+        }
+
+
+# Global cache instance
+_attachment_cache = AttachmentCache()
+
+
+def get_attachment_cache() -> AttachmentCache:
+    """Get the global attachment cache instance."""
+    return _attachment_cache

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -1,11 +1,14 @@
 """Attachment operations for Jira API."""
 
+import io
 import logging
 import os
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from ..models.jira import JiraAttachment
+from .attachment_cache import get_attachment_cache
 from .client import JiraClient
 from .protocols import AttachmentsOperationsProto
 
@@ -66,29 +69,43 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
             return False
 
     def download_issue_attachments(
-        self, issue_key: str, target_dir: str
+        self,
+        issue_key: str,
+        target_dir: str = "",
+        return_content: bool | None = None,
     ) -> dict[str, Any]:
         """
         Download all attachments for a Jira issue.
 
         Args:
             issue_key: The Jira issue key (e.g., 'PROJ-123')
-            target_dir: The directory where attachments should be saved
+            target_dir: The directory where attachments should be saved (optional)
+            return_content: If True, returns MCP resource URIs. Defaults to True
+                when target_dir is omitted and False when target_dir is provided.
 
         Returns:
-            A dictionary with download results
+            A dictionary with download results, including resource URIs if requested
         """
-        # Convert to absolute path if relative
-        if not os.path.isabs(target_dir):
-            target_dir = os.path.abspath(target_dir)
+        # Handle target directory if saving files
+        should_return_content = return_content
+        if should_return_content is None:
+            should_return_content = not bool(target_dir)
 
-        logger.info(
-            f"Downloading attachments for {issue_key} to directory: {target_dir}"
-        )
+        target_path = None
+        if target_dir:
+            # Convert to absolute path if relative
+            if not os.path.isabs(target_dir):
+                target_dir = os.path.abspath(target_dir)
 
-        # Create the target directory if it doesn't exist
-        target_path = Path(target_dir)
-        target_path.mkdir(parents=True, exist_ok=True)
+            logger.info(
+                f"Downloading attachments for {issue_key} to directory: {target_dir}"
+            )
+
+            # Create the target directory if it doesn't exist
+            target_path = Path(target_dir)
+            target_path.mkdir(parents=True, exist_ok=True)
+        else:
+            logger.info(f"Fetching attachments for {issue_key} (content only)")
 
         # Get the issue with attachments
         logger.info(f"Fetching issue {issue_key} with attachments")
@@ -125,6 +142,7 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
         # Download each attachment
         downloaded = []
         failed = []
+        cache = get_attachment_cache()
 
         for attachment in attachments:
             if not attachment.url:
@@ -134,25 +152,107 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
                 )
                 continue
 
-            # Create a safe filename
-            safe_filename = Path(attachment.filename).name
-            file_path = target_path / safe_filename
+            try:
+                # Create a safe filename
+                safe_filename = Path(attachment.filename).name
+                file_path = target_path / safe_filename if target_path else None
 
-            # Download the attachment
-            success = self.download_attachment(attachment.url, str(file_path))
+                attachment_info = {
+                    "filename": attachment.filename,
+                    "size": attachment.size,
+                }
 
-            if success:
-                downloaded.append(
-                    {
-                        "filename": attachment.filename,
-                        "path": str(file_path),
-                        "size": attachment.size,
-                    }
-                )
-            else:
-                failed.append(
-                    {"filename": attachment.filename, "error": "Download failed"}
-                )
+                if target_path and not should_return_content:
+                    if self.download_attachment(attachment.url, str(file_path)):
+                        attachment_info["path"] = str(file_path)
+                        downloaded.append(attachment_info)
+                    else:
+                        failed.append(
+                            {
+                                "filename": attachment.filename,
+                                "error": "Failed to download attachment",
+                            }
+                        )
+                    continue
+
+                response = self.jira._session.get(attachment.url, stream=True)
+                response.raise_for_status()
+
+                content_buffer = bytearray() if should_return_content else None
+                file_handle = open(file_path, "wb") if file_path else None
+                try:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if not chunk:
+                            continue
+                        if file_handle:
+                            file_handle.write(chunk)
+                        if content_buffer is not None:
+                            content_buffer.extend(chunk)
+                finally:
+                    if file_handle:
+                        file_handle.close()
+
+                if file_path:
+                    attachment_info["path"] = str(file_path)
+                    logger.info(f"Saved attachment to {file_path}")
+
+                # Store in cache and return resource URI if requested
+                if should_return_content:
+                    content_bytes = bytes(content_buffer or b"")
+                    try:
+                        # Determine MIME type from attachment or use generic binary
+                        mime_type = (
+                            attachment.content_type or "application/octet-stream"
+                        )
+
+                        # Store in cache
+                        cache_key = cache.store(
+                            issue_key=issue_key,
+                            filename=attachment.filename,
+                            content=content_bytes,
+                            mime_type=mime_type,
+                        )
+
+                        # Static resource URI: issue_key + filename, no cache key needed.
+                        # Becomes immediately accessible in MCP resource browser.
+                        static_resource_uri = (
+                            f"jira://attachments/{issue_key}"
+                            f"/{quote(attachment.filename, safe='')}"
+                        )
+                        # Legacy cache-key URI (kept for backward compatibility)
+                        resource_uri = (
+                            f"jira://attachment/{cache_key}"
+                            f"/{quote(attachment.filename, safe='')}"
+                        )
+                        attachment_info["static_resource_uri"] = static_resource_uri
+                        attachment_info["resource_uri"] = resource_uri
+                        attachment_info["cache_key"] = cache_key
+                        attachment_info["mime_type"] = mime_type
+
+                        logger.info(
+                            f"Cached attachment {attachment.filename} with resource URI: {resource_uri}"
+                        )
+                    except Exception as cache_error:
+                        message = (
+                            f"Failed to cache attachment content for {attachment.filename}: "
+                            f"{cache_error}"
+                        )
+                        logger.warning(message)
+                        if not file_path:
+                            failed.append(
+                                {
+                                    "filename": attachment.filename,
+                                    "error": message,
+                                }
+                            )
+                            continue
+                        attachment_info["resource_error"] = str(cache_error)
+
+                downloaded.append(attachment_info)
+
+            except Exception as e:
+                logger.error(f"Failed to download {attachment.filename}: {str(e)}")
+                failed.append({"filename": attachment.filename, "error": str(e)})
 
         return {
             "success": True,
@@ -224,6 +324,72 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
         except Exception as e:
             error_msg = str(e)
             logger.error(f"Error uploading attachment: {error_msg}")
+            return {"success": False, "error": error_msg}
+
+    def upload_attachment_from_bytes(
+        self,
+        issue_key: str,
+        filename: str,
+        content: bytes,
+        mime_type: str = "application/octet-stream",
+    ) -> dict[str, Any]:
+        """Upload attachment content directly from bytes to a Jira issue.
+
+        Used by the jira_upload_attachment MCP tool, which receives file content
+        from the staging store after the client POSTed files to /upload.
+
+        Args:
+            issue_key: The Jira issue key (e.g., 'PROJ-123').
+            filename: Display name for the attachment in Jira.
+            content: Raw file bytes.
+            mime_type: MIME type (used as the content-type in the multipart upload).
+
+        Returns:
+            A dictionary with upload result information.
+        """
+        if not issue_key:
+            return {"success": False, "error": "No issue key provided"}
+        if not filename:
+            return {"success": False, "error": "No filename provided"}
+        if not content:
+            return {"success": False, "error": "Empty file content"}
+
+        try:
+            logger.info(
+                "Uploading %d bytes as '%s' to issue %s",
+                len(content),
+                filename,
+                issue_key,
+            )
+            buf = io.BytesIO(content)
+            # Setting .name on the BytesIO causes requests to use it as the
+            # filename in the multipart form upload.
+            buf.name = filename
+            attachment = self.jira.add_attachment_object(issue_key, buf)
+            if attachment:
+                logger.info(
+                    "Successfully uploaded '%s' to %s (%d bytes)",
+                    filename,
+                    issue_key,
+                    len(content),
+                )
+                return {
+                    "success": True,
+                    "issue_key": issue_key,
+                    "filename": filename,
+                    "size": len(content),
+                    "id": attachment.get("id")
+                    if isinstance(attachment, dict)
+                    else None,
+                }
+            logger.error("Upload returned empty response for '%s'", filename)
+            return {
+                "success": False,
+                "error": f"Upload returned empty response for '{filename}'",
+            }
+        except Exception as e:
+            error_msg = str(e)
+            logger.error("Error uploading '%s': %s", filename, error_msg)
             return {"success": False, "error": error_msg}
 
     def upload_attachments(

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -178,19 +178,57 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
                 response = self.jira._session.get(attachment.url, stream=True)
                 response.raise_for_status()
 
+                # Enforce a per-file size limit to prevent memory exhaustion.
+                # Use 100 MB as the default cap (matches AttachmentCache default).
+                from .attachment_cache import AttachmentCache
+
+                default_max_download_bytes = 100 * 1024 * 1024
+                if isinstance(cache, AttachmentCache):
+                    max_download_bytes = cache._max_size_bytes
+                else:
+                    max_download_bytes = default_max_download_bytes
                 content_buffer = bytearray() if should_return_content else None
                 file_handle = open(file_path, "wb") if file_path else None
                 try:
+                    bytes_read = 0
                     for chunk in response.iter_content(chunk_size=8192):
                         if not chunk:
                             continue
+                        bytes_read += len(chunk)
+                        if bytes_read > max_download_bytes:
+                            logger.error(
+                                f"Attachment '{attachment.filename}' exceeds "
+                                f"maximum size ({max_download_bytes} bytes), "
+                                f"aborting download"
+                            )
+                            failed.append(
+                                {
+                                    "filename": attachment.filename,
+                                    "error": (
+                                        f"File exceeds maximum allowed size "
+                                        f"({max_download_bytes} bytes)"
+                                    ),
+                                }
+                            )
+                            break
                         if file_handle:
                             file_handle.write(chunk)
                         if content_buffer is not None:
                             content_buffer.extend(chunk)
+                    else:
+                        # Loop completed without break — download succeeded
+                        bytes_read = -1  # sentinel: success
                 finally:
                     if file_handle:
                         file_handle.close()
+                    response.close()
+
+                # If download was aborted due to size, skip to next attachment
+                if bytes_read != -1:
+                    # Clean up partial file if it was written
+                    if file_path and file_path.exists():
+                        file_path.unlink(missing_ok=True)
+                    continue
 
                 if file_path:
                     attachment_info["path"] = str(file_path)

--- a/src/mcp_atlassian/jira/upload_staging.py
+++ b/src/mcp_atlassian/jira/upload_staging.py
@@ -1,0 +1,212 @@
+"""In-memory staging store for client-uploaded files pending Jira attachment.
+
+Files are uploaded by the MCP client to the /upload HTTP endpoint, staged here,
+then consumed by the jira_upload_attachment MCP tool to push them to Jira.
+
+URI scheme: upload://sessions/<session_id>/<file_id>
+"""
+
+import logging
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+logger = logging.getLogger("mcp-jira")
+
+
+def _utcnow() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+_TTL_MINUTES = int(os.environ.get("UPLOAD_STAGING_TTL_MINUTES", "30"))
+_MAX_SIZE_MB = int(os.environ.get("UPLOAD_STAGING_MAX_SIZE_MB", "200"))
+_URI_PREFIX = "upload://sessions/"
+
+
+class UploadStagingStore:
+    """In-memory staging store for files uploaded by MCP clients."""
+
+    def __init__(self, ttl_minutes: int = 30, max_size_mb: int = 200) -> None:
+        # {session_id: {file_id: entry_dict}}
+        self._store: dict[str, dict[str, dict[str, Any]]] = {}
+        self._sessions: dict[str, datetime] = {}
+        self._ttl = timedelta(minutes=ttl_minutes)
+        self._max_size_bytes = max_size_mb * 1024 * 1024
+        self._current_size_bytes = 0
+
+    def create_session(self) -> str:
+        """Generate a new opaque upload session token."""
+        session_id = secrets.token_urlsafe(24)
+        self._sessions[session_id] = _utcnow() + self._ttl
+        return session_id
+
+    def is_valid_session(self, session_id: str) -> bool:
+        """Return True when the session was issued by the server and is unexpired."""
+        self._evict_expired()
+        expires_at = self._sessions.get(session_id)
+        return expires_at is not None and _utcnow() <= expires_at
+
+    def store(
+        self, session_id: str, filename: str, content: bytes, mime_type: str
+    ) -> str:
+        """Stage a file and return its file_id.
+
+        Args:
+            session_id: The upload session token (from construct_upload_endpoint).
+            filename: Original filename (already sanitised by the upload endpoint).
+            content: Raw file bytes.
+            mime_type: MIME type of the file.
+
+        Returns:
+            file_id component of the resulting upload:// URI.
+
+        Raises:
+            PermissionError: If the session was not issued by the server or expired.
+            ValueError: If the file is too large for the staging store.
+        """
+        self._evict_expired()
+
+        if not self.is_valid_session(session_id):
+            raise PermissionError(
+                "Upload session is invalid or expired. "
+                "Call construct_upload_endpoint to create a new session."
+            )
+
+        content_size = len(content)
+        if content_size > self._max_size_bytes:
+            raise ValueError(
+                f"File size ({content_size} bytes) exceeds staging limit "
+                f"({self._max_size_bytes} bytes)"
+            )
+
+        # Evict LRU entries if needed to make room
+        while (
+            self._current_size_bytes + content_size > self._max_size_bytes
+            and self._store
+        ):
+            self._evict_oldest()
+
+        file_id = secrets.token_urlsafe(12)
+        entry: dict[str, Any] = {
+            "filename": filename,
+            "content": content,
+            "mime_type": mime_type,
+            "created_at": _utcnow(),
+            "expires_at": _utcnow() + self._ttl,
+        }
+        self._store.setdefault(session_id, {})[file_id] = entry
+        self._current_size_bytes += content_size
+        logger.debug(
+            "Staged upload '%s' → session=%s file_id=%s (%d bytes)",
+            filename,
+            session_id,
+            file_id,
+            content_size,
+        )
+        return file_id
+
+    def get(self, session_id: str, file_id: str) -> dict[str, Any] | None:
+        """Return a staged entry, or None if not found / expired."""
+        self._evict_expired()
+        entry = self._store.get(session_id, {}).get(file_id)
+        if entry and _utcnow() <= entry["expires_at"]:
+            return entry
+        return None
+
+    def remove(self, session_id: str, file_id: str) -> None:
+        """Remove a staged file (call after successful Jira upload)."""
+        session = self._store.get(session_id, {})
+        if file_id in session:
+            self._current_size_bytes -= len(session[file_id]["content"])
+            del session[file_id]
+            if not session:
+                del self._store[session_id]
+                logger.debug("Removed empty upload session: %s", session_id)
+
+    def clear(self) -> None:
+        """Clear all staged files and issued sessions."""
+        self._store.clear()
+        self._sessions.clear()
+        self._current_size_bytes = 0
+
+    # ------------------------------------------------------------------
+    # URI helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def make_uri(session_id: str, file_id: str) -> str:
+        """Build the canonical upload:// URI for a staged file."""
+        return f"{_URI_PREFIX}{session_id}/{file_id}"
+
+    @staticmethod
+    def parse_uri(uri: str) -> tuple[str, str] | None:
+        """Parse upload://sessions/<session_id>/<file_id> → (session_id, file_id).
+
+        Returns None if the URI does not match the expected format.
+        """
+        if not uri.startswith(_URI_PREFIX):
+            return None
+        rest = uri[len(_URI_PREFIX) :]
+        parts = rest.split("/", 1)
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            return None
+        return parts[0], parts[1]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _evict_expired(self) -> None:
+        now = _utcnow()
+        expired_sessions = [
+            session_id
+            for session_id, expires_at in self._sessions.items()
+            if now > expires_at
+        ]
+        for session_id in expired_sessions:
+            session = self._store.pop(session_id, {})
+            for entry in session.values():
+                self._current_size_bytes -= len(entry["content"])
+            self._sessions.pop(session_id, None)
+
+        for session_id in list(self._store):
+            for file_id in list(self._store[session_id]):
+                if now > self._store[session_id][file_id]["expires_at"]:
+                    self._current_size_bytes -= len(
+                        self._store[session_id][file_id]["content"]
+                    )
+                    del self._store[session_id][file_id]
+            if not self._store.get(session_id):
+                self._store.pop(session_id, None)
+
+    def _evict_oldest(self) -> None:
+        """Remove the globally oldest staged file to free space."""
+        oldest_key: tuple[str, str] | None = None
+        oldest_time: datetime | None = None
+        for session_id, files in self._store.items():
+            for file_id, entry in files.items():
+                if oldest_time is None or entry["created_at"] < oldest_time:
+                    oldest_time = entry["created_at"]
+                    oldest_key = (session_id, file_id)
+        if oldest_key:
+            self.remove(*oldest_key)
+
+
+# ---------------------------------------------------------------------------
+# Singleton accessor
+# ---------------------------------------------------------------------------
+
+_upload_staging: UploadStagingStore | None = None
+
+
+def get_upload_staging() -> UploadStagingStore:
+    """Return the process-wide singleton UploadStagingStore."""
+    global _upload_staging
+    if _upload_staging is None:
+        _upload_staging = UploadStagingStore(
+            ttl_minutes=_TTL_MINUTES,
+            max_size_mb=_MAX_SIZE_MB,
+        )
+    return _upload_staging

--- a/src/mcp_atlassian/jira/upload_staging.py
+++ b/src/mcp_atlassian/jira/upload_staging.py
@@ -20,8 +20,22 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
-_TTL_MINUTES = int(os.environ.get("UPLOAD_STAGING_TTL_MINUTES", "30"))
-_MAX_SIZE_MB = int(os.environ.get("UPLOAD_STAGING_MAX_SIZE_MB", "200"))
+def _safe_int_env(name: str, default: int) -> int:
+    """Parse an integer environment variable with a safe fallback."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        logger.warning(
+            "Invalid value for %s=%r, falling back to default %d", name, raw, default
+        )
+        return default
+
+
+_TTL_MINUTES = _safe_int_env("UPLOAD_STAGING_TTL_MINUTES", 30)
+_MAX_SIZE_MB = _safe_int_env("UPLOAD_STAGING_MAX_SIZE_MB", 200)
 _URI_PREFIX = "upload://sessions/"
 
 

--- a/src/mcp_atlassian/servers/bitbucket.py
+++ b/src/mcp_atlassian/servers/bitbucket.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 from typing import Annotated, Literal
 
 from fastmcp import Context, FastMCP
@@ -1247,8 +1248,11 @@ async def analyze_pr_review_status(
     Raises:
         ValueError: If the Bitbucket client is not configured or available.
     """
-    # Keywords in a reply that signal the author considers the work done
-    _done_keywords = {
+    # Keywords in a reply that signal the author considers the work done.
+    # We use word-boundary regex to avoid false positives from substrings
+    # (e.g. "not fixed yet" matching "fixed", or "undone" matching "done").
+
+    _done_keywords = [
         "done",
         "fixed",
         "addressed",
@@ -1257,15 +1261,32 @@ async def analyze_pr_review_status(
         "completed",
         "applied",
         "changed",
-    }
+    ]
+    # Match keywords only at word boundaries
+    _done_pattern = re.compile(
+        r"\b(" + "|".join(_done_keywords) + r")\b",
+        re.IGNORECASE,
+    )
+    # Negation patterns that invalidate a keyword match
+    _negation_pattern = re.compile(
+        r"\b(not|no|never|hasn't|haven't|hasn't been|not yet|un)\s*"
+        r"(" + "|".join(_done_keywords) + r")\b",
+        re.IGNORECASE,
+    )
 
     def _reply_indicates_done(replies: list[dict]) -> bool:
         for reply in replies:
-            text = ""
             # Cloud uses content.raw; Server uses text
             content = reply.get("content") or {}
-            text = (content.get("raw") or reply.get("text") or "").lower()
-            if any(kw in text for kw in _done_keywords):
+            text = (content.get("raw") or reply.get("text") or "").strip()
+            if not text:
+                continue
+            # Reject if the reply is clearly a negation
+            lower_text = text.lower()
+            if lower_text.startswith(("not ", "no,", "no ", "hasn't", "haven't")):
+                continue
+            # Check for positive keyword match without negation
+            if _done_pattern.search(text) and not _negation_pattern.search(text):
                 return True
         return False
 

--- a/src/mcp_atlassian/servers/bitbucket.py
+++ b/src/mcp_atlassian/servers/bitbucket.py
@@ -1078,3 +1078,360 @@ async def add_pull_request_comment(
             log_level, f"bitbucket_add_pull_request_comment failed: {error_message}"
         )
         return json.dumps(error_result, indent=2)
+
+
+@bitbucket_mcp.tool(tags={"bitbucket", "write"})
+@check_write_access
+async def add_pull_request_inline_comment(
+    ctx: Context,
+    workspace: Annotated[
+        str,
+        Field(description="Workspace name (Cloud) or project key (Server/DC)"),
+    ],
+    repository: Annotated[
+        str,
+        Field(description="Repository name"),
+    ],
+    pull_request_id: Annotated[
+        int,
+        Field(description="Pull request ID"),
+    ],
+    comment: Annotated[
+        str,
+        Field(description="Comment text"),
+    ],
+    file_path: Annotated[
+        str,
+        Field(description="Path to the file being commented on (e.g. 'src/main.py')"),
+    ],
+    line: Annotated[
+        int,
+        Field(description="Line number in the file to attach the comment to", ge=1),
+    ],
+    line_type: Annotated[
+        Literal["ADDED", "REMOVED", "CONTEXT"],
+        Field(
+            description=(
+                "Type of the line being commented on. Only used for Bitbucket Server/DC. "
+                "'ADDED' for new lines, 'REMOVED' for deleted lines, 'CONTEXT' for unchanged lines."
+            ),
+            default="ADDED",
+        ),
+    ] = "ADDED",
+) -> str:
+    """
+    Add an inline comment on a specific line of a file in a pull request.
+
+    Args:
+        workspace: Workspace name or project key.
+        repository: Repository name.
+        pull_request_id: Pull request ID.
+        comment: Comment text.
+        file_path: Path to the file to comment on.
+        line: Line number to attach the comment to.
+        line_type: Line type for Server/DC ('ADDED', 'REMOVED', or 'CONTEXT').
+
+    Returns:
+        JSON string containing the created comment details.
+
+    Raises:
+        ValueError: If the Bitbucket client is not configured or available.
+    """
+    try:
+        bitbucket = await get_bitbucket_fetcher(ctx)
+
+        result = bitbucket.add_pull_request_inline_comment(
+            workspace, repository, pull_request_id, comment, file_path, line, line_type
+        )
+
+        inline_info = result.get("inline") if isinstance(result, dict) else None
+        anchor_info = result.get("anchor") if isinstance(result, dict) else None
+        resolved_path = None
+        resolved_line = None
+
+        if isinstance(inline_info, dict):
+            resolved_path = inline_info.get("path")
+            resolved_line = inline_info.get("to") or inline_info.get("from")
+        elif isinstance(anchor_info, dict):
+            resolved_path = anchor_info.get("path")
+            resolved_line = anchor_info.get("line")
+
+        response_payload = {
+            "success": True,
+            "comment": result,
+            "pull_request_id": pull_request_id,
+            "requested_file_path": file_path,
+            "requested_line": line,
+            "anchored": resolved_line is not None,
+            "file_path": resolved_path,
+            "line": resolved_line,
+        }
+
+        if resolved_line is None:
+            response_payload["warning"] = (
+                "Bitbucket accepted the comment but did not return a line anchor. "
+                "This usually means the supplied path/line did not match the PR diff "
+                "or the API created a general PR comment instead."
+            )
+
+        return json.dumps(
+            response_payload,
+            indent=2,
+        )
+    except Exception as e:
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            error_message = f"Configuration Error: {str(e)}"
+        else:
+            error_message = f"An unexpected error occurred while adding inline comment to PR {pull_request_id} in {workspace}/{repository}."
+            logger.exception(
+                "Unexpected error in bitbucket_add_pull_request_inline_comment:"
+            )
+
+        error_result = {
+            "success": False,
+            "error": error_message,
+        }
+        logger.log(
+            log_level,
+            f"bitbucket_add_pull_request_inline_comment failed: {error_message}",
+        )
+        return json.dumps(error_result, indent=2)
+
+
+@bitbucket_mcp.tool(tags={"bitbucket", "read"})
+async def analyze_pr_review_status(
+    ctx: Context,
+    workspace: Annotated[
+        str,
+        Field(description="Workspace name (Cloud) or project key (Server/DC)"),
+    ],
+    repository: Annotated[
+        str,
+        Field(description="Repository name"),
+    ],
+    pull_request_id: Annotated[
+        int,
+        Field(description="Pull request ID to analyze"),
+    ],
+) -> str:
+    """
+    Analyze a pull request's comment threads to determine which review feedback
+    has been addressed and which is still pending.
+
+    For each comment thread the tool inspects:
+    - Whether the comment is explicitly resolved/marked done (Server/DC ``state`` field,
+      Cloud ``resolved`` flag).
+    - Replies in the thread — if a reply contains completion keywords
+      ("done", "fixed", "addressed", "resolved", "updated", "completed") it is
+      considered addressed even when no formal resolve action was taken.
+
+    Returns a structured summary with:
+    - ``total_comments``: number of top-level review comments found
+    - ``addressed``: list of comments considered done (resolved or positively replied)
+    - ``pending``: list of comments that still need attention
+    - ``overall_status``: "ALL_ADDRESSED" | "PARTIALLY_ADDRESSED" | "NONE_ADDRESSED"
+
+    Args:
+        workspace: Workspace name or project key.
+        repository: Repository name.
+        pull_request_id: Pull request ID.
+
+    Returns:
+        JSON string with the review status analysis.
+
+    Raises:
+        ValueError: If the Bitbucket client is not configured or available.
+    """
+    # Keywords in a reply that signal the author considers the work done
+    _done_keywords = {
+        "done",
+        "fixed",
+        "addressed",
+        "resolved",
+        "updated",
+        "completed",
+        "applied",
+        "changed",
+    }
+
+    def _reply_indicates_done(replies: list[dict]) -> bool:
+        for reply in replies:
+            text = ""
+            # Cloud uses content.raw; Server uses text
+            content = reply.get("content") or {}
+            text = (content.get("raw") or reply.get("text") or "").lower()
+            if any(kw in text for kw in _done_keywords):
+                return True
+        return False
+
+    def _is_comment_addressed(activity: dict) -> bool:
+        """Return True if an activity's comment is considered addressed."""
+        comment = activity.get("comment") or activity
+        # Explicit resolve: Server/DC sets state="RESOLVED"; Cloud sets resolved=True
+        if comment.get("state") == "RESOLVED":
+            return True
+        if comment.get("resolved") is True:
+            return True
+        # Check replies
+        replies = comment.get("comments") or []  # Server nests as 'comments'
+        if replies:
+            return _reply_indicates_done(replies)
+        return False
+
+    def _summarise_comment(activity: dict) -> dict:
+        comment = activity.get("comment") or activity
+        content = comment.get("content") or {}
+        text = content.get("raw") or comment.get("text") or "(no text)"
+        author_info = comment.get("author") or {}
+        return {
+            "id": comment.get("id"),
+            "author": author_info.get("display_name")
+            or author_info.get("displayName")
+            or author_info.get("name")
+            or "unknown",
+            "text": text[:300],  # truncate for readability
+            "created_on": comment.get("created_on") or comment.get("createdDate"),
+            "state": comment.get("state")
+            or ("resolved" if comment.get("resolved") else "open"),
+            "reply_count": len(comment.get("comments") or []),
+        }
+
+    try:
+        bitbucket = await get_bitbucket_fetcher(ctx)
+        activities = bitbucket.get_pull_request_activities(
+            workspace, repository, pull_request_id
+        )
+
+        addressed = []
+        pending = []
+
+        for activity in activities:
+            # Filter to comment activities only
+            event = activity.get("action") or activity.get("event") or ""
+            has_comment = "comment" in activity or event.upper() in (
+                "COMMENTED",
+                "COMMENT",
+            )
+            if not has_comment:
+                continue
+
+            summary = _summarise_comment(activity)
+            if _is_comment_addressed(activity):
+                addressed.append(summary)
+            else:
+                pending.append(summary)
+
+        total = len(addressed) + len(pending)
+        if total == 0:
+            overall_status = "NO_COMMENTS"
+        elif len(pending) == 0:
+            overall_status = "ALL_ADDRESSED"
+        elif len(addressed) == 0:
+            overall_status = "NONE_ADDRESSED"
+        else:
+            overall_status = "PARTIALLY_ADDRESSED"
+
+        result = {
+            "pull_request_id": pull_request_id,
+            "workspace": workspace,
+            "repository": repository,
+            "total_comments": total,
+            "addressed_count": len(addressed),
+            "pending_count": len(pending),
+            "overall_status": overall_status,
+            "addressed": addressed,
+            "pending": pending,
+        }
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            error_message = f"Configuration Error: {str(e)}"
+        else:
+            error_message = f"An unexpected error occurred while analyzing review status for PR {pull_request_id} in {workspace}/{repository}."
+            logger.exception("Unexpected error in bitbucket_analyze_pr_review_status:")
+
+        error_result = {"success": False, "error": error_message}
+        logger.log(
+            log_level, f"bitbucket_analyze_pr_review_status failed: {error_message}"
+        )
+        return json.dumps(error_result, indent=2)
+
+
+@bitbucket_mcp.tool(tags={"bitbucket", "read"})
+async def get_pull_request_diff(
+    ctx: Context,
+    workspace: Annotated[
+        str,
+        Field(description="Workspace name (Cloud) or project key (Server/DC)"),
+    ],
+    repository: Annotated[
+        str,
+        Field(description="Repository name"),
+    ],
+    pull_request_id: Annotated[
+        int,
+        Field(description="Pull request ID"),
+    ],
+) -> str:
+    """
+    Get the full code diff (all changed files and lines) for a pull request.
+
+    Returns the unified diff of all changes included in the PR so you can
+    review exactly what new code was added, modified, or removed.
+
+    For Bitbucket Cloud the response is a raw unified diff string.
+    For Bitbucket Server/DC the response is structured JSON containing per-file
+    diff hunks.
+
+    Args:
+        workspace: Workspace name or project key.
+        repository: Repository name.
+        pull_request_id: Pull request ID.
+
+    Returns:
+        JSON string wrapping the diff content and metadata.
+
+    Raises:
+        ValueError: If the Bitbucket client is not configured or available.
+    """
+    try:
+        bitbucket = await get_bitbucket_fetcher(ctx)
+        diff_content = bitbucket.get_pull_request_diff(
+            workspace, repository, pull_request_id
+        )
+        return json.dumps(
+            {
+                "pull_request_id": pull_request_id,
+                "workspace": workspace,
+                "repository": repository,
+                "diff": diff_content,
+            },
+            indent=2,
+        )
+    except Exception as e:
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            error_message = f"Configuration Error: {str(e)}"
+        else:
+            error_message = f"An unexpected error occurred while fetching diff for PR {pull_request_id} in {workspace}/{repository}."
+            logger.exception("Unexpected error in bitbucket_get_pull_request_diff:")
+
+        error_result = {"success": False, "error": error_message}
+        logger.log(
+            log_level, f"bitbucket_get_pull_request_diff failed: {error_message}"
+        )
+        return json.dumps(error_result, indent=2)

--- a/src/mcp_atlassian/servers/context.py
+++ b/src/mcp_atlassian/servers/context.py
@@ -27,3 +27,10 @@ class MainAppContext:
     cli_read_only: bool | None = None
     env_read_only: bool | None = None
     enabled_tools: list[str] | None = None
+
+    # Per-product read_only overrides. When set, these take precedence over
+    # the global read_only flag for the corresponding product. When None the
+    # global flag applies.
+    jira_read_only: bool | None = None
+    confluence_read_only: bool | None = None
+    bitbucket_read_only: bool | None = None

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2,14 +2,19 @@
 
 import json
 import logging
+import mimetypes
 from typing import Annotated, Any
+from urllib.parse import quote, unquote
 
 from fastmcp import Context, FastMCP
+from fastmcp.resources import FunctionResource
 from pydantic import Field
 from requests.exceptions import HTTPError
 
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira.attachment_cache import get_attachment_cache
 from mcp_atlassian.jira.constants import DEFAULT_READ_JIRA_FIELDS
+from mcp_atlassian.jira.upload_staging import get_upload_staging
 from mcp_atlassian.models.jira.common import JiraUser
 from mcp_atlassian.servers.dependencies import get_jira_fetcher
 from mcp_atlassian.utils.decorators import check_write_access
@@ -19,6 +24,26 @@ logger = logging.getLogger(__name__)
 jira_mcp = FastMCP(
     name="Jira MCP Service",
 )
+
+
+def _get_external_base_url() -> str:
+    """Resolve the external base URL used for upload/download helper endpoints."""
+    import os
+
+    from fastmcp.server.dependencies import get_http_request
+
+    base_url: str | None = None
+    try:
+        http_request = get_http_request()
+        candidate = getattr(http_request.state, "upload_base_url", None)
+        if isinstance(candidate, str):
+            base_url = candidate.strip()
+    except Exception as exc:
+        logger.debug("Jira endpoint base URL unavailable from request state: %s", exc)
+
+    if not base_url:
+        base_url = os.environ.get("MCP_SERVER_BASE_URL", "http://localhost:8932")
+    return base_url.rstrip("/")
 
 
 @jira_mcp.tool(tags={"jira", "read"})
@@ -360,21 +385,74 @@ async def download_attachments(
     ctx: Context,
     issue_key: Annotated[str, Field(description="Jira issue key (e.g., 'PROJ-123')")],
     target_dir: Annotated[
-        str, Field(description="Directory where attachments should be saved")
-    ],
+        str | None,
+        Field(
+            description=(
+                "(Optional) Directory where attachments should be saved on the server. "
+                "Preserves the legacy jira_download_attachments behavior."
+            )
+        ),
+    ] = None,
+    return_content: Annotated[
+        bool | None,
+        Field(
+            description=(
+                "(Optional) Cache attachments as MCP resources. Defaults to true when "
+                "target_dir is omitted and false when target_dir is provided."
+            )
+        ),
+    ] = None,
 ) -> str:
-    """Download attachments from a Jira issue.
+    """Download attachments from a Jira issue to disk, MCP resources, or both.
+
+    When resource caching is enabled, each attachment is immediately available in the MCP
+    resource browser via a static URI — no cache key required:
+
+        jira://attachments/{issue_key}/{filename}
+
+    Examples:
+        jira://attachments/JDQU-2322/desktop-screenshot-1.png   ← renders as image
+        jira://attachments/JDQU-2322/SPyDR%20Metadata.txt       ← opens as text
+
+    Cached resources are valid for 10 minutes. Re-run this tool to refresh.
 
     Args:
         ctx: The FastMCP context.
-        issue_key: Jira issue key.
-        target_dir: Directory to save attachments.
+        issue_key: Jira issue key (e.g., 'PROJ-123').
+        target_dir: Optional server-side save path for downloaded files.
+        return_content: Optional flag to cache attachments as MCP resources.
 
     Returns:
-        JSON string indicating the result of the download operation.
+        JSON string with download results. Attachments may include:
+        - filename: The attachment filename
+        - size: File size in bytes
+        - path: Server-side download path when target_dir is provided
+        - static_resource_uri: Direct MCP resource URI when return_content is enabled
+        - mime_type: MIME type of the file when return_content is enabled
     """
+    should_return_content = return_content
+    if should_return_content is None:
+        should_return_content = not bool(target_dir)
+
+    if not target_dir and not should_return_content:
+        raise ValueError(
+            "Either target_dir must be provided or return_content must be true."
+        )
+
     jira = await get_jira_fetcher(ctx)
-    result = jira.download_issue_attachments(issue_key=issue_key, target_dir=target_dir)
+    result = jira.download_issue_attachments(
+        issue_key=issue_key,
+        target_dir=target_dir or "",
+        return_content=should_return_content,
+    )
+    if should_return_content:
+        # Dynamically register a concrete static MCP resource URI for every
+        # downloaded attachment so they appear as direct clickable links in the
+        # VS Code MCP resource browser — no manual input required.
+        for item in result.get("downloaded", []):
+            filename = item.get("filename")
+            if filename:
+                _register_static_attachment_resource(issue_key, filename)
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 
@@ -1655,3 +1733,576 @@ async def batch_create_versions(
             )
             results.append({"success": False, "error": str(e), "input": v})
     return json.dumps(results, indent=2, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# MCP Resource helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_attachment_resource_uri(issue_key: str, filename: str) -> str:
+    """Build the static attachment resource URI for an issue/filename pair."""
+    return f"jira://attachments/{issue_key}/{quote(filename, safe='')}"
+
+
+def _deregister_static_attachment_resource(issue_key: str, filename: str) -> None:
+    """Remove a static attachment resource when its cached content expires."""
+    uri = _make_attachment_resource_uri(issue_key, filename)
+    rm = jira_mcp._resource_manager  # type: ignore[attr-defined]
+    try:
+        if rm._resources.pop(uri, None) is not None:
+            logger.info(f"Deregistered static MCP resource: {uri}")
+    except Exception as exc:
+        logger.warning(f"Could not deregister resource {uri}: {exc}")
+
+
+def _register_static_attachment_resource(issue_key: str, filename: str) -> None:
+    """Dynamically register a concrete (non-template) MCP resource URI.
+
+    Calling ``jira_mcp.add_resource_fn()`` at runtime creates a static entry in
+    the MCP resource list, which VS Code shows as a direct clickable link — no
+    manual text input required by the user.
+
+    The registered function checks the live cache, so it returns a clear error
+    if the 10-minute TTL has expired rather than silently returning stale data.
+    Calling ``download_attachments`` again re-registers and refreshes the cache.
+    """
+    uri = _make_attachment_resource_uri(issue_key, filename)
+
+    # Capture loop variables via default arguments to avoid late-binding closure
+    # issues when iterating over multiple attachments.
+    def _resource_fn(
+        _ik: str = issue_key,
+        _fn: str = filename,
+    ) -> bytes:
+        data = get_attachment_cache().get_by_issue_and_filename(_ik, _fn)
+        if not data:
+            raise ValueError(
+                f"Attachment '{_fn}' for issue '{_ik}' has expired (10-min TTL). "
+                "Re-run download_attachments to refresh."
+            )
+        return data["content"]
+
+    # Detect MIME type from filename extension (e.g. image/png for .png)
+    mime_type, _ = mimetypes.guess_type(filename)
+    mime_type = mime_type or "application/octet-stream"
+
+    resource = FunctionResource.from_function(
+        _resource_fn,
+        uri=uri,
+        name=f"{issue_key} — {filename}",
+        description=f"Jira attachment '{filename}' from issue {issue_key}",
+        mime_type=mime_type,
+    )
+
+    rm = jira_mcp._resource_manager  # type: ignore[attr-defined]
+    try:
+        # Remove any stale entry for this URI before re-registering
+        # (e.g. after a cache refresh / re-download).
+        rm._resources.pop(uri, None)
+        rm.add_resource(resource)
+        logger.info(f"Registered static MCP resource: {uri} ({mime_type})")
+    except Exception as exc:
+        logger.warning(f"Could not register resource {uri}: {exc}")
+
+
+get_attachment_cache().add_remove_listener(_deregister_static_attachment_resource)
+
+
+# ---------------------------------------------------------------------------
+# MCP Resource handlers for Jira attachments
+# ---------------------------------------------------------------------------
+
+
+@jira_mcp.resource("jira://attachments/{issue_key}/{filename}")
+def get_attachment_by_issue_resource(issue_key: str, filename: str) -> bytes:
+    """
+    Serve a cached Jira attachment directly by issue key and filename.
+
+    These static URIs are auto-generated when download_attachments is called and
+    are valid for 10 minutes.  No cache key is required — just use the issue key
+    and the original filename (URL-encoded).
+
+    Example URIs (rendered automatically in VS Code / MCP clients):
+        jira://attachments/JDQU-2322/desktop-screenshot-1.png
+        jira://attachments/JDQU-2322/SPyDR%20Metadata.txt
+
+    Args:
+        issue_key: The Jira issue key (e.g., 'JDQU-2322')
+        filename: URL-encoded attachment filename (e.g., 'desktop-screenshot-1.png')
+
+    Returns:
+        Raw binary content — images render inline in MCP clients that support it.
+
+    Raises:
+        ValueError: If no matching entry is found or it has expired (10-min TTL).
+    """
+    cache = get_attachment_cache()
+    # Strip query-string params that some MCP clients (e.g. VS Code) append
+    # for cache-busting (e.g. ?version=1234567890).
+    actual_filename = unquote(filename).split("?")[0]
+    attachment_data = cache.get_by_issue_and_filename(issue_key, actual_filename)
+
+    if not attachment_data:
+        logger.warning(
+            f"Attachment not found for issue={issue_key}, filename={actual_filename}"
+        )
+        raise ValueError(
+            f"Attachment '{actual_filename}' for issue '{issue_key}' not found. "
+            "It may have expired (10-minute TTL). Re-run download_attachments to refresh."
+        )
+
+    logger.info(f"Serving static resource: jira://attachments/{issue_key}/{filename}")
+    return attachment_data["content"]
+
+
+@jira_mcp.resource("jira://attachment/{cache_key}/{filename}")
+def get_attachment_resource(cache_key: str, filename: str) -> bytes:
+    """
+    Serve cached Jira attachment content via legacy cache-key URI.
+
+    Prefer jira://attachments/{issue_key}/{filename} for direct access.
+    This handler is kept for backward compatibility.
+
+    Args:
+        cache_key: The unique cache identifier returned from download_attachments tool
+        filename: URL-encoded attachment filename (with extension)
+
+    Returns:
+        Raw binary content of the attachment.
+
+    Raises:
+        ValueError: If the cache key is not found or has expired
+    """
+    cache = get_attachment_cache()
+    attachment_data = cache.get(cache_key)
+
+    if not attachment_data:
+        logger.warning(f"Attachment not found in cache: {cache_key}")
+        raise ValueError(
+            f"Attachment not found. Cache key '{cache_key}' may have expired or is invalid."
+        )
+
+    # Strip any query-string params appended by MCP clients for cache-busting.
+    actual_filename = unquote(filename).split("?")[0]
+    logger.info(
+        f"Serving attachment resource: {actual_filename} "
+        f"from issue {attachment_data['issue_key']} (key: {cache_key})"
+    )
+    return attachment_data["content"]
+
+
+@jira_mcp.tool(tags={"jira", "utility"})
+async def save_attachment_to_disk(
+    ctx: Context,
+    cache_key: Annotated[
+        str,
+        Field(description="The cache key from download_attachments response"),
+    ],
+    target_path: Annotated[
+        str,
+        Field(
+            description="Full path on MCP SERVER filesystem (e.g., '/tmp/file.pdf' or 'C:/server/downloads/file.pdf')"
+        ),
+    ],
+) -> str:
+    """Save a cached attachment to the MCP SERVER's filesystem.
+
+    ⚠️ WARNING: This saves to the SERVER's filesystem, NOT your local client machine!
+
+    Use cases:
+    - MCP server is running locally on your machine
+    - Need to save files on a remote server for server-side processing
+    - Saving to a shared network location accessible from server
+
+    For CLIENT-SIDE saving (your local VS Code machine):
+    - Use the resource URI from download_attachments response
+    - Your MCP client (VS Code) will fetch and save it locally
+
+    Args:
+        ctx: The FastMCP context.
+        cache_key: The cache_key returned from download_attachments tool
+        target_path: Full file path on SERVER filesystem (not client's local disk)
+
+    Returns:
+        JSON string with save result including absolute path on server
+
+    Example:
+        # This saves to SERVER filesystem, not your local machine!
+        save_attachment_to_disk(
+            cache_key="abc123def456",
+            target_path="/server/storage/design.pdf"
+        )
+    """
+    from pathlib import Path
+
+    cache = get_attachment_cache()
+    attachment_data = cache.get(cache_key)
+
+    if not attachment_data:
+        return json.dumps(
+            {
+                "success": False,
+                "error": f"Attachment not found in cache. Cache key '{cache_key}' may have expired or is invalid.",
+            },
+            indent=2,
+        )
+
+    try:
+        # Ensure parent directory exists
+        target_file = Path(target_path)
+        target_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write file
+        with open(target_file, "wb") as f:
+            f.write(attachment_data["content"])
+
+        file_size = len(attachment_data["content"])
+        logger.info(
+            f"Saved attachment {attachment_data['filename']} to {target_path} "
+            f"({file_size} bytes)"
+        )
+
+        return json.dumps(
+            {
+                "success": True,
+                "filename": attachment_data["filename"],
+                "saved_to": str(target_file.absolute()),
+                "size_bytes": file_size,
+                "issue_key": attachment_data["issue_key"],
+            },
+            indent=2,
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to save attachment: {str(e)}")
+        return json.dumps(
+            {"success": False, "error": str(e)},
+            indent=2,
+        )
+
+
+@jira_mcp.tool(tags={"jira", "utility"})
+async def list_cached_attachments(ctx: Context) -> str:
+    """List all currently cached attachments available via MCP resources.
+
+    Each attachment exposes a static_resource_uri that can be opened directly in
+    the MCP resource browser without knowing the cache key:
+
+        jira://attachments/{issue_key}/{filename}
+
+    Images (PNG, JPEG, etc.) render inline. Text files open as-is.
+    All cached resources expire after 10 minutes.
+
+    Returns:
+        JSON string with list of cached attachments including URIs and metadata
+    """
+    cache = get_attachment_cache()
+    stats = cache.get_stats()
+
+    cached_items = []
+    for key, item in cache._cache.items():
+        encoded_filename = quote(item["filename"], safe="")
+        cached_items.append(
+            {
+                "cache_key": key,
+                "filename": item["filename"],
+                "issue_key": item["issue_key"],
+                "size_bytes": item["size"],
+                "mime_type": item["mime_type"],
+                "static_resource_uri": (
+                    f"jira://attachments/{item['issue_key']}/{encoded_filename}"
+                ),
+                "resource_uri": f"jira://attachment/{key}/{encoded_filename}",
+                "created_at": item["created_at"].isoformat(),
+                "expires_at": item["expires_at"].isoformat(),
+            }
+        )
+
+    cached_items.sort(key=lambda x: x["created_at"], reverse=True)
+
+    result = {
+        "cache_stats": {
+            "total_items": stats["item_count"],
+            "total_size_bytes": stats["total_size_bytes"],
+            "total_size_mb": round(stats["total_size_bytes"] / (1024 * 1024), 2),
+            "utilization_percent": stats["utilization_percent"],
+            "ttl_minutes": 10,
+        },
+        "cached_attachments": cached_items,
+        "usage_instructions": {
+            "open_in_browser": "Click static_resource_uri in the MCP resource browser",
+            "images": "PNG/JPEG files render inline automatically",
+            "expiry": "Resources expire after 10 minutes — re-run download_attachments to refresh",
+        },
+    }
+
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(tags={"jira", "utility"})
+async def construct_upload_endpoint(ctx: Context) -> str:
+    """Return the URL and session token needed to upload local files to the MCP server.
+
+    This is step 1 of the client-side file upload flow:
+
+    1. Call this tool to get upload_url + session_id.
+    2. POST your file(s) to upload_url using multipart/form-data with the
+       Mcp-Session-Id header set to session_id.
+
+       Windows PowerShell (handles paths with spaces):
+           curl.exe -X POST <upload_url> -H "Mcp-Session-Id: <id>" -F 'file=@"C:\\path with spaces\\file.pdf"'
+
+       Linux / macOS (handles paths with spaces):
+           curl -X POST <upload_url> -H "Mcp-Session-Id: <id>" -F "file=@'/path/with spaces/file.pdf'"
+
+       The server returns: {"uploaded": [{"filename": "...", "uri": "upload://...", "size": ...}]}
+
+    3. Pass the returned upload:// URIs to jira_upload_attachment.
+
+    Sessions expire after 30 minutes (configurable via UPLOAD_STAGING_TTL_MINUTES).
+    The base URL defaults to http://localhost:8932 and can be overridden by the
+    MCP_SERVER_BASE_URL environment variable.
+
+    Args:
+        ctx: The FastMCP context.
+
+    Returns:
+        JSON string with upload_url, session_id, required_headers, and OS-specific usage example.
+    """
+    import platform
+
+    staging = get_upload_staging()
+    session_id = staging.create_session()
+    base_url = _get_external_base_url()
+    upload_url = f"{base_url}/upload"
+
+    is_windows = platform.system() == "Windows"
+    curl_cmd = "curl.exe" if is_windows else "curl"
+
+    if is_windows:
+        # PowerShell: -s silences progress bar; outer single-quotes + inner double-quotes
+        # handles paths with spaces. e.g. -F 'file=@"C:\My Documents\report.pdf"'
+        curl_example = (
+            f'{curl_cmd} -s -X POST "{upload_url}"'
+            f' -H "Mcp-Session-Id: {session_id}"'
+            " -F 'file=@\"C:\\path with spaces\\your_file.pdf\"'"
+        )
+    else:
+        # bash/zsh: -s silences progress bar; outer double-quotes + inner single-quotes
+        # handles paths with spaces. e.g. -F "file=@'/home/user/my docs/report.pdf'"
+        curl_example = (
+            f'{curl_cmd} -s -X POST "{upload_url}"'
+            f' -H "Mcp-Session-Id: {session_id}"'
+            " -F \"file=@'/path/with spaces/your_file.pdf'\""
+        )
+
+    return json.dumps(
+        {
+            "upload_url": upload_url,
+            "session_id": session_id,
+            "required_headers": {"Mcp-Session-Id": session_id},
+            "curl_example": curl_example,
+            "instructions": (
+                "1. Replace the path placeholder in curl_example with your actual file path. "
+                "2. Run the curl command in a terminal. "
+                "3. The command will output JSON. A successful upload looks like: "
+                '{"success": true, "uploaded": [{"filename": "your_file.pdf", "uri": "upload://sessions/SESSION_ID/FILE_ID", "size": 12345}]}. '
+                "4. Copy the uri value(s) from the uploaded array. "
+                "5. Call jira_upload_attachment with issue_key and those uri value(s)."
+            ),
+            "path_with_spaces_note": (
+                "Windows PowerShell — outer single quotes, path in double quotes: "
+                "-F 'file=@\"C:\\My Docs\\file.pdf\"'  |  "
+                "Linux/macOS bash — path in single quotes inside double quotes: "
+                "-F \"file=@'/my docs/file.pdf'\""
+            ),
+        },
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+@jira_mcp.tool(tags={"jira", "utility"})
+async def construct_download_endpoint(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key for the cached attachment (e.g., 'PROJ-123')"
+        ),
+    ],
+    filename: Annotated[
+        str,
+        Field(
+            description=(
+                "Attachment filename exactly as returned by jira_download_attachments "
+                "or list_cached_attachments."
+            )
+        ),
+    ],
+    ttl_minutes: Annotated[
+        int,
+        Field(
+            description="Lifetime for the generated download URL in minutes.",
+            default=5,
+            ge=1,
+            le=10,
+        ),
+    ] = 5,
+) -> str:
+    """Return a short-lived authenticated download URL for a cached Jira attachment.
+
+    This is intended for clients that need a regular HTTP URL instead of an MCP
+    resource URI. The attachment must already be present in the in-memory cache,
+    typically by running jira_download_attachments with return_content=true.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key for the cached attachment.
+        filename: Cached attachment filename.
+        ttl_minutes: Download URL lifetime in minutes (max 10).
+
+    Returns:
+        JSON string with download_url, expires_at, and attachment metadata.
+    """
+    del ctx
+
+    cache = get_attachment_cache()
+    token_info = cache.create_download_token(
+        issue_key=issue_key,
+        filename=filename,
+        ttl_minutes=ttl_minutes,
+    )
+    base_url = _get_external_base_url()
+    download_url = f"{base_url}/download/{token_info['token']}"
+
+    return json.dumps(
+        {
+            "download_url": download_url,
+            "expires_at": token_info["expires_at"].isoformat(),
+            "issue_key": token_info["issue_key"],
+            "filename": token_info["filename"],
+            "mime_type": token_info["mime_type"],
+            "instructions": (
+                "Open the URL before it expires to download the cached attachment. "
+                "If the URL has expired, generate a new one."
+            ),
+        },
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+@jira_mcp.tool(tags={"jira", "write"})
+@check_write_access
+async def jira_upload_attachment(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(description="Jira issue key to attach the file(s) to (e.g., 'PROJ-123')"),
+    ],
+    upload_uris: Annotated[
+        list[str],
+        Field(
+            description=(
+                "List of upload:// URIs returned by the /upload endpoint after calling "
+                "construct_upload_endpoint and uploading your files. "
+                "Example: ['upload://sessions/abc123/xyz456']"
+            )
+        ),
+    ],
+) -> str:
+    """Upload one or more staged files to a Jira issue as attachments.
+
+    This is step 3 of the client-side file upload flow (after construct_upload_endpoint
+    and POSTing files to /upload).
+
+    Each upload:// URI is resolved from the server-side staging store, then
+    uploaded directly to Jira via the REST API — no base64, no context-window
+    overhead.
+
+    Staged files are removed from the store after a successful upload.
+    Unused uploads expire automatically after 30 minutes.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key (e.g., 'PROJ-123').
+        upload_uris: List of upload:// URIs from the /upload endpoint response.
+
+    Returns:
+        JSON string with per-file upload results.
+
+    Raises:
+        ValueError: If in read-only mode or Jira client is unavailable.
+    """
+    jira = await get_jira_fetcher(ctx)
+    staging = get_upload_staging()
+
+    uploaded = []
+    failed = []
+
+    for uri in upload_uris:
+        parsed = staging.parse_uri(uri)
+        if not parsed:
+            failed.append(
+                {
+                    "uri": uri,
+                    "error": (
+                        "Invalid upload URI format. "
+                        "Expected upload://sessions/<session_id>/<file_id>"
+                    ),
+                }
+            )
+            continue
+
+        session_id, file_id = parsed
+        entry = staging.get(session_id, file_id)
+        if not entry:
+            failed.append(
+                {
+                    "uri": uri,
+                    "error": (
+                        "Staged file not found or expired. "
+                        "Call construct_upload_endpoint and re-upload the file."
+                    ),
+                }
+            )
+            continue
+
+        result = jira.upload_attachment_from_bytes(
+            issue_key=issue_key,
+            filename=entry["filename"],
+            content=entry["content"],
+            mime_type=entry["mime_type"],
+        )
+
+        if result.get("success"):
+            staging.remove(session_id, file_id)
+            uploaded.append(
+                {
+                    "filename": result["filename"],
+                    "size": result["size"],
+                    "id": result.get("id"),
+                }
+            )
+        else:
+            failed.append(
+                {
+                    "uri": uri,
+                    "filename": entry["filename"],
+                    "error": result.get("error"),
+                }
+            )
+
+    return json.dumps(
+        {
+            "success": len(failed) == 0,
+            "issue_key": issue_key,
+            "total": len(upload_uris),
+            "uploaded": uploaded,
+            "failed": failed,
+        },
+        indent=2,
+        ensure_ascii=False,
+    )

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from typing import Any, Literal, Optional
+from urllib.parse import quote
 
 from cachetools import TTLCache
 from fastmcp import FastMCP, settings
@@ -22,7 +23,9 @@ from mcp_atlassian.bitbucket.config import BitbucketConfig
 from mcp_atlassian.confluence import ConfluenceFetcher
 from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.attachment_cache import get_attachment_cache
 from mcp_atlassian.jira.config import JiraConfig
+from mcp_atlassian.jira.upload_staging import get_upload_staging
 from mcp_atlassian.utils.environment import get_available_services
 from mcp_atlassian.utils.io import (
     get_cli_read_only_flag,
@@ -51,6 +54,115 @@ logger.info(f"Metrics collection initialized for pod: {pod_name}")
 
 async def health_check() -> JSONResponse:
     return JSONResponse({"status": "ok"})
+
+
+async def upload_endpoint(request: Request) -> JSONResponse:
+    """Receive multipart file uploads and stage them for Jira attachment.
+
+    Expects:
+      - Header:  Mcp-Session-Id: <session_id>  (from construct_upload_endpoint)
+      - Body:    multipart/form-data with one or more file fields
+
+    Returns JSON:
+      {"uploaded": [{"filename": "...", "uri": "upload://sessions/…", "size": …}]}
+    """
+    from pathlib import Path
+
+    session_id = request.headers.get("mcp-session-id")
+    if not session_id:
+        return JSONResponse(
+            {"error": "Mcp-Session-Id header is required"},
+            status_code=400,
+        )
+
+    staging = get_upload_staging()
+    if not staging.is_valid_session(session_id):
+        return JSONResponse(
+            {
+                "error": (
+                    "Invalid or expired upload session. "
+                    "Call construct_upload_endpoint to create a new session."
+                )
+            },
+            status_code=403,
+        )
+
+    try:
+        form = await request.form()
+    except Exception as exc:
+        logger.error("Failed to parse upload form: %s", exc)
+        return JSONResponse({"error": "Invalid multipart form data"}, status_code=400)
+
+    uploaded = []
+    for _field_name, file_field in form.multi_items():
+        if not hasattr(file_field, "filename") or not file_field.filename:
+            continue
+        # Prevent path traversal: keep only the basename
+        safe_name = Path(file_field.filename).name
+        if not safe_name:
+            continue
+        try:
+            content: bytes = await file_field.read()
+        except Exception as exc:
+            logger.error("Failed to read uploaded file '%s': %s", safe_name, exc)
+            continue
+        mime_type: str = (
+            getattr(file_field, "content_type", None) or "application/octet-stream"
+        )
+        try:
+            file_id = staging.store(session_id, safe_name, content, mime_type)
+        except PermissionError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=403)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=413)
+        uri = staging.make_uri(session_id, file_id)
+        uploaded.append({"filename": safe_name, "uri": uri, "size": len(content)})
+
+    if not uploaded:
+        return JSONResponse(
+            {
+                "error": "No files found in request. Use multipart/form-data with file fields."
+            },
+            status_code=400,
+        )
+
+    logger.info(
+        "Staged %d file(s) for session %s: %s",
+        len(uploaded),
+        session_id,
+        [u["filename"] for u in uploaded],
+    )
+    return JSONResponse({"success": True, "uploaded": uploaded})
+
+
+async def download_endpoint(request: Request) -> Response:
+    """Serve a cached Jira attachment via a short-lived download token."""
+    token = request.path_params.get("token")
+    if not token:
+        return JSONResponse({"error": "Download token is required"}, status_code=400)
+
+    attachment = get_attachment_cache().get_by_download_token(token)
+    if not attachment:
+        return JSONResponse(
+            {
+                "error": (
+                    "Invalid or expired download token. "
+                    "Generate a new download URL and try again."
+                )
+            },
+            status_code=403,
+        )
+
+    encoded_name = quote(attachment["filename"], safe="")
+    headers = {
+        "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_name}",
+        "Cache-Control": "private, max-age=0, no-store",
+    }
+    return Response(
+        content=attachment["content"],
+        media_type=attachment["mime_type"],
+        headers=headers,
+    )
 
 
 async def metrics_endpoint(request: Request) -> Response:
@@ -429,6 +541,12 @@ class AtlassianMCP(FastMCP[MainAppContext]):
 
         # Add metrics endpoint
         app.router.routes.append(Route("/metrics", metrics_endpoint, methods=["GET"]))
+        # Add file upload endpoint (used by construct_upload_endpoint / jira_upload_attachment flow)
+        app.router.routes.append(Route("/upload", upload_endpoint, methods=["POST"]))
+        # Add short-lived attachment download endpoint (used by construct_download_endpoint)
+        app.router.routes.append(
+            Route("/download/{token}", download_endpoint, methods=["GET"])
+        )
 
         return app
 
@@ -548,6 +666,25 @@ class UserTokenMiddleware:
                 logger.debug(
                     "UserTokenMiddleware: X-Atlassian-Enable-Xray header: %s",
                     enable_xray_header_value,
+                )
+
+            # Extract X-MCP-Upload-Base-URL header for the file upload endpoint
+            upload_base_url_header = headers.get(b"x-mcp-upload-base-url")
+            upload_base_url_header_str = (
+                upload_base_url_header.decode("latin-1")
+                if upload_base_url_header
+                else None
+            )
+            upload_base_url_header_str = (
+                upload_base_url_header_str.strip()
+                if upload_base_url_header_str
+                else None
+            )
+            scope_copy["state"]["upload_base_url"] = upload_base_url_header_str
+            if upload_base_url_header_str:
+                logger.debug(
+                    "UserTokenMiddleware: X-MCP-Upload-Base-URL header: %s",
+                    upload_base_url_header_str,
                 )
 
             # Extract User-Agent header for tracking and make it lowercase

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -28,8 +28,16 @@ from mcp_atlassian.jira.config import JiraConfig
 from mcp_atlassian.jira.upload_staging import get_upload_staging
 from mcp_atlassian.utils.environment import get_available_services
 from mcp_atlassian.utils.io import (
+    get_cli_bitbucket_read_only_flag,
+    get_cli_confluence_read_only_flag,
+    get_cli_jira_read_only_flag,
     get_cli_read_only_flag,
+    get_env_bitbucket_read_only_flag,
+    get_env_confluence_read_only_flag,
+    get_env_jira_read_only_flag,
     get_env_read_only_flag,
+    parse_extended_bool,
+    resolve_product_read_only_mode,
     resolve_read_only_mode,
 )
 from mcp_atlassian.utils.logging import mask_sensitive
@@ -191,6 +199,29 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
     read_only = resolve_read_only_mode(cli_read_only, env_read_only, None)
     enabled_tools = get_enabled_tools()
 
+    # Resolve per-product read_only flags (no header at startup time)
+    jira_read_only = resolve_product_read_only_mode(
+        product_cli=get_cli_jira_read_only_flag(),
+        product_env=get_env_jira_read_only_flag(),
+        global_cli=cli_read_only,
+        global_env=env_read_only,
+        header_read_only=None,
+    )
+    confluence_read_only = resolve_product_read_only_mode(
+        product_cli=get_cli_confluence_read_only_flag(),
+        product_env=get_env_confluence_read_only_flag(),
+        global_cli=cli_read_only,
+        global_env=env_read_only,
+        header_read_only=None,
+    )
+    bitbucket_read_only = resolve_product_read_only_mode(
+        product_cli=get_cli_bitbucket_read_only_flag(),
+        product_env=get_env_bitbucket_read_only_flag(),
+        global_cli=cli_read_only,
+        global_env=env_read_only,
+        header_read_only=None,
+    )
+
     loaded_jira_config: JiraConfig | None = None
     loaded_confluence_config: ConfluenceConfig | None = None
     loaded_bitbucket_config: BitbucketConfig | None = None
@@ -270,10 +301,17 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
         cli_read_only=cli_read_only,
         env_read_only=env_read_only,
         enabled_tools=enabled_tools,
+        jira_read_only=jira_read_only,
+        confluence_read_only=confluence_read_only,
+        bitbucket_read_only=bitbucket_read_only,
     )
     logger.info(
-        "Read-only mode resolved: %s (cli=%s, env=%s)",
+        "Read-only mode resolved: global=%s, jira=%s, confluence=%s, bitbucket=%s "
+        "(cli=%s, env=%s)",
         "ENABLED" if read_only else "DISABLED",
+        "ENABLED" if jira_read_only else "DISABLED",
+        "ENABLED" if confluence_read_only else "DISABLED",
+        "ENABLED" if bitbucket_read_only else "DISABLED",
         cli_read_only,
         env_read_only,
     )
@@ -342,6 +380,9 @@ class AtlassianMCP(FastMCP[MainAppContext]):
             env_read_only = get_env_read_only_flag()
 
         header_read_only = None
+        header_jira_read_only = None
+        header_confluence_read_only = None
+        header_bitbucket_read_only = None
         enable_xray_header = None
         header_based_services = {
             "jira": False,
@@ -353,6 +394,15 @@ class AtlassianMCP(FastMCP[MainAppContext]):
             request_state = req_context.request.state
             service_headers = getattr(request_state, "atlassian_service_headers", {})
             header_read_only = getattr(request_state, "read_only_mode_header", None)
+            header_jira_read_only = getattr(
+                request_state, "jira_read_only_mode_header", None
+            )
+            header_confluence_read_only = getattr(
+                request_state, "confluence_read_only_mode_header", None
+            )
+            header_bitbucket_read_only = getattr(
+                request_state, "bitbucket_read_only_mode_header", None
+            )
             enable_xray_header = getattr(request_state, "enable_xray_header", None)
 
             if service_headers:
@@ -375,15 +425,52 @@ class AtlassianMCP(FastMCP[MainAppContext]):
         ):
             effective_read_only = bool(base_read_only)
 
+        # Resolve per-product effective read_only.
+        # Priority (highest first):
+        #   product-specific header > global header > product-specific startup value > effective_read_only
+        def _product_read_only(
+            product_header: str | None,
+            context_attr: str,
+        ) -> bool:
+            product_hdr_bool = parse_extended_bool(product_header)
+            if product_hdr_bool is not None:
+                return product_hdr_bool
+            global_hdr_bool = parse_extended_bool(header_read_only)
+            if global_hdr_bool is not None:
+                return global_hdr_bool
+            stored = (
+                getattr(app_lifespan_state, context_attr, None)
+                if app_lifespan_state
+                else None
+            )
+            return bool(stored) if stored is not None else effective_read_only
+
+        effective_jira_read_only = _product_read_only(
+            header_jira_read_only, "jira_read_only"
+        )
+        effective_confluence_read_only = _product_read_only(
+            header_confluence_read_only, "confluence_read_only"
+        )
+        effective_bitbucket_read_only = _product_read_only(
+            header_bitbucket_read_only, "bitbucket_read_only"
+        )
+
         logger.debug(
             "_main_mcp_list_tools: base_read_only=%s, cli_read_only=%s, "
-            "env_read_only=%s, header_read_only=%s, effective_read_only=%s, "
-            "enabled_tools_filter=%s, header_services=%s",
+            "env_read_only=%s, header_read_only=%s (jira=%s, confluence=%s, bitbucket=%s), "
+            "effective_read_only=%s, jira_read_only=%s, confluence_read_only=%s, "
+            "bitbucket_read_only=%s, enabled_tools_filter=%s, header_services=%s",
             base_read_only,
             cli_read_only,
             env_read_only,
             header_read_only,
+            header_jira_read_only,
+            header_confluence_read_only,
+            header_bitbucket_read_only,
             effective_read_only,
+            effective_jira_read_only,
+            effective_confluence_read_only,
+            effective_bitbucket_read_only,
             enabled_tools_filter,
             header_based_services,
         )
@@ -405,12 +492,35 @@ class AtlassianMCP(FastMCP[MainAppContext]):
                 logger.debug(f"Excluding tool '{registered_name}' (not enabled)")
                 continue
 
-            if tool_obj and effective_read_only and "write" in tool_tags:
-                logger.debug(
-                    f"Excluding tool '{registered_name}' due to read-only mode "
-                    f"and 'write' tag"
-                )
-                continue
+            if tool_obj and "write" in tool_tags:
+                is_jira_write = "jira" in tool_tags
+                is_confluence_write = "confluence" in tool_tags
+                is_bitbucket_write = "bitbucket" in tool_tags
+                if is_jira_write and effective_jira_read_only:
+                    logger.debug(
+                        f"Excluding tool '{registered_name}' due to Jira read-only mode"
+                    )
+                    continue
+                if is_confluence_write and effective_confluence_read_only:
+                    logger.debug(
+                        f"Excluding tool '{registered_name}' due to Confluence read-only mode"
+                    )
+                    continue
+                if is_bitbucket_write and effective_bitbucket_read_only:
+                    logger.debug(
+                        f"Excluding tool '{registered_name}' due to Bitbucket read-only mode"
+                    )
+                    continue
+                # Fallback for write tools not tagged to a specific product (e.g. xray)
+                if (
+                    not any([is_jira_write, is_confluence_write, is_bitbucket_write])
+                    and effective_read_only
+                ):
+                    logger.debug(
+                        f"Excluding tool '{registered_name}' due to global read-only mode "
+                        f"and 'write' tag"
+                    )
+                    continue
 
             # Exclude Jira/Confluence tools if config is not fully authenticated
             is_jira_tool = "jira" in tool_tags
@@ -648,6 +758,30 @@ class UserTokenMiddleware:
                     "UserTokenMiddleware: X-Atlassian-Read-Only-Mode header: %s",
                     read_only_header_value,
                 )
+
+            # Per-product read-only headers
+            def _extract_header(key: bytes) -> str | None:
+                raw = headers.get(key)
+                val = raw.decode("latin-1").strip() if raw else None
+                return val if val else None
+
+            jira_ro_hdr = _extract_header(b"x-atlassian-jira-read-only-mode")
+            confluence_ro_hdr = _extract_header(
+                b"x-atlassian-confluence-read-only-mode"
+            )
+            bitbucket_ro_hdr = _extract_header(b"x-atlassian-bitbucket-read-only-mode")
+            scope_copy["state"]["jira_read_only_mode_header"] = jira_ro_hdr
+            scope_copy["state"]["confluence_read_only_mode_header"] = confluence_ro_hdr
+            scope_copy["state"]["bitbucket_read_only_mode_header"] = bitbucket_ro_hdr
+            for hdr_name, hdr_val in (
+                ("X-Atlassian-Jira-Read-Only-Mode", jira_ro_hdr),
+                ("X-Atlassian-Confluence-Read-Only-Mode", confluence_ro_hdr),
+                ("X-Atlassian-Bitbucket-Read-Only-Mode", bitbucket_ro_hdr),
+            ):
+                if hdr_val:
+                    logger.debug(
+                        "UserTokenMiddleware: %s header: %s", hdr_name, hdr_val
+                    )
 
             # Extract X-Atlassian-Enable-Xray header
             enable_xray_header_bytes = headers.get(b"x-atlassian-enable-xray")

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -102,6 +102,7 @@ async def upload_endpoint(request: Request) -> JSONResponse:
         return JSONResponse({"error": "Invalid multipart form data"}, status_code=400)
 
     uploaded = []
+    max_file_bytes = staging._max_size_bytes
     for _field_name, file_field in form.multi_items():
         if not hasattr(file_field, "filename") or not file_field.filename:
             continue
@@ -110,7 +111,28 @@ async def upload_endpoint(request: Request) -> JSONResponse:
         if not safe_name:
             continue
         try:
-            content: bytes = await file_field.read()
+            # Stream-read in chunks and enforce size limit early to prevent
+            # memory exhaustion from oversized uploads.
+            chunks: list[bytes] = []
+            total_read = 0
+            chunk_size = 64 * 1024  # 64 KB
+            while True:
+                chunk = await file_field.read(chunk_size)
+                if not chunk:
+                    break
+                total_read += len(chunk)
+                if total_read > max_file_bytes:
+                    return JSONResponse(
+                        {
+                            "error": (
+                                f"File '{safe_name}' exceeds maximum allowed size "
+                                f"({max_file_bytes} bytes). Upload rejected."
+                            )
+                        },
+                        status_code=413,
+                    )
+                chunks.append(chunk)
+            content: bytes = b"".join(chunks)
         except Exception as exc:
             logger.error("Failed to read uploaded file '%s': %s", safe_name, exc)
             continue

--- a/src/mcp_atlassian/utils/__init__.py
+++ b/src/mcp_atlassian/utils/__init__.py
@@ -5,9 +5,16 @@ This package provides various utility functions used throughout the codebase.
 
 from .date import parse_date
 from .io import (
+    get_cli_bitbucket_read_only_flag,
+    get_cli_confluence_read_only_flag,
+    get_cli_jira_read_only_flag,
     get_cli_read_only_flag,
+    get_env_bitbucket_read_only_flag,
+    get_env_confluence_read_only_flag,
+    get_env_jira_read_only_flag,
     get_env_read_only_flag,
     is_read_only_mode,
+    resolve_product_read_only_mode,
     resolve_read_only_mode,
 )
 
@@ -32,6 +39,13 @@ __all__ = [
     "get_cli_read_only_flag",
     "get_env_read_only_flag",
     "resolve_read_only_mode",
+    "get_cli_jira_read_only_flag",
+    "get_env_jira_read_only_flag",
+    "get_cli_confluence_read_only_flag",
+    "get_env_confluence_read_only_flag",
+    "get_cli_bitbucket_read_only_flag",
+    "get_env_bitbucket_read_only_flag",
+    "resolve_product_read_only_mode",
     "setup_logging",
     "parse_date",
     "OAuthConfig",

--- a/src/mcp_atlassian/utils/decorators.py
+++ b/src/mcp_atlassian/utils/decorators.py
@@ -11,8 +11,29 @@ from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.utils.io import (
     get_cli_read_only_flag,
     get_env_read_only_flag,
+    parse_extended_bool,
     resolve_read_only_mode,
 )
+
+# Maps a tool module path to:
+#   (context_attr, request_state_header_attr, display_name)
+_MODULE_TO_PRODUCT: dict[str, tuple[str, str, str]] = {
+    "mcp_atlassian.servers.jira": (
+        "jira_read_only",
+        "jira_read_only_mode_header",
+        "Jira",
+    ),
+    "mcp_atlassian.servers.confluence": (
+        "confluence_read_only",
+        "confluence_read_only_mode_header",
+        "Confluence",
+    ),
+    "mcp_atlassian.servers.bitbucket": (
+        "bitbucket_read_only",
+        "bitbucket_read_only_mode_header",
+        "Bitbucket",
+    ),
+}
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +46,16 @@ def check_write_access(func: F) -> F:
     Decorator for FastMCP tools to check if the application is in read-only mode.
     If in read-only mode, it raises a ValueError.
     Assumes the decorated function is async and has `ctx: Context` as its first argument.
+
+    Per-product read-only flags are respected: a tool belonging to a specific product
+    (Jira, Confluence, Bitbucket) uses that product's effective read-only state, which
+    may differ from the global flag.  Priority (highest first):
+      product-specific header > global header > product startup value > global effective.
     """
+    # Determine the product for this tool once at decoration time.
+    product_info: tuple[str, str, str] | None = _MODULE_TO_PRODUCT.get(
+        getattr(func, "__module__", ""), None
+    )
 
     @wraps(func)
     async def wrapper(ctx: Context, *args: Any, **kwargs: Any) -> Any:
@@ -48,22 +78,26 @@ def check_write_access(func: F) -> F:
             cli_read_only = get_cli_read_only_flag()
             env_read_only = get_env_read_only_flag()
 
-        header_read_only = None
+        request_state = None
         if (
             req_context
             and hasattr(req_context, "request")
             and hasattr(req_context.request, "state")
         ):
-            header_read_only = getattr(
-                req_context.request.state, "read_only_mode_header", None
-            )
+            request_state = req_context.request.state
 
+        header_read_only = (
+            getattr(request_state, "read_only_mode_header", None)
+            if request_state is not None
+            else None
+        )
+
+        # --- Global effective read-only (same logic as before) ---
         effective_read_only = resolve_read_only_mode(
             cli_read_only=cli_read_only,
             env_read_only=env_read_only,
             header_read_only=header_read_only,
         )
-
         if (
             header_read_only is None
             and env_read_only is None
@@ -72,11 +106,41 @@ def check_write_access(func: F) -> F:
         ):
             effective_read_only = bool(base_read_only)
 
+        # --- Per-product override ---
+        # If this tool belongs to a known product, resolve its effective read-only
+        # using the same priority chain as _mcp_list_tools:
+        #   product header > global header > product startup value > global effective
+        if product_info is not None:
+            ctx_attr, hdr_attr, product_name = product_info
+
+            product_header = (
+                getattr(request_state, hdr_attr, None)
+                if request_state is not None
+                else None
+            )
+            product_hdr_bool = parse_extended_bool(product_header)
+            if product_hdr_bool is not None:
+                # Product-specific header wins.
+                effective_read_only = product_hdr_bool
+            else:
+                global_hdr_bool = parse_extended_bool(header_read_only)
+                if global_hdr_bool is not None:
+                    # Global header applies to this product (no product override).
+                    effective_read_only = global_hdr_bool
+                else:
+                    # No header at all — check the startup-resolved product value.
+                    product_startup = (
+                        getattr(app_lifespan_ctx, ctx_attr, None)
+                        if app_lifespan_ctx is not None
+                        else None
+                    )
+                    if product_startup is not None:
+                        effective_read_only = bool(product_startup)
+                    # else: keep effective_read_only from global resolution above.
+
         if effective_read_only:
             tool_name = func.__name__
-            action_description = tool_name.replace(
-                "_", " "
-            )  # e.g., "create_issue" -> "create issue"
+            action_description = tool_name.replace("_", " ")
             logger.warning(f"Attempted to call tool '{tool_name}' in read-only mode.")
             msg = f"Cannot {action_description} in read-only mode."
             raise ValueError(msg)

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -74,9 +74,15 @@ def get_available_services(
         confluence_token = headers.get("X-Atlassian-Confluence-Personal-Token")
         confluence_url_header = headers.get("X-Atlassian-Confluence-Url")
 
-        if confluence_token and confluence_url_header:
+        if confluence_url_header:
             confluence_is_setup = True
-            logger.info("Using Confluence authentication from header personal token")
+            if confluence_token:
+                logger.info("Using Confluence authentication from header personal token")
+            else:
+                logger.info(
+                    "Confluence URL provided without personal token - tools will be "
+                    "listed but API calls require a valid token"
+                )
 
     # Jira service detection
     jira_url = os.getenv("JIRA_URL")
@@ -134,9 +140,15 @@ def get_available_services(
         jira_token = headers.get("X-Atlassian-Jira-Personal-Token")
         jira_url_header = headers.get("X-Atlassian-Jira-Url")
 
-        if jira_token and jira_url_header:
+        if jira_url_header:
             jira_is_setup = True
-            logger.info("Using Jira authentication from header personal token")
+            if jira_token:
+                logger.info("Using Jira authentication from header personal token")
+            else:
+                logger.info(
+                    "Jira URL provided without personal token - tools will be "
+                    "listed but API calls require a valid token"
+                )
 
     # Bitbucket service detection
     bitbucket_url = os.getenv("BITBUCKET_URL")
@@ -196,9 +208,15 @@ def get_available_services(
         bitbucket_token = headers.get("X-Atlassian-Bitbucket-Personal-Token")
         bitbucket_url_header = headers.get("X-Atlassian-Bitbucket-Url")
 
-        if bitbucket_token and bitbucket_url_header:
+        if bitbucket_url_header:
             bitbucket_is_setup = True
-            logger.info("Using Bitbucket authentication from header personal token")
+            if bitbucket_token:
+                logger.info("Using Bitbucket authentication from header personal token")
+            else:
+                logger.info(
+                    "Bitbucket URL provided without personal token - tools will be "
+                    "listed but API calls require a valid token"
+                )
 
     # Xray for Jira reuses Jira URL and credentials (Server/Data Center only)
     xray_is_setup = False

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -77,7 +77,9 @@ def get_available_services(
         if confluence_url_header:
             confluence_is_setup = True
             if confluence_token:
-                logger.info("Using Confluence authentication from header personal token")
+                logger.info(
+                    "Using Confluence authentication from header personal token"
+                )
             else:
                 logger.info(
                     "Confluence URL provided without personal token - tools will be "

--- a/src/mcp_atlassian/utils/io.py
+++ b/src/mcp_atlassian/utils/io.py
@@ -42,6 +42,72 @@ def get_cli_read_only_flag() -> bool | None:
     return parse_extended_bool(os.getenv("CLI_READ_ONLY_MODE"))
 
 
+def get_env_jira_read_only_flag() -> bool | None:
+    """Return the JIRA_READ_ONLY_MODE environment flag, if provided."""
+    return parse_extended_bool(os.getenv("JIRA_READ_ONLY_MODE"))
+
+
+def get_cli_jira_read_only_flag() -> bool | None:
+    """Return the CLI Jira read-only flag captured in CLI_JIRA_READ_ONLY_MODE."""
+    return parse_extended_bool(os.getenv("CLI_JIRA_READ_ONLY_MODE"))
+
+
+def get_env_confluence_read_only_flag() -> bool | None:
+    """Return the CONFLUENCE_READ_ONLY_MODE environment flag, if provided."""
+    return parse_extended_bool(os.getenv("CONFLUENCE_READ_ONLY_MODE"))
+
+
+def get_cli_confluence_read_only_flag() -> bool | None:
+    """Return the CLI Confluence read-only flag captured in CLI_CONFLUENCE_READ_ONLY_MODE."""
+    return parse_extended_bool(os.getenv("CLI_CONFLUENCE_READ_ONLY_MODE"))
+
+
+def get_env_bitbucket_read_only_flag() -> bool | None:
+    """Return the BITBUCKET_READ_ONLY_MODE environment flag, if provided."""
+    return parse_extended_bool(os.getenv("BITBUCKET_READ_ONLY_MODE"))
+
+
+def get_cli_bitbucket_read_only_flag() -> bool | None:
+    """Return the CLI Bitbucket read-only flag captured in CLI_BITBUCKET_READ_ONLY_MODE."""
+    return parse_extended_bool(os.getenv("CLI_BITBUCKET_READ_ONLY_MODE"))
+
+
+def resolve_product_read_only_mode(
+    product_cli: bool | None,
+    product_env: bool | None,
+    global_cli: bool | None,
+    global_env: bool | None,
+    header_read_only: str | bool | None,
+) -> bool:
+    """Resolve read-only mode for a specific product.
+
+    Priority (highest first):
+    1. Request header (overrides everything)
+    2. Product-specific env var
+    3. Global env var
+    4. Product-specific CLI flag
+    5. Global CLI flag
+    6. Default: False
+    """
+    header_value = parse_extended_bool(header_read_only)
+    if header_value is not None:
+        return header_value
+
+    if product_env is not None:
+        return product_env
+
+    if global_env is not None:
+        return global_env
+
+    if product_cli is not None:
+        return product_cli
+
+    if global_cli is not None:
+        return global_cli
+
+    return False
+
+
 def resolve_read_only_mode(
     cli_read_only: bool | None,
     env_read_only: bool | None,

--- a/tests/unit/bitbucket/test_pullrequests.py
+++ b/tests/unit/bitbucket/test_pullrequests.py
@@ -542,3 +542,150 @@ class TestPullRequestsMixin:
                 "workspace", "repo", 1, "Blocker!", severity="BLOCKER"
             )
         assert "Error blocker adding PR comment" in str(exc_info.value)
+
+    def test_add_pull_request_inline_comment_success_cloud(self, pullrequests_mixin):
+        """Test successful addition of an inline comment on Cloud."""
+        expected_response = {"id": 789, "content": {"raw": "Looks good!"}}
+        pullrequests_mixin.bitbucket.post.return_value = expected_response
+
+        with patch.object(
+            type(pullrequests_mixin.config),
+            "is_cloud",
+            new_callable=lambda: property(lambda self: True),
+        ):
+            result = pullrequests_mixin.add_pull_request_inline_comment(
+                "workspace", "repo", 1, "Looks good!", "src/main.py", 42
+            )
+
+        assert result == expected_response
+        pullrequests_mixin.bitbucket.post.assert_called_once_with(
+            "repositories/workspace/repo/pullrequests/1/comments",
+            data={
+                "content": {"raw": "Looks good!"},
+                "inline": {"to": 42, "path": "src/main.py"},
+            },
+        )
+
+    def test_add_pull_request_inline_comment_success_server(self, pullrequests_mixin):
+        """Test successful addition of an inline comment on Server/DC."""
+        expected_response = {"id": 101, "text": "Needs fix"}
+        pullrequests_mixin.bitbucket.post.return_value = expected_response
+
+        with patch.object(
+            type(pullrequests_mixin.config),
+            "is_cloud",
+            new_callable=lambda: property(lambda self: False),
+        ):
+            result = pullrequests_mixin.add_pull_request_inline_comment(
+                "PROJECT", "repo", 2, "Needs fix", "src/utils.py", 10, line_type="ADDED"
+            )
+
+        assert result == expected_response
+        pullrequests_mixin.bitbucket.post.assert_called_once_with(
+            "projects/PROJECT/repos/repo/pull-requests/2/comments",
+            data={
+                "text": "Needs fix",
+                "anchor": {
+                    "diffType": "EFFECTIVE",
+                    "line": 10,
+                    "lineType": "ADDED",
+                    "fileType": "TO",
+                    "path": "src/utils.py",
+                },
+            },
+        )
+
+    def test_add_pull_request_inline_comment_invalid_line_type_defaults(
+        self, pullrequests_mixin
+    ):
+        """Test that an invalid line_type defaults to 'ADDED' for Server/DC."""
+        pullrequests_mixin.bitbucket.post.return_value = {"id": 1}
+
+        with patch.object(
+            type(pullrequests_mixin.config),
+            "is_cloud",
+            new_callable=lambda: property(lambda self: False),
+        ):
+            pullrequests_mixin.add_pull_request_inline_comment(
+                "PROJECT", "repo", 1, "comment", "file.py", 5, line_type="INVALID"
+            )
+
+        call_data = pullrequests_mixin.bitbucket.post.call_args[1]["data"]
+        assert call_data["anchor"]["lineType"] == "ADDED"
+        assert call_data["anchor"]["fileType"] == "TO"
+
+    def test_add_pull_request_inline_comment_removed_line_uses_from_file(
+        self, pullrequests_mixin
+    ):
+        """Test removed-line comments anchor to the source side of the diff."""
+        pullrequests_mixin.bitbucket.post.return_value = {"id": 1}
+
+        with patch.object(
+            type(pullrequests_mixin.config),
+            "is_cloud",
+            new_callable=lambda: property(lambda self: False),
+        ):
+            pullrequests_mixin.add_pull_request_inline_comment(
+                "PROJECT", "repo", 1, "comment", "file.py", 5, line_type="REMOVED"
+            )
+
+        call_data = pullrequests_mixin.bitbucket.post.call_args[1]["data"]
+        assert call_data["anchor"]["fileType"] == "FROM"
+
+    def test_add_pull_request_inline_comment_server_uses_effective_diff(
+        self, pullrequests_mixin
+    ):
+        """Test Server/DC inline comments use EFFECTIVE diffType (no hashes required)."""
+        pullrequests_mixin.bitbucket.post.return_value = {"id": 1}
+
+        with patch.object(
+            type(pullrequests_mixin.config),
+            "is_cloud",
+            new_callable=lambda: property(lambda self: False),
+        ):
+            pullrequests_mixin.add_pull_request_inline_comment(
+                "PROJECT", "repo", 1, "comment", "file.py", 5
+            )
+
+        call_data = pullrequests_mixin.bitbucket.post.call_args[1]["data"]
+        assert call_data["anchor"]["diffType"] == "EFFECTIVE"
+        assert "fromHash" not in call_data["anchor"]
+        assert "toHash" not in call_data["anchor"]
+
+    def test_add_pull_request_inline_comment_authentication_error(
+        self, pullrequests_mixin
+    ):
+        """Test authentication error in add_pull_request_inline_comment."""
+        mock_response = Mock()
+        mock_response.status_code = 401
+        http_error = HTTPError(response=mock_response)
+        pullrequests_mixin.bitbucket.post.side_effect = http_error
+
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            pullrequests_mixin.add_pull_request_inline_comment(
+                "workspace", "repo", 1, "comment", "file.py", 1
+            )
+
+    def test_add_pull_request_inline_comment_http_error_other(self, pullrequests_mixin):
+        """Test other HTTP error in add_pull_request_inline_comment."""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        http_error = HTTPError(response=mock_response)
+        pullrequests_mixin.bitbucket.post.side_effect = http_error
+
+        with pytest.raises(HTTPError):
+            pullrequests_mixin.add_pull_request_inline_comment(
+                "workspace", "repo", 1, "comment", "file.py", 1
+            )
+
+    def test_add_pull_request_inline_comment_general_exception(
+        self, pullrequests_mixin
+    ):
+        """Test general exception in add_pull_request_inline_comment."""
+        pullrequests_mixin.bitbucket.post.side_effect = Exception("API error")
+
+        with pytest.raises(Exception) as exc_info:
+            pullrequests_mixin.add_pull_request_inline_comment(
+                "workspace", "repo", 1, "comment", "file.py", 1
+            )
+        assert "Error adding inline PR comment" in str(exc_info.value)

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.attachment_cache import AttachmentCache
 from mcp_atlassian.jira.attachments import AttachmentsMixin
+from mcp_atlassian.jira.upload_staging import UploadStagingStore
 
 # Test scenarios for AttachmentsMixin
 #
@@ -443,6 +445,135 @@ class TestAttachmentsMixin:
             assert len(result["failed"]) == 1
             assert result["failed"][0]["filename"] == "test1.txt"
             assert "No URL available" in result["failed"][0]["error"]
+
+    def test_download_issue_attachments_cache_failure_reports_error(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Test cache failures return an error instead of embedding base64 content."""
+        mock_issue = {
+            "fields": {
+                "attachment": [
+                    {
+                        "filename": "test1.txt",
+                        "content": "https://test.url/attachment1",
+                        "size": 100,
+                    }
+                ]
+            }
+        }
+        attachments_mixin.jira.issue.return_value = mock_issue
+
+        mock_attachment = MagicMock()
+        mock_attachment.filename = "test1.txt"
+        mock_attachment.url = "https://test.url/attachment1"
+        mock_attachment.size = 100
+        mock_attachment.content_type = "text/plain"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.iter_content.return_value = [b"test content"]
+        attachments_mixin.jira._session.get.return_value = mock_response
+
+        cache = MagicMock()
+        cache.store.side_effect = ValueError("cache full")
+
+        with (
+            patch(
+                "mcp_atlassian.models.jira.JiraAttachment.from_api_response",
+                return_value=mock_attachment,
+            ),
+            patch(
+                "mcp_atlassian.jira.attachments.get_attachment_cache",
+                return_value=cache,
+            ),
+        ):
+            result = attachments_mixin.download_issue_attachments(
+                "TEST-123", return_content=True
+            )
+
+        assert result["downloaded"] == []
+        assert len(result["failed"]) == 1
+        assert "Failed to cache attachment content" in result["failed"][0]["error"]
+        assert "content" not in result["failed"][0]
+
+
+class TestUploadStagingStore:
+    """Tests for the upload staging session validation flow."""
+
+    @pytest.fixture
+    def attachments_mixin(self, jira_fetcher: JiraFetcher) -> AttachmentsMixin:
+        """Mirror the shared AttachmentsMixin fixture for tests in this class."""
+        attachments_mixin = jira_fetcher
+        attachments_mixin.jira = MagicMock()
+        attachments_mixin.jira._session = MagicMock()
+        return attachments_mixin
+
+    def test_store_requires_issued_session(self):
+        """Test staging rejects arbitrary caller-provided session ids."""
+        store = UploadStagingStore(ttl_minutes=30, max_size_mb=1)
+
+        with pytest.raises(PermissionError, match="invalid or expired"):
+            store.store("unknown-session", "test.txt", b"data", "text/plain")
+
+    def test_store_accepts_server_issued_session(self):
+        """Test staging accepts sessions created by create_session."""
+        store = UploadStagingStore(ttl_minutes=30, max_size_mb=1)
+        session_id = store.create_session()
+
+        file_id = store.store(session_id, "test.txt", b"data", "text/plain")
+
+        assert store.get(session_id, file_id) is not None
+
+
+class TestAttachmentCacheDownloadTokens:
+    """Tests for short-lived attachment download tokens."""
+
+    @pytest.fixture
+    def attachments_mixin(self, jira_fetcher: JiraFetcher) -> AttachmentsMixin:
+        """Mirror the shared AttachmentsMixin fixture for tests in this class."""
+        attachments_mixin = jira_fetcher
+        attachments_mixin.jira = MagicMock()
+        attachments_mixin.jira._session = MagicMock()
+        return attachments_mixin
+
+    def test_create_download_token_requires_cached_attachment(self):
+        """Test a download URL cannot be created for an uncached attachment."""
+        cache = AttachmentCache(ttl_minutes=10, max_size_mb=1)
+
+        with pytest.raises(ValueError, match="is not cached"):
+            cache.create_download_token("PROJ-1", "missing.txt")
+
+    def test_download_token_resolves_cached_attachment(self):
+        """Test a valid download token resolves to the cached attachment content."""
+        cache = AttachmentCache(ttl_minutes=10, max_size_mb=1)
+        cache.store(
+            issue_key="PROJ-1",
+            filename="report.pdf",
+            content=b"pdf-bytes",
+            mime_type="application/pdf",
+        )
+
+        token_info = cache.create_download_token("PROJ-1", "report.pdf", ttl_minutes=5)
+        attachment = cache.get_by_download_token(token_info["token"])
+
+        assert attachment is not None
+        assert attachment["content"] == b"pdf-bytes"
+        assert attachment["mime_type"] == "application/pdf"
+
+    def test_clear_revokes_download_tokens(self):
+        """Test clearing the cache invalidates outstanding download tokens."""
+        cache = AttachmentCache(ttl_minutes=10, max_size_mb=1)
+        cache.store(
+            issue_key="PROJ-1",
+            filename="report.pdf",
+            content=b"pdf-bytes",
+            mime_type="application/pdf",
+        )
+        token_info = cache.create_download_token("PROJ-1", "report.pdf", ttl_minutes=5)
+
+        cache.clear()
+
+        assert cache.get_by_download_token(token_info["token"]) is None
 
     # Tests for upload_attachment method
 

--- a/tests/unit/servers/test_bitbucket_server.py
+++ b/tests/unit/servers/test_bitbucket_server.py
@@ -259,6 +259,38 @@ success_cases.extend(
                 "pull_request_id": 5,
             },
         },
+        {
+            "func": "add_pull_request_inline_comment",
+            "method": "add_pull_request_inline_comment",
+            "return_value": {
+                "id": 99,
+                "text": "inline",
+                "inline": {"path": "src/main.py", "to": 42},
+            },
+            "kwargs": {
+                "workspace": "ws",
+                "repository": "rep",
+                "pull_request_id": 7,
+                "comment": "inline note",
+                "file_path": "src/main.py",
+                "line": 42,
+                "line_type": "ADDED",
+            },
+            "expected": {
+                "success": True,
+                "comment": {
+                    "id": 99,
+                    "text": "inline",
+                    "inline": {"path": "src/main.py", "to": 42},
+                },
+                "pull_request_id": 7,
+                "requested_file_path": "src/main.py",
+                "requested_line": 42,
+                "anchored": True,
+                "file_path": "src/main.py",
+                "line": 42,
+            },
+        },
     ]
 )
 

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -57,9 +57,12 @@ def mock_jira_fetcher():
         {"author": {"displayName": "Test User"}, "timeSpent": "1h"}
     ]
     mock_fetcher.download_issue_attachments.return_value = {
-        "issue": "TEST-123",
-        "target_dir": "/tmp/downloads",
-        "downloaded": 2,
+        "issue_key": "TEST-123",
+        "downloaded": [
+            {"filename": "test-1.txt", "path": "/tmp/downloads/test-1.txt"},
+            {"filename": "test-2.txt", "path": "/tmp/downloads/test-2.txt"},
+        ],
+        "failed": [],
     }
 
     board_mock = MagicMock()
@@ -429,6 +432,7 @@ class DirectJiraToolCaller:
             batch_create_issues,
             batch_create_versions,
             batch_get_changelogs,
+            construct_download_endpoint,
             create_issue,
             create_issue_link,
             create_remote_issue_link,
@@ -481,6 +485,7 @@ class DirectJiraToolCaller:
             "jira_batch_get_changelogs": batch_get_changelogs.fn,
             "jira_get_project_versions": get_project_versions.fn,
             "jira_get_all_projects": get_all_projects.fn,
+            "jira_construct_download_endpoint": construct_download_endpoint.fn,
             "jira_create_issue": create_issue.fn,
             "jira_batch_create_issues": batch_create_issues.fn,
             "jira_update_issue": update_issue.fn,
@@ -672,10 +677,120 @@ async def test_download_attachments_tool(jira_client, mock_jira_fetcher):
         {"issue_key": "PROJ-1", "target_dir": "/tmp/downloads"},
     )
     mock_jira_fetcher.download_issue_attachments.assert_called_once_with(
-        issue_key="PROJ-1", target_dir="/tmp/downloads"
+        issue_key="PROJ-1", target_dir="/tmp/downloads", return_content=False
     )
     payload = json.loads(response.content[0].text)
-    assert payload["downloaded"] == 2
+    assert len(payload["downloaded"]) == 2
+
+
+@pytest.mark.anyio
+async def test_download_attachments_tool_returns_resources_by_default(
+    jira_client, mock_jira_fetcher
+):
+    """Test jira_download_attachments defaults to resource caching without target_dir."""
+    mock_jira_fetcher.download_issue_attachments.return_value = {
+        "issue_key": "PROJ-1",
+        "downloaded": [
+            {
+                "filename": "test-1.txt",
+                "static_resource_uri": "jira://attachments/PROJ-1/test-1.txt",
+            }
+        ],
+        "failed": [],
+    }
+
+    with patch(
+        "mcp_atlassian.servers.jira._register_static_attachment_resource"
+    ) as mock_register:
+        response = await jira_client.call_tool(
+            "jira_download_attachments",
+            {"issue_key": "PROJ-1"},
+        )
+
+    mock_jira_fetcher.download_issue_attachments.assert_called_with(
+        issue_key="PROJ-1", target_dir="", return_content=True
+    )
+    mock_register.assert_called_once_with("PROJ-1", "test-1.txt")
+    payload = json.loads(response.content[0].text)
+    assert payload["downloaded"][0]["filename"] == "test-1.txt"
+
+
+@pytest.mark.anyio
+async def test_construct_download_endpoint_tool():
+    """Test jira_construct_download_endpoint returns a short-lived HTTP URL."""
+    from mcp_atlassian.servers.jira import construct_download_endpoint
+
+    mock_context = MagicMock()
+    cache = MagicMock()
+    cache.create_download_token.return_value = {
+        "token": "download-token",
+        "expires_at": "2026-04-10T00:00:00+00:00",
+        "issue_key": "PROJ-1",
+        "filename": "report.pdf",
+        "mime_type": "application/pdf",
+    }
+
+    class IsoDate:
+        def isoformat(self) -> str:
+            return "2026-04-10T00:00:00+00:00"
+
+    cache.create_download_token.return_value["expires_at"] = IsoDate()
+
+    with (
+        patch("mcp_atlassian.servers.jira.get_attachment_cache", return_value=cache),
+        patch(
+            "mcp_atlassian.servers.jira._get_external_base_url",
+            return_value="http://localhost:8932",
+        ),
+    ):
+        response = await construct_download_endpoint.fn(
+            mock_context,
+            issue_key="PROJ-1",
+            filename="report.pdf",
+            ttl_minutes=5,
+        )
+
+    payload = json.loads(response)
+    assert payload["download_url"] == "http://localhost:8932/download/download-token"
+    assert payload["filename"] == "report.pdf"
+    cache.create_download_token.assert_called_once_with(
+        issue_key="PROJ-1",
+        filename="report.pdf",
+        ttl_minutes=5,
+    )
+
+
+def test_attachment_cache_clear_deregisters_static_resources(monkeypatch):
+    """Test cached attachment cleanup removes static resource registrations."""
+    from mcp_atlassian.servers import jira as jira_server
+
+    class DummyResourceManager:
+        def __init__(self) -> None:
+            self._resources = {}
+
+        def add_resource(self, resource) -> None:
+            self._resources[str(resource.uri)] = resource
+
+    cache = jira_server.get_attachment_cache()
+    cache.clear()
+
+    resource_manager = DummyResourceManager()
+    monkeypatch.setattr(jira_server.jira_mcp, "_resource_manager", resource_manager)
+
+    cache.store(
+        issue_key="PROJ-1",
+        filename="test-1.txt",
+        content=b"hello",
+        mime_type="text/plain",
+    )
+    jira_server._register_static_attachment_resource("PROJ-1", "test-1.txt")
+
+    uri = jira_server._make_attachment_resource_uri("PROJ-1", "test-1.txt")
+    assert uri in resource_manager._resources
+
+    cache.clear()
+
+    assert uri not in resource_manager._resources
 
 
 @pytest.mark.anyio

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -7,7 +7,12 @@ import pytest
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from mcp_atlassian.servers.main import UserTokenMiddleware, main_mcp
+from mcp_atlassian.servers.main import (
+    UserTokenMiddleware,
+    download_endpoint,
+    main_mcp,
+    upload_endpoint,
+)
 
 
 @pytest.mark.anyio
@@ -90,6 +95,62 @@ async def test_streamable_http_app_health_check_endpoint():
         response = await client.get("/healthz")
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.anyio
+async def test_upload_endpoint_rejects_invalid_session():
+    """Test the upload endpoint rejects session ids that were not issued by the server."""
+    request = MagicMock(spec=Request)
+    request.headers = {"mcp-session-id": "invalid-session"}
+    request.form = AsyncMock()
+
+    staging = MagicMock()
+    staging.is_valid_session.return_value = False
+
+    with patch("mcp_atlassian.servers.main.get_upload_staging", return_value=staging):
+        response = await upload_endpoint(request)
+
+    assert response.status_code == 403
+    assert b"Invalid or expired upload session" in response.body
+    request.form.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_download_endpoint_rejects_invalid_token():
+    """Test the download endpoint rejects missing or expired download tokens."""
+    request = MagicMock(spec=Request)
+    request.path_params = {"token": "invalid-token"}
+
+    cache = MagicMock()
+    cache.get_by_download_token.return_value = None
+
+    with patch("mcp_atlassian.servers.main.get_attachment_cache", return_value=cache):
+        response = await download_endpoint(request)
+
+    assert response.status_code == 403
+    assert b"Invalid or expired download token" in response.body
+
+
+@pytest.mark.anyio
+async def test_download_endpoint_serves_cached_attachment():
+    """Test the download endpoint returns cached attachment bytes and headers."""
+    request = MagicMock(spec=Request)
+    request.path_params = {"token": "valid-token"}
+
+    cache = MagicMock()
+    cache.get_by_download_token.return_value = {
+        "filename": "report 1.pdf",
+        "mime_type": "application/pdf",
+        "content": b"pdf-bytes",
+    }
+
+    with patch("mcp_atlassian.servers.main.get_attachment_cache", return_value=cache):
+        response = await download_endpoint(request)
+
+    assert response.status_code == 200
+    assert response.body == b"pdf-bytes"
+    assert response.headers["content-type"] == "application/pdf"
+    assert "filename*=UTF-8''report%201.pdf" in response.headers["content-disposition"]
 
 
 class TestUserTokenMiddleware:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #

This PR adds per-product read-only mode control, Bitbucket PR tooling, and Jira file attachment support to the MCP Atlassian server.

<!-- Briefly list the key changes made. -->

- Optional PAT startup — Server starts without credentials; auth can be supplied entirely via per-request HTTP headers
Per-product read-only mode — Independent read-only control for Jira, Confluence, and Bitbucket via CLI flags, env vars, and HTTP headers; product-specific flags override the global flag in both tool listing and [check_write_access](vscode-file://vscode-app/d:/My%20Workspace/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

- Bitbucket PR tools — New tools: [add_pull_request_inline_comment](vscode-file://vscode-app/d:/My%20Workspace/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [analyze_pr_review_status](vscode-file://vscode-app/d:/My%20Workspace/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (with negation-aware keyword detection), and [get_pull_request_diff](vscode-file://vscode-app/d:/My%20Workspace/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

- Jira attachment upload — New jira_upload_attachment tool with streaming 64 KB chunked upload to prevent memory exhaustion and early 413 rejection on oversized files

- Jira attachment download — New jira_download_attachment tool serving cached attachments via short-lived download tokens

- Safe env-var parsing — UPLOAD_STAGING_TTL_MINUTES / UPLOAD_STAGING_MAX_SIZE_MB fall back to defaults on invalid values instead of crashing at startup

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `[briefly describe]`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [ ] All tests pass locally.
- [x] Documentation updated (if needed).
