### PR TITLE
Introduce the tool to create repo with BB MCP

### DIFF
--- a/src/mcp_atlassian/bitbucket/repositories.py
+++ b/src/mcp_atlassian/bitbucket/repositories.py
@@ -212,3 +212,50 @@ class RepositoriesMixin(BitbucketClient):
             logger.error(error_msg)
             msg = f"Error getting repos: {str(e)}"
             raise Exception(msg) from e
+
+    def create_repository(
+        self,
+        workspace: str,
+        repo_slug: str,
+        is_private: bool = True,
+        forkable: bool = False,
+    ) -> BitbucketRepository:
+        """
+        Create a new repository in a workspace/project.
+
+        Args:
+            workspace: Workspace name (Cloud) or project key (Server/DC)
+            repo_slug: Repository name/slug to create
+            is_private: Whether the repository should be private (default: True)
+            forkable: Whether the repository can be forked (default: False)
+
+        Returns:
+            BitbucketRepository object for the created repository
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails with the Bitbucket API (401/403)
+        """
+        try:
+            repo_data = self.bitbucket.create_repo(
+                workspace, repo_slug, forkable=forkable, is_private=is_private
+            )
+            return BitbucketRepository.from_api_response(repo_data)
+        except HTTPError as http_err:
+            if http_err.response is not None and http_err.response.status_code in [
+                401,
+                403,
+            ]:
+                error_msg = (
+                    f"Authentication failed for Bitbucket API ({http_err.response.status_code}). "
+                    "Token may be expired or invalid. Please verify credentials."
+                )
+                logger.error(error_msg)
+                raise MCPAtlassianAuthenticationError(error_msg) from http_err
+            else:
+                logger.error(f"HTTP error during API call: {http_err}", exc_info=False)
+                raise http_err
+        except Exception as e:
+            error_msg = f"Error creating repository {repo_slug} in {workspace}: {str(e)}"
+            logger.error(error_msg)
+            msg = f"Error creating repository: {str(e)}"
+            raise Exception(msg) from e

