### PR TITLE
fix: serve both /mcp and /mcp/ without redirect

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -704,6 +704,29 @@ class AtlassianMCP(FastMCP[MainAppContext]):
             Route("/download/{token}", download_endpoint, methods=["GET"])
         )
 
+        # Serve both `/mcp` and `/mcp/` directly. FastMCP registers the
+        # streamable-http handler at a single path (e.g. `/mcp`); without this,
+        # requests to the trailing-slash variant trigger Starlette's
+        # `redirect_slashes`, issuing a 307 that can drop the original scheme
+        # (HTTPS -> HTTP) behind a TLS-terminating proxy and break clients.
+        # Register an explicit alias route for the trailing-slash path that
+        # points at the same ASGI handler so both paths are served identically.
+        mcp_path = (path or settings.streamable_http_path).rstrip("/")
+        if mcp_path:
+            alias_path = f"{mcp_path}/"
+            for route in list(app.router.routes):
+                if isinstance(route, Route) and route.path == mcp_path:
+                    app.router.routes.append(
+                        Route(
+                            alias_path,
+                            route.endpoint,
+                            methods=route.methods,
+                            name=f"{route.name}_slash" if route.name else None,
+                            include_in_schema=False,
+                        )
+                    )
+                    break
+
         return app
 
 

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -97,6 +97,40 @@ async def test_streamable_http_app_health_check_endpoint():
         assert response.json() == {"status": "ok"}
 
 
+@pytest.mark.parametrize("mcp_endpoint", ["/mcp", "/mcp/"])
+def test_streamable_http_app_serves_both_slash_variants(mcp_endpoint):
+    """Both `/mcp` and `/mcp/` must be served directly without a 307 redirect.
+
+    A trailing-slash redirect can drop the original scheme (HTTPS -> HTTP)
+    behind a TLS-terminating proxy, breaking MCP clients, so the server
+    registers an explicit alias route for the trailing-slash path.
+    """
+    from starlette.testclient import TestClient
+
+    app = main_mcp.http_app(path="/mcp", transport="streamable-http")
+    init_request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "1.0"},
+        },
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    # TestClient runs the app lifespan (starts the streamable-http session
+    # manager) and does NOT follow redirects, so a 307 would surface here.
+    with TestClient(app) as client:
+        response = client.post(mcp_endpoint, json=init_request, headers=headers)
+
+    assert response.status_code == 200
+    assert "mcp-session-id" in response.headers
+
+
 @pytest.mark.anyio
 async def test_upload_endpoint_rejects_invalid_session():
     """Test the upload endpoint rejects session ids that were not issued by the server."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

Fixes the bug to support `/mcp` and `/mcp/` routes

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