--- a/src/mcp_atlassian/servers/bitbucket.py
+++ b/src/mcp_atlassian/servers/bitbucket.py
@@ -163,6 +163,75 @@ async def get_repository_info(
         return json.dumps(error_result, indent=2)
 
 
+@bitbucket_mcp.tool(tags={"bitbucket", "write"})
+@check_write_access
+async def create_repository(
+    ctx: Context,
+    workspace: Annotated[
+        str,
+        Field(description="Workspace name (Cloud) or project key (Server/DC)"),
+    ],
+    repo_slug: Annotated[
+        str,
+        Field(description="Repository name/slug to create"),
+    ],
+    is_private: Annotated[
+        bool,
+        Field(description="Whether the repository should be private"),
+    ] = True,
+    forkable: Annotated[
+        bool,
+        Field(description="Whether the repository can be forked"),
+    ] = False,
+) -> str:
+    """
+    Create a new repository in a workspace/project.
+
+    Args:
+        ctx: The MCP context.
+        workspace: Workspace name (Cloud) or project key (Server/DC).
+        repo_slug: Repository name/slug to create.
+        is_private: Whether the repository should be private (default: True).
+        forkable: Whether the repository can be forked (default: False).
+
+    Returns:
+        JSON string containing the created repository details.
+
+    Raises:
+        ValueError: If the Bitbucket client is not configured or available.
+    """
+    try:
+        bitbucket = await get_bitbucket_fetcher(ctx)
+        repo = bitbucket.create_repository(
+            workspace, repo_slug, is_private=is_private, forkable=forkable
+        )
+        return json.dumps(
+            {
+                "success": True,
+                "repository": repo.model_dump(mode="json", serialize_as_any=True),
+            },
+            indent=2,
+        )
+    except Exception as e:
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            error_message = f"Configuration Error: {str(e)}"
+        else:
+            error_message = f"An unexpected error occurred while creating repository {repo_slug} in {workspace}."
+            logger.exception("Unexpected error in bitbucket_create_repository:")
+
+        error_result = {
+            "success": False,
+            "error": error_message,
+        }
+        logger.log(log_level, f"bitbucket_create_repository failed: {error_message}")
+        return json.dumps(error_result, indent=2)
+
+
 @bitbucket_mcp.tool(tags={"bitbucket", "read"})
 async def list_branches(
     ctx: Context,

--- a/tests/unit/bitbucket/test_repositories.py
+++ b/tests/unit/bitbucket/test_repositories.py
@@ -411,4 +411,117 @@ class TestRepositoriesMixin:
                 assert hasattr(mixin, "get_file_content")
                 assert hasattr(mixin, "get_directory_content")
                 assert hasattr(mixin, "get_repositories")
+                assert hasattr(mixin, "create_repository")
                 assert hasattr(mixin, "config")  # From parent class
+
+
+class TestCreateRepository:
+    """Test cases for RepositoriesMixin.create_repository method."""
+
+    @pytest.fixture
+    def config(self):
+        return BitbucketConfig(
+            url="https://api.bitbucket.org/2.0",
+            auth_type="basic",
+            username="test@example.com",
+            app_password="app_password",
+        )
+
+    @pytest.fixture
+    def repositories_mixin(self, config):
+        with patch("mcp_atlassian.bitbucket.client.Bitbucket"):
+            with patch("mcp_atlassian.bitbucket.client.configure_ssl_verification"):
+                mixin = RepositoriesMixin(config)
+                mixin.bitbucket = MagicMock()
+                return mixin
+
+    @pytest.fixture
+    def sample_created_repo_data(self):
+        return {
+            "slug": "new-repo",
+            "name": "new-repo",
+            "description": "",
+            "state": "AVAILABLE",
+            "forkable": False,
+            "public": False,
+            "project": {"key": "TEST"},
+            "links": {},
+        }
+
+    def test_create_repository_success(
+        self, repositories_mixin, sample_created_repo_data
+    ):
+        """Test successful repository creation."""
+        repositories_mixin.bitbucket.create_repo.return_value = sample_created_repo_data
+
+        with patch.object(
+            BitbucketRepository, "from_api_response", return_value=MagicMock(spec=BitbucketRepository)
+        ) as mock_from_api:
+            result = repositories_mixin.create_repository("TEST", "new-repo")
+
+            assert isinstance(result, MagicMock)
+            repositories_mixin.bitbucket.create_repo.assert_called_once_with(
+                "TEST", "new-repo", forkable=False, is_private=True
+            )
+            mock_from_api.assert_called_once_with(sample_created_repo_data)
+
+    def test_create_repository_custom_flags(
+        self, repositories_mixin, sample_created_repo_data
+    ):
+        """Test repository creation with custom is_private and forkable flags."""
+        repositories_mixin.bitbucket.create_repo.return_value = sample_created_repo_data
+
+        with patch.object(BitbucketRepository, "from_api_response", return_value=MagicMock(spec=BitbucketRepository)):
+            repositories_mixin.create_repository(
+                "TEST", "public-repo", is_private=False, forkable=True
+            )
+
+            repositories_mixin.bitbucket.create_repo.assert_called_once_with(
+                "TEST", "public-repo", forkable=True, is_private=False
+            )
+
+    def test_create_repository_http_401_error(self, repositories_mixin):
+        """Test handling of 401 HTTP error in create_repository."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        http_error = HTTPError()
+        http_error.response = mock_response
+        repositories_mixin.bitbucket.create_repo.side_effect = http_error
+
+        with pytest.raises(
+            MCPAtlassianAuthenticationError,
+            match="Authentication failed for Bitbucket API \\(401\\)",
+        ):
+            repositories_mixin.create_repository("TEST", "new-repo")
+
+    def test_create_repository_http_403_error(self, repositories_mixin):
+        """Test handling of 403 HTTP error in create_repository."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        http_error = HTTPError()
+        http_error.response = mock_response
+        repositories_mixin.bitbucket.create_repo.side_effect = http_error
+
+        with pytest.raises(
+            MCPAtlassianAuthenticationError,
+            match="Authentication failed for Bitbucket API \\(403\\)",
+        ):
+            repositories_mixin.create_repository("TEST", "new-repo")
+
+    def test_create_repository_http_409_conflict(self, repositories_mixin):
+        """Test handling of 409 conflict (repo already exists) in create_repository."""
+        mock_response = MagicMock()
+        mock_response.status_code = 409
+        http_error = HTTPError()
+        http_error.response = mock_response
+        repositories_mixin.bitbucket.create_repo.side_effect = http_error
+
+        with pytest.raises(HTTPError):
+            repositories_mixin.create_repository("TEST", "existing-repo")
+
+    def test_create_repository_general_exception(self, repositories_mixin):
+        """Test handling of general exceptions in create_repository."""
+        repositories_mixin.bitbucket.create_repo.side_effect = Exception("Network error")
+
+        with pytest.raises(Exception, match="Error creating repository: Network error"):
+            repositories_mixin.create_repository("TEST", "new-repo")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Adds a `create_repository` tool to the Bitbucket MCP integration, allowing AI agents to programmatically create new repositories in Bitbucket Server/Data Center (and Cloud) workspaces/projects.

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

- Added `create_repository(workspace, repo_slug, is_private, forkable)` method to `RepositoriesMixin` in `src/mcp_atlassian/bitbucket/repositories.py`, delegating to the underlying `atlassian-python-api` `create_repo()` call with full auth-error and generic-error handling
- Registered `bitbucket_create_repository` as a write-tagged MCP tool in `src/mcp_atlassian/servers/bitbucket.py` with `@check_write_access` guard and parameters: `workspace`, `repo_slug`, `is_private` (default `True`), `forkable` (default `False`)
- Added `TestCreateRepository` test class with 6 unit tests covering: successful creation, custom `is_private`/`forkable` flags, 401/403 auth errors, 409 conflict, and general exceptions

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: server started locally with 67 tools discovered; `bitbucket_create_repository` tool visible and callable via MCP client

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally (`28 passed` in `test_repositories.py`).
- [ ] Documentation updated (if needed).