### PR TITLE
xrey test result publish

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -365,7 +365,7 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
 class AtlassianMCP(FastMCP[MainAppContext]):
     """Custom FastMCP server class for Atlassian integration with tool filtering."""
 
-    async def _mcp_list_tools(self) -> list[MCPTool]:
+    async def _list_tools_mcp(self) -> list[MCPTool]:
         # Filter tools based on enabled_tools, read_only mode, and service configuration
         # from the lifespan context.
         req_context = self._mcp_server.request_context
@@ -433,6 +433,12 @@ class AtlassianMCP(FastMCP[MainAppContext]):
                 logger.debug(
                     f"Header-based service availability: {header_based_services}"
                 )
+
+        # Fall back to env var when running in stdio mode (no HTTP request headers)
+        if enable_xray_header is None:
+            env_xray = os.environ.get("X-Atlassian-Enable-Xray", "").strip().lower()
+            if env_xray:
+                enable_xray_header = env_xray
 
         # When no service-identifying headers are present, list all tools so clients
         # can discover the full tool catalogue without needing to provide URLs upfront.
@@ -674,6 +680,10 @@ class AtlassianMCP(FastMCP[MainAppContext]):
             f"_main_mcp_list_tools: Total tools after filtering: {len(filtered_tools)}"
         )
         return filtered_tools
+
+    async def _mcp_list_tools(self) -> list[MCPTool]:
+        """Backward-compatible alias for tests and older FastMCP versions."""
+        return await self._list_tools_mcp()
 
     def http_app(
         self,

--- a/src/mcp_atlassian/servers/xray.py
+++ b/src/mcp_atlassian/servers/xray.py
@@ -6,6 +6,7 @@ from typing import Annotated
 
 from fastmcp import Context, FastMCP
 from pydantic import Field
+from requests.exceptions import HTTPError
 
 from mcp_atlassian.servers.dependencies import get_xray_fetcher
 from mcp_atlassian.utils.decorators import check_write_access
@@ -213,27 +214,51 @@ async def get_test_executions(
     test_key: Annotated[
         str,
         Field(
-            description="The test key to retrieve test executions for (e.g., 'TEST-001')"
+            description=(
+                "The issue key of a Test issue to retrieve its associated test executions "
+                "(e.g., 'TEST-001'). NOTE: this must be a Test issue, NOT a Test Execution "
+                "issue. To get results inside a Test Execution, use get_test_execution_results."
+            )
         ),
     ],
 ) -> str:
     """
     Retrieve test executions of a test.
 
+    This tool requires ``test_key`` to be a **Test** issue (Xray issue type
+    ``Test``).  If you pass a Test Execution key you will receive a 400 error
+    from the Xray API.  To inspect the results *within* a Test Execution, use
+    ``get_test_execution_results`` instead.
+
     Args:
         ctx: The FastMCP context.
-        test_key: The test key to retrieve test executions for.
+        test_key: The key of a Test issue whose executions should be listed.
 
     Returns:
         JSON string representing the test executions.
 
     Raises:
-        ValueError: If the Xray client is not configured or available.
+        ValueError: If the Xray client is not configured, or if the supplied
+            key does not belong to a Test issue.
     """
     xray = await get_xray_fetcher(ctx)
     try:
         result = xray.xray.get_test_executions(test_key)
         return json.dumps(result, indent=2, default=str)
+    except HTTPError as e:
+        if e.response is not None and e.response.status_code == 400:
+            msg = (
+                f"400 Bad Request for '{test_key}': the Xray API rejected this key. "
+                f"'{test_key}' is likely a Test Execution issue, not a Test issue. "
+                f"To get the test results inside a Test Execution, call "
+                f"'get_test_execution_results' with execution_key='{test_key}'. "
+                f"To get evidences, call 'get_test_execution_evidences' with "
+                f"execution_key='{test_key}'."
+            )
+            logger.error(msg)
+            raise ValueError(msg) from e
+        logger.error(f"Error retrieving test executions for {test_key}: {e}")
+        raise
     except Exception as e:
         logger.error(f"Error retrieving test executions for {test_key}: {e}")
         raise
@@ -1901,8 +1926,17 @@ async def download_test_run_evidence(
     target_path: Annotated[
         str | None,
         Field(
-            description="Optional filesystem path to save the file (e.g., '/tmp/screenshot.png'). "
+            description="Optional filesystem path to save the file (e.g., 'C:/Downloads/screenshot.png'). "
             "When omitted the file content is returned as a Base64 string.",
+            default=None,
+        ),
+    ] = None,
+    file_url: Annotated[
+        str | None,
+        Field(
+            description="Optional direct download URL for the evidence file "
+            "(the 'fileURL' field from get_test_execution_evidences or get_test_run_evidences). "
+            "Provide this to bypass the Xray attachment endpoint when it returns a 500 error.",
             default=None,
         ),
     ] = None,
@@ -1914,16 +1948,24 @@ async def download_test_run_evidence(
     either be saved directly to disk (when ``target_path`` is provided) or
     returned as a Base64-encoded string suitable for further processing.
 
+    If the Xray attachment endpoint returns a 500 error (a known server-side
+    bug in some Xray versions), the tool automatically falls back to the
+    ``fileURL`` from the evidence metadata. You can also supply ``file_url``
+    directly (from ``get_test_execution_evidences``) to skip the broken
+    endpoint entirely.
+
     Args:
         ctx: The FastMCP context.
         test_run_id: The numeric test run ID.
         attachment_id: The numeric evidence attachment ID (from ``get_test_run_evidences``).
         target_path: Optional path to save the file on disk.
+        file_url: Optional direct URL for the evidence file (bypasses the Xray endpoint).
 
     Returns:
         JSON object with ``attachment_id``, ``run_id``, ``file_name``,
         ``content_type``, ``size_bytes``, ``saved_to`` (path if saved),
-        and ``content_base64`` (Base64 content if not saved to disk).
+        ``content_base64`` (Base64 content if not saved to disk), and
+        ``fallback_used`` (``true`` when the fileURL fallback was used).
 
     Raises:
         ValueError: If the Xray client is not configured or available.
@@ -1934,6 +1976,7 @@ async def download_test_run_evidence(
             test_run_id=test_run_id,
             attachment_id=attachment_id,
             target_path=target_path,
+            file_url=file_url,
         )
         return json.dumps(result, indent=2, default=str)
     except Exception as e:

--- a/src/mcp_atlassian/servers/xray.py
+++ b/src/mcp_atlassian/servers/xray.py
@@ -1601,3 +1601,343 @@ async def get_test_run_steps(
     except Exception as e:
         logger.error(f"Error retrieving steps for test run {test_run_id}: {e}")
         raise
+
+
+# Test Results Tools
+
+
+@xray_mcp.tool(tags={"xray", "read"})
+async def get_test_runs_in_context(
+    ctx: Context,
+    test_exec_key: Annotated[
+        str | None,
+        Field(
+            description="The test execution key to retrieve runs from (e.g., 'EXEC-001')",
+            default=None,
+        ),
+    ] = None,
+    test_key: Annotated[
+        str | None,
+        Field(
+            description="Filter by a specific test key within the execution (e.g., 'TEST-001'). "
+            "Only valid when test_exec_key is also provided.",
+            default=None,
+        ),
+    ] = None,
+    test_plan_key: Annotated[
+        str | None,
+        Field(
+            description="The test plan key to retrieve runs from (e.g., 'PLAN-001')",
+            default=None,
+        ),
+    ] = None,
+    saved_filter_id: Annotated[
+        str | None,
+        Field(
+            description="A Jira JQL filter ID or name that returns test execution issues",
+            default=None,
+        ),
+    ] = None,
+    include_test_fields: Annotated[
+        str | None,
+        Field(
+            description="Comma-separated list of custom test-issue fields to include in the response",
+            default=None,
+        ),
+    ] = None,
+    page: Annotated[
+        int,
+        Field(description="Page number for pagination (default: 1)", default=1),
+    ] = 1,
+    limit: Annotated[
+        int,
+        Field(
+            description="Maximum number of test runs to return (default: 50)",
+            default=50,
+        ),
+    ] = 50,
+) -> str:
+    """
+    Retrieve all test runs (with their results) from a given context.
+
+    Supports three mutually exclusive contexts:
+    - A specific test execution (test_exec_key), optionally narrowed to one test.
+    - A test plan (test_plan_key).
+    - A saved JQL filter returning test execution issues (saved_filter_id).
+
+    Each returned test run includes its result status, steps summary, defects,
+    and other execution metadata.
+
+    Args:
+        ctx: The FastMCP context.
+        test_exec_key: Optional test execution key.
+        test_key: Optional test key (only with test_exec_key).
+        test_plan_key: Optional test plan key.
+        saved_filter_id: Optional saved JQL filter ID or name.
+        include_test_fields: Optional comma-separated custom field names.
+        page: Page number for pagination.
+        limit: Maximum number of results per page.
+
+    Returns:
+        JSON string representing the test runs with result data.
+
+    Raises:
+        ValueError: If the Xray client is not configured or available.
+    """
+    xray = await get_xray_fetcher(ctx)
+    try:
+        result = xray.xray.get_test_runs_in_context(
+            test_exec_key=test_exec_key,
+            test_key=test_key,
+            test_plan_key=test_plan_key,
+            include_test_fields=include_test_fields,
+            saved_filter_id=saved_filter_id,
+            limit=limit,
+            page=page,
+        )
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Error retrieving test runs in context: {e}")
+        raise
+
+
+@xray_mcp.tool(tags={"xray", "read"})
+async def get_test_execution_results(
+    ctx: Context,
+    execution_key: Annotated[
+        str,
+        Field(
+            description="The test execution key to retrieve results for (e.g., 'EXEC-001')"
+        ),
+    ],
+    page: Annotated[
+        int,
+        Field(description="Page number for pagination (default: 1)", default=1),
+    ] = 1,
+    limit: Annotated[
+        int,
+        Field(
+            description="Maximum number of results per page (default: 50)", default=50
+        ),
+    ] = 50,
+) -> str:
+    """
+    Retrieve enriched test results for a test execution.
+
+    Returns each test in the execution with its run status, assignee, linked
+    defects, run ID, start time, and comment in a structured summary format.
+
+    Args:
+        ctx: The FastMCP context.
+        execution_key: The test execution key.
+        page: Page number for pagination.
+        limit: Maximum number of results per page.
+
+    Returns:
+        JSON string with execution_key, page, limit, total count, and a
+        ``results`` list where each entry contains test_key, run_id, status,
+        assignee, defects, started_on, and comment.
+
+    Raises:
+        ValueError: If the Xray client is not configured or available.
+    """
+    xray = await get_xray_fetcher(ctx)
+    try:
+        result = xray.get_test_execution_results(
+            execution_key=execution_key,
+            page=page,
+            limit=limit,
+        )
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(
+            f"Error retrieving test results for execution {execution_key}: {e}"
+        )
+        raise
+
+
+@xray_mcp.tool(tags={"xray", "read"})
+async def get_test_run_full_results(
+    ctx: Context,
+    test_run_id: Annotated[
+        int,
+        Field(description="The numeric ID of the test run"),
+    ],
+) -> str:
+    """
+    Retrieve comprehensive results for a single test run.
+
+    Aggregates the overall status, assignee, comment, linked defects, and
+    step-level results into one structured response. Useful for a deep-dive
+    view of how a specific test was executed.
+
+    Args:
+        ctx: The FastMCP context.
+        test_run_id: The numeric test run ID.
+
+    Returns:
+        JSON string containing run_id, status, assignee, comment, defects,
+        steps (with per-step status and actual results), and the full raw
+        details object from the Xray API.
+
+    Raises:
+        ValueError: If the Xray client is not configured or available.
+    """
+    xray = await get_xray_fetcher(ctx)
+    try:
+        result = xray.get_test_run_full_results(test_run_id=test_run_id)
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Error retrieving full results for test run {test_run_id}: {e}")
+        raise
+
+
+# Evidence / Attachment Tools
+
+
+@xray_mcp.tool(tags={"xray", "read"})
+async def get_test_run_evidences(
+    ctx: Context,
+    test_run_id: Annotated[
+        int,
+        Field(description="The numeric ID of the test run"),
+    ],
+) -> str:
+    """
+    List all evidence (attachment) metadata for a test run.
+
+    Returns the file name, size, content type, URL, and creation date for
+    every evidence file attached to the specified test run. Use this to
+    discover available attachments before downloading them.
+
+    Args:
+        ctx: The FastMCP context.
+        test_run_id: The numeric test run ID.
+
+    Returns:
+        JSON array of evidence objects. Each object contains:
+        ``id``, ``fileName``, ``fileSize``, ``fileURL``,
+        ``contentType``, and ``created``.
+
+    Raises:
+        ValueError: If the Xray client is not configured or available.
+    """
+    xray = await get_xray_fetcher(ctx)
+    try:
+        result = xray.get_test_run_evidences(test_run_id=test_run_id)
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Error retrieving evidences for test run {test_run_id}: {e}")
+        raise
+
+
+@xray_mcp.tool(tags={"xray", "read"})
+async def get_test_execution_evidences(
+    ctx: Context,
+    execution_key: Annotated[
+        str,
+        Field(
+            description="The test execution key to retrieve evidences for (e.g., 'EXEC-001')"
+        ),
+    ],
+    page: Annotated[
+        int,
+        Field(description="Page number for pagination (default: 1)", default=1),
+    ] = 1,
+    limit: Annotated[
+        int,
+        Field(
+            description="Maximum number of test runs to inspect per page (default: 50)",
+            default=50,
+        ),
+    ] = 50,
+) -> str:
+    """
+    Retrieve all evidence attachments across every test run in a test execution.
+
+    Iterates over every test run in the given execution and collects the
+    evidence metadata (file name, size, URL, etc.) from each run into a
+    single aggregated response. Useful for auditing all attachments produced
+    during an execution cycle.
+
+    Args:
+        ctx: The FastMCP context.
+        execution_key: The test execution key.
+        page: Page number for pagination.
+        limit: Maximum number of test runs to inspect per page.
+
+    Returns:
+        JSON object with ``execution_key``, ``total_runs``,
+        ``total_evidences``, and ``evidences`` — a list where each entry
+        contains ``run_id``, ``test_key``, and ``attachments``.
+
+    Raises:
+        ValueError: If the Xray client is not configured or available.
+    """
+    xray = await get_xray_fetcher(ctx)
+    try:
+        result = xray.get_test_execution_evidences(
+            execution_key=execution_key,
+            page=page,
+            limit=limit,
+        )
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(f"Error retrieving evidences for execution {execution_key}: {e}")
+        raise
+
+
+@xray_mcp.tool(tags={"xray", "read"})
+async def download_test_run_evidence(
+    ctx: Context,
+    test_run_id: Annotated[
+        int,
+        Field(description="The numeric ID of the test run"),
+    ],
+    attachment_id: Annotated[
+        int,
+        Field(description="The numeric ID of the evidence attachment"),
+    ],
+    target_path: Annotated[
+        str | None,
+        Field(
+            description="Optional filesystem path to save the file (e.g., '/tmp/screenshot.png'). "
+            "When omitted the file content is returned as a Base64 string.",
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """
+    Download a specific evidence file from a test run.
+
+    Fetches the raw binary content of the evidence attachment. The file can
+    either be saved directly to disk (when ``target_path`` is provided) or
+    returned as a Base64-encoded string suitable for further processing.
+
+    Args:
+        ctx: The FastMCP context.
+        test_run_id: The numeric test run ID.
+        attachment_id: The numeric evidence attachment ID (from ``get_test_run_evidences``).
+        target_path: Optional path to save the file on disk.
+
+    Returns:
+        JSON object with ``attachment_id``, ``run_id``, ``file_name``,
+        ``content_type``, ``size_bytes``, ``saved_to`` (path if saved),
+        and ``content_base64`` (Base64 content if not saved to disk).
+
+    Raises:
+        ValueError: If the Xray client is not configured or available.
+    """
+    xray = await get_xray_fetcher(ctx)
+    try:
+        result = xray.download_test_run_evidence(
+            test_run_id=test_run_id,
+            attachment_id=attachment_id,
+            target_path=target_path,
+        )
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(
+            f"Error downloading evidence {attachment_id} from test run {test_run_id}: {e}"
+        )
+        raise

--- a/src/mcp_atlassian/xray/__init__.py
+++ b/src/mcp_atlassian/xray/__init__.py
@@ -4,10 +4,12 @@ from atlassian.xray import Xray
 
 from .client import XrayClient
 from .config import XrayConfig
+from .results import MixTestResults
 from .user import MixUsers
 
 
 class XrayFetcher(
+    MixTestResults,
     MixUsers,
     XrayClient,
 ):
@@ -26,6 +28,7 @@ __all__ = [
     "XrayClient",
     "XrayConfig",
     "XrayFetcher",
+    "MixTestResults",
     "MixUsers",
     "Xray",
 ]

--- a/src/mcp_atlassian/xray/results.py
+++ b/src/mcp_atlassian/xray/results.py
@@ -192,22 +192,52 @@ class MixTestResults(XrayClient):
             "evidences": evidence_rows,
         }
 
+    def _resolve_evidence_file_url(
+        self, test_run_id: int, attachment_id: int
+    ) -> str | None:
+        """Look up the direct ``fileURL`` for an evidence attachment.
+
+        Fetches the evidence list for *test_run_id* and returns the ``fileURL``
+        of the entry whose ``id`` matches *attachment_id*, or ``None`` if not
+        found.
+        """
+        try:
+            evidences = self.get_test_run_evidences(test_run_id)
+            for ev in evidences:
+                if str(ev.get("id")) == str(attachment_id):
+                    return ev.get("fileURL") or ev.get("fileUrl")
+        except Exception as lookup_err:
+            logger.warning(
+                "Could not look up fileURL for attachment %s on run %s: %s",
+                attachment_id,
+                test_run_id,
+                lookup_err,
+            )
+        return None
+
     def download_test_run_evidence(
         self,
         test_run_id: int,
         attachment_id: int,
         target_path: str | None = None,
+        file_url: str | None = None,
     ) -> dict[str, Any]:
         """Download a specific evidence file from a test run.
 
-        Fetches the raw file bytes using the Xray session and either saves
-        the file to *target_path* or returns the content as a Base64 string.
+        Attempts the Xray ``testrun/{id}/attachment/{attachment_id}`` endpoint
+        first.  If the server returns a 5xx error (a known Xray server-side
+        bug), the method automatically falls back to downloading via the
+        ``fileURL`` stored in the evidence metadata (a standard Jira attachment
+        URL that requires only the PAT token, which is already in the session).
 
         Args:
             test_run_id: The numeric ID of the test run.
             attachment_id: The numeric ID of the evidence attachment.
             target_path: Optional filesystem path to save the file. When
                 ``None`` (default) the content is returned Base64-encoded.
+            file_url: Optional direct download URL for the evidence file
+                (e.g. from ``get_test_execution_evidences``).  When provided
+                this URL is used directly, skipping the Xray endpoint entirely.
 
         Returns:
             dict containing:
@@ -220,12 +250,42 @@ class MixTestResults(XrayClient):
                 - saved_to: Absolute path if saved to disk, else ``None``.
                 - content_base64: Base64-encoded file content when *target_path*
                   is ``None``, else ``None``.
+                - fallback_used: ``True`` when the Xray endpoint failed and the
+                  ``fileURL`` fallback was used.
         """
-        url = self.xray.resource_url(
-            f"testrun/{test_run_id}/attachment/{attachment_id}"
-        )
-        response = self.xray._session.get(f"{self.xray.url}/{url}", stream=True)
-        response.raise_for_status()
+        fallback_used = False
+
+        if file_url:
+            # Caller supplied a direct URL — use it straight away.
+            fallback_used = True
+            response = self.xray._session.get(file_url, stream=True)
+            response.raise_for_status()
+        else:
+            xray_url = self.xray.resource_url(
+                f"testrun/{test_run_id}/attachment/{attachment_id}"
+            )
+            response = self.xray._session.get(
+                f"{self.xray.url}/{xray_url}", stream=True
+            )
+
+            if response.status_code >= 500:
+                logger.warning(
+                    "Xray attachment endpoint returned %s for run %s / attachment %s; "
+                    "falling back to fileURL lookup.",
+                    response.status_code,
+                    test_run_id,
+                    attachment_id,
+                )
+                resolved_url = self._resolve_evidence_file_url(
+                    test_run_id, attachment_id
+                )
+                if not resolved_url:
+                    response.raise_for_status()  # re-raise the original 5xx
+                fallback_used = True
+                response = self.xray._session.get(resolved_url, stream=True)
+                response.raise_for_status()
+            else:
+                response.raise_for_status()
 
         content = response.content
         content_type = response.headers.get("Content-Type", "application/octet-stream")
@@ -266,4 +326,5 @@ class MixTestResults(XrayClient):
             "size_bytes": len(content),
             "saved_to": saved_to,
             "content_base64": content_base64,
+            "fallback_used": fallback_used,
         }

--- a/src/mcp_atlassian/xray/results.py
+++ b/src/mcp_atlassian/xray/results.py
@@ -1,0 +1,269 @@
+"""Test results mixin for Xray API interactions."""
+
+import base64
+import logging
+import os
+from typing import Any
+
+from .client import XrayClient
+
+logger = logging.getLogger(__name__)
+
+
+class MixTestResults(XrayClient):
+    """Mixin for Xray test result retrieval operations."""
+
+    def get_test_execution_results(
+        self,
+        execution_key: str,
+        page: int = 1,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        """Retrieve enriched test results for a test execution.
+
+        Fetches all tests in the execution with their detailed run information
+        (status, assignee, defects, run ID) in a single structured response.
+
+        Args:
+            execution_key: The test execution issue key (e.g., 'EXEC-001').
+            page: Page number for pagination (1-based).
+            limit: Maximum number of results per page.
+
+        Returns:
+            dict containing:
+                - execution_key: The execution key provided.
+                - page: Current page number.
+                - limit: Page size.
+                - total: Number of results returned.
+                - results: List of test result dicts with keys
+                  ``test_key``, ``run_id``, ``status``, ``assignee``,
+                  ``defects``, ``started_on``, ``comment``.
+        """
+        raw = self.xray.get_tests_with_test_execution(
+            execution_key,
+            detailed=True,
+            page=page,
+            limit=limit,
+        )
+
+        tests: list[Any] = raw if isinstance(raw, list) else []
+        results: list[dict[str, Any]] = []
+        for test in tests:
+            results.append(
+                {
+                    "test_key": test.get("key") or test.get("testKey"),
+                    "run_id": test.get("id"),
+                    "status": test.get("status"),
+                    "assignee": test.get("assignee"),
+                    "defects": test.get("defects", []),
+                    "started_on": test.get("startedOn") or test.get("startedOnIso"),
+                    "comment": test.get("comment"),
+                }
+            )
+
+        return {
+            "execution_key": execution_key,
+            "page": page,
+            "limit": limit,
+            "total": len(results),
+            "results": results,
+        }
+
+    def get_test_run_full_results(self, test_run_id: int) -> dict[str, Any]:
+        """Retrieve comprehensive results for a single test run.
+
+        Aggregates status, assignee, comment, defects, and step-level
+        results into one structured response.
+
+        Args:
+            test_run_id: The numeric ID of the test run.
+
+        Returns:
+            dict containing:
+                - run_id: The test run ID.
+                - status: Overall run status string.
+                - assignee: Username of the assignee.
+                - comment: Comment on the test run.
+                - defects: List of defect keys linked to the run.
+                - steps: List of step result objects.
+                - details: Full raw test run object from the API.
+        """
+        details = self.xray.get_test_run(test_run_id)
+        status = self.xray.get_test_run_status(test_run_id)
+        assignee = self.xray.get_test_run_assignee(test_run_id)
+        comment = self.xray.get_test_run_comment(test_run_id)
+        defects = self.xray.get_test_run_defects(test_run_id)
+        steps = self.xray.get_test_run_steps(test_run_id)
+
+        return {
+            "run_id": test_run_id,
+            "status": status,
+            "assignee": assignee,
+            "comment": comment,
+            "defects": defects if isinstance(defects, list) else [],
+            "steps": steps if isinstance(steps, list) else [],
+            "details": details,
+        }
+
+    # ------------------------------------------------------------------ #
+    # Evidence / attachment helpers                                        #
+    # ------------------------------------------------------------------ #
+
+    def get_test_run_evidences(self, test_run_id: int) -> list[dict[str, Any]]:
+        """Retrieve all evidence (attachment) metadata for a test run.
+
+        Calls the Xray REST endpoint ``testrun/{id}/attachment`` to list
+        every file attached as evidence to the run.
+
+        Args:
+            test_run_id: The numeric ID of the test run.
+
+        Returns:
+            List of evidence dicts. Each entry contains at minimum:
+            ``id``, ``fileName``, ``fileSize``, ``fileURL``,
+            ``contentType``, and ``created``.
+        """
+        url = self.xray.resource_url(f"testrun/{test_run_id}/attachment")
+        result = self.xray.get(url)
+        return result if isinstance(result, list) else []
+
+    def get_test_execution_evidences(
+        self,
+        execution_key: str,
+        page: int = 1,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        """Retrieve all evidence attachments across every test run in an execution.
+
+        Fetches the test runs for the execution, then collects evidence
+        metadata from each run in a single aggregated response.
+
+        Args:
+            execution_key: The test execution issue key (e.g., 'EXEC-001').
+            page: Page number passed to the test-execution listing.
+            limit: Maximum number of test runs to inspect per page.
+
+        Returns:
+            dict containing:
+                - execution_key: The execution key provided.
+                - total_runs: Number of test runs inspected.
+                - total_evidences: Total evidence files found across all runs.
+                - evidences: List of dicts, each with ``run_id``, ``test_key``,
+                  and ``attachments`` (list of evidence metadata objects).
+        """
+        raw = self.xray.get_tests_with_test_execution(
+            execution_key,
+            detailed=True,
+            page=page,
+            limit=limit,
+        )
+        tests: list[Any] = raw if isinstance(raw, list) else []
+
+        evidence_rows: list[dict[str, Any]] = []
+        total_evidences = 0
+
+        for test in tests:
+            run_id = test.get("id")
+            test_key = test.get("key") or test.get("testKey")
+
+            # Prefer the evidences already embedded in the detailed response;
+            # fall back to a dedicated API call so we always get fresh data.
+            embedded: list[Any] = test.get("evidences") or []
+            if embedded:
+                attachments = embedded
+            elif run_id is not None:
+                attachments = self.get_test_run_evidences(run_id)
+            else:
+                attachments = []
+
+            total_evidences += len(attachments)
+            evidence_rows.append(
+                {
+                    "run_id": run_id,
+                    "test_key": test_key,
+                    "attachments": attachments,
+                }
+            )
+
+        return {
+            "execution_key": execution_key,
+            "total_runs": len(evidence_rows),
+            "total_evidences": total_evidences,
+            "evidences": evidence_rows,
+        }
+
+    def download_test_run_evidence(
+        self,
+        test_run_id: int,
+        attachment_id: int,
+        target_path: str | None = None,
+    ) -> dict[str, Any]:
+        """Download a specific evidence file from a test run.
+
+        Fetches the raw file bytes using the Xray session and either saves
+        the file to *target_path* or returns the content as a Base64 string.
+
+        Args:
+            test_run_id: The numeric ID of the test run.
+            attachment_id: The numeric ID of the evidence attachment.
+            target_path: Optional filesystem path to save the file. When
+                ``None`` (default) the content is returned Base64-encoded.
+
+        Returns:
+            dict containing:
+                - attachment_id: The evidence attachment ID.
+                - run_id: The test run ID.
+                - file_name: File name from the Content-Disposition header
+                  (or ``attachment_{id}`` if unavailable).
+                - content_type: MIME type from the response headers.
+                - size_bytes: Size of the downloaded content.
+                - saved_to: Absolute path if saved to disk, else ``None``.
+                - content_base64: Base64-encoded file content when *target_path*
+                  is ``None``, else ``None``.
+        """
+        url = self.xray.resource_url(
+            f"testrun/{test_run_id}/attachment/{attachment_id}"
+        )
+        response = self.xray._session.get(f"{self.xray.url}/{url}", stream=True)
+        response.raise_for_status()
+
+        content = response.content
+        content_type = response.headers.get("Content-Type", "application/octet-stream")
+
+        # Extract file name from Content-Disposition or fall back gracefully
+        disposition = response.headers.get("Content-Disposition", "")
+        file_name = f"attachment_{attachment_id}"
+        for part in disposition.split(";"):
+            part = part.strip()
+            if part.startswith("filename="):
+                file_name = part.split("=", 1)[1].strip().strip('"')
+                break
+
+        saved_to: str | None = None
+        content_base64: str | None = None
+
+        if target_path:
+            abs_path = os.path.abspath(target_path)
+            os.makedirs(os.path.dirname(abs_path) or ".", exist_ok=True)
+            with open(abs_path, "wb") as fh:
+                fh.write(content)
+            saved_to = abs_path
+            logger.info(
+                "Evidence %s from test run %s saved to %s (%d bytes)",
+                attachment_id,
+                test_run_id,
+                abs_path,
+                len(content),
+            )
+        else:
+            content_base64 = base64.b64encode(content).decode("ascii")
+
+        return {
+            "attachment_id": attachment_id,
+            "run_id": test_run_id,
+            "file_name": file_name,
+            "content_type": content_type,
+            "size_bytes": len(content),
+            "saved_to": saved_to,
+            "content_base64": content_base64,
+        }

--- a/tests/fixtures/xray_mocks.py
+++ b/tests/fixtures/xray_mocks.py
@@ -448,6 +448,180 @@ MOCK_XRAY_TEST_EXECUTIONS_WITH_TEST_PLAN_RESPONSE = [
     },
 ]
 
+# Mock data for test results tools (get_test_runs_in_context)
+MOCK_XRAY_TEST_RUNS_IN_CONTEXT_RESPONSE = [
+    {
+        "id": 12345,
+        "status": "PASS",
+        "color": "#95C160",
+        "testKey": "TEST-001",
+        "testExecKey": "EXEC-001",
+        "assignee": "test-user",
+        "startedOn": "2024-01-15T10:00:00-05:00",
+        "startedOnIso": "2024-01-15T10:00:00-05:00",
+        "defects": [],
+        "comment": "Test executed successfully",
+        "steps": [
+            {
+                "id": 1001,
+                "index": 1,
+                "status": "PASS",
+                "comment": {"rendered": "Step passed"},
+                "actualResult": {"rendered": "Application loaded"},
+            }
+        ],
+    },
+    {
+        "id": 12346,
+        "status": "FAIL",
+        "color": "#D45D52",
+        "testKey": "TEST-002",
+        "testExecKey": "EXEC-001",
+        "assignee": "test-user-2",
+        "startedOn": "2024-01-16T10:00:00-05:00",
+        "startedOnIso": "2024-01-16T10:00:00-05:00",
+        "defects": ["BUG-001"],
+        "comment": "Test failed",
+        "steps": [
+            {
+                "id": 1002,
+                "index": 1,
+                "status": "FAIL",
+                "comment": {"rendered": "Step failed"},
+                "actualResult": {"rendered": "Error occurred"},
+            }
+        ],
+    },
+]
+
+# Mock detailed test execution result items (from get_tests_with_test_execution detailed=True)
+MOCK_XRAY_TEST_EXECUTION_DETAILED_RESPONSE = [
+    {
+        "id": 12345,
+        "key": "TEST-001",
+        "status": "PASS",
+        "assignee": "test-user",
+        "defects": [],
+        "startedOn": "2024-01-15T10:00:00-05:00",
+        "comment": "Test executed successfully",
+    },
+    {
+        "id": 12346,
+        "key": "TEST-002",
+        "status": "FAIL",
+        "assignee": "test-user-2",
+        "defects": ["BUG-001"],
+        "startedOn": "2024-01-16T10:00:00-05:00",
+        "comment": "Test failed with error",
+    },
+    {
+        "id": 12347,
+        "key": "TEST-003",
+        "status": "TODO",
+        "assignee": None,
+        "defects": [],
+        "startedOn": None,
+        "comment": None,
+    },
+]
+
+# Mock full test run results (combined status + steps + defects + comment + assignee)
+MOCK_XRAY_TEST_RUN_FULL_RESULTS = {
+    "run_id": 12345,
+    "status": "PASS",
+    "assignee": "test-user",
+    "comment": "Test executed successfully",
+    "defects": [],
+    "steps": [
+        {
+            "id": 1001,
+            "index": 1,
+            "status": "PASS",
+            "comment": {"rendered": "Step passed"},
+            "actualResult": {"rendered": "Application loaded successfully"},
+        }
+    ],
+    "details": MOCK_XRAY_TEST_RUN_RESPONSE,
+}
+
+# Mock evidence / attachment data returned by testrun/{id}/attachment
+MOCK_XRAY_EVIDENCE_LIST = [
+    {
+        "id": 301,
+        "fileName": "screenshot_pass.png",
+        "fileSize": 45678,
+        "fileURL": "http://example.com/rest/raven/1.0/api/testrun/12345/attachment/301",
+        "contentType": "image/png",
+        "created": "2024-01-15T10:05:00-05:00",
+    },
+    {
+        "id": 302,
+        "fileName": "log_output.txt",
+        "fileSize": 1234,
+        "fileURL": "http://example.com/rest/raven/1.0/api/testrun/12345/attachment/302",
+        "contentType": "text/plain",
+        "created": "2024-01-15T10:06:00-05:00",
+    },
+]
+
+MOCK_XRAY_EVIDENCE_LIST_EMPTY: list = []
+
+# Mock aggregated evidences for a test execution
+MOCK_XRAY_TEST_EXECUTION_EVIDENCES = {
+    "execution_key": "EXEC-001",
+    "total_runs": 2,
+    "total_evidences": 3,
+    "evidences": [
+        {
+            "run_id": 12345,
+            "test_key": "TEST-001",
+            "attachments": [
+                {
+                    "id": 301,
+                    "fileName": "screenshot_pass.png",
+                    "fileSize": 45678,
+                    "fileURL": "http://example.com/rest/raven/1.0/api/testrun/12345/attachment/301",
+                    "contentType": "image/png",
+                    "created": "2024-01-15T10:05:00-05:00",
+                },
+                {
+                    "id": 302,
+                    "fileName": "log_output.txt",
+                    "fileSize": 1234,
+                    "fileURL": "http://example.com/rest/raven/1.0/api/testrun/12345/attachment/302",
+                    "contentType": "text/plain",
+                    "created": "2024-01-15T10:06:00-05:00",
+                },
+            ],
+        },
+        {
+            "run_id": 12346,
+            "test_key": "TEST-002",
+            "attachments": [
+                {
+                    "id": 303,
+                    "fileName": "failure_screenshot.png",
+                    "fileSize": 89012,
+                    "fileURL": "http://example.com/rest/raven/1.0/api/testrun/12346/attachment/303",
+                    "contentType": "image/png",
+                    "created": "2024-01-16T10:07:00-05:00",
+                },
+            ],
+        },
+    ],
+}
+
+# Mock download result (Base64-encoded content)
+MOCK_XRAY_EVIDENCE_DOWNLOAD_RESULT = {
+    "attachment_id": 301,
+    "run_id": 12345,
+    "file_name": "screenshot_pass.png",
+    "content_type": "image/png",
+    "size_bytes": 6,
+    "saved_to": None,
+    "content_base64": "aGVsbG8=",  # base64("hello\n")
+}
+
 # Success Response Templates
 MOCK_XRAY_SUCCESS_RESPONSE = {
     "success": True,

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -1,5 +1,6 @@
 """Tests for the main MCP server implementation."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -129,6 +130,59 @@ def test_streamable_http_app_serves_both_slash_variants(mcp_endpoint):
 
     assert response.status_code == 200
     assert "mcp-session-id" in response.headers
+
+
+def test_streamable_http_tools_list_honors_header_filters():
+    """The live tools/list route must honor request-scoped read-only and Xray headers."""
+    from starlette.testclient import TestClient
+
+    app = main_mcp.http_app(path="/mcp", transport="streamable-http")
+    init_request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "1.0"},
+        },
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "X-Atlassian-Bitbucket-Personal-Token": "dummy",
+        "X-Atlassian-Bitbucket-Url": "https://example.bitbucket.local",
+        "X-Atlassian-Bitbucket-Read-Only-Mode": "true",
+        "X-Atlassian-Confluence-Personal-Token": "dummy",
+        "X-Atlassian-Confluence-Url": "https://example.confluence.local",
+        "X-Atlassian-Enable-Xray": "false",
+        "X-Atlassian-Jira-Personal-Token": "dummy",
+        "X-Atlassian-Jira-Url": "https://example.jira.local",
+        "X-Atlassian-Read-Only-Mode": "false",
+        "X-Atlassian-Username": "tester",
+    }
+
+    with TestClient(app) as client:
+        init_response = client.post("/mcp", json=init_request, headers=headers)
+        assert init_response.status_code == 200
+
+        session_headers = dict(headers)
+        session_headers["mcp-session-id"] = init_response.headers["mcp-session-id"]
+        tools_response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+            headers=session_headers,
+        )
+
+    assert tools_response.status_code == 200
+    data_line = next(
+        line for line in tools_response.text.splitlines() if line.startswith("data: ")
+    )
+    tool_names = {tool["name"] for tool in json.loads(data_line[6:])["result"]["tools"]}
+
+    assert "jira_create_issue" in tool_names
+    assert "bitbucket_create_branch" not in tool_names
+    assert not any(name.startswith("xray_") for name in tool_names)
 
 
 @pytest.mark.anyio

--- a/tests/unit/xray/test_xray_results.py
+++ b/tests/unit/xray/test_xray_results.py
@@ -1,0 +1,360 @@
+"""Tests for the Xray test results mixin."""
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_atlassian.xray.config import XrayConfig
+from mcp_atlassian.xray.results import MixTestResults
+from tests.fixtures.xray_mocks import (
+    MOCK_XRAY_EVIDENCE_LIST,
+    MOCK_XRAY_EVIDENCE_LIST_EMPTY,
+    MOCK_XRAY_TEST_EXECUTION_DETAILED_RESPONSE,
+    MOCK_XRAY_TEST_RUN_RESPONSE,
+    MOCK_XRAY_TEST_STEPS_RESPONSE,
+)
+
+
+class TestMixTestResults:
+    """Tests for the MixTestResults mixin."""
+
+    @pytest.fixture
+    def xray_config(self):
+        """Create a basic Xray config for testing."""
+        return XrayConfig(
+            url="https://xray.example.com",
+            auth_type="basic",
+            username="test_user",
+            api_token="test_token",
+        )
+
+    @pytest.fixture
+    def results_mixin(self, xray_config):
+        """Create a MixTestResults instance for testing."""
+        with patch("mcp_atlassian.xray.results.XrayClient.__init__", return_value=None):
+            mixin = MixTestResults()
+            mixin.config = xray_config
+            mixin.xray = MagicMock()
+            return mixin
+
+    # ------------------------------------------------------------------ #
+    # get_test_execution_results                                           #
+    # ------------------------------------------------------------------ #
+
+    def test_get_test_execution_results_returns_structured_response(
+        self, results_mixin
+    ):
+        """get_test_execution_results returns structured dict with results list."""
+        results_mixin.xray.get_tests_with_test_execution.return_value = (
+            MOCK_XRAY_TEST_EXECUTION_DETAILED_RESPONSE
+        )
+
+        output = results_mixin.get_test_execution_results("EXEC-001")
+
+        assert output["execution_key"] == "EXEC-001"
+        assert output["page"] == 1
+        assert output["limit"] == 50
+        assert output["total"] == 3
+        assert len(output["results"]) == 3
+
+    def test_get_test_execution_results_maps_fields(self, results_mixin):
+        """Each result entry contains the expected mapped fields."""
+        results_mixin.xray.get_tests_with_test_execution.return_value = (
+            MOCK_XRAY_TEST_EXECUTION_DETAILED_RESPONSE
+        )
+
+        output = results_mixin.get_test_execution_results("EXEC-001")
+
+        first = output["results"][0]
+        assert first["test_key"] == "TEST-001"
+        assert first["run_id"] == 12345
+        assert first["status"] == "PASS"
+        assert first["assignee"] == "test-user"
+        assert first["defects"] == []
+        assert first["started_on"] == "2024-01-15T10:00:00-05:00"
+        assert first["comment"] == "Test executed successfully"
+
+        second = output["results"][1]
+        assert second["test_key"] == "TEST-002"
+        assert second["status"] == "FAIL"
+        assert second["defects"] == ["BUG-001"]
+
+        third = output["results"][2]
+        assert third["status"] == "TODO"
+        assert third["assignee"] is None
+        assert third["started_on"] is None
+
+    def test_get_test_execution_results_passes_pagination(self, results_mixin):
+        """Pagination parameters are forwarded to the underlying API call."""
+        results_mixin.xray.get_tests_with_test_execution.return_value = []
+
+        results_mixin.get_test_execution_results("EXEC-002", page=2, limit=25)
+
+        results_mixin.xray.get_tests_with_test_execution.assert_called_once_with(
+            "EXEC-002",
+            detailed=True,
+            page=2,
+            limit=25,
+        )
+
+    def test_get_test_execution_results_empty_execution(self, results_mixin):
+        """An empty execution returns total=0 and an empty results list."""
+        results_mixin.xray.get_tests_with_test_execution.return_value = []
+
+        output = results_mixin.get_test_execution_results("EXEC-EMPTY")
+
+        assert output["total"] == 0
+        assert output["results"] == []
+
+    def test_get_test_execution_results_handles_non_list_response(self, results_mixin):
+        """Non-list API responses are treated as empty safely."""
+        results_mixin.xray.get_tests_with_test_execution.return_value = None
+
+        output = results_mixin.get_test_execution_results("EXEC-001")
+
+        assert output["total"] == 0
+        assert output["results"] == []
+
+    # ------------------------------------------------------------------ #
+    # get_test_run_full_results                                            #
+    # ------------------------------------------------------------------ #
+
+    def test_get_test_run_full_results_returns_all_fields(self, results_mixin):
+        """get_test_run_full_results aggregates all sub-calls into one dict."""
+        results_mixin.xray.get_test_run.return_value = MOCK_XRAY_TEST_RUN_RESPONSE
+        results_mixin.xray.get_test_run_status.return_value = "PASS"
+        results_mixin.xray.get_test_run_assignee.return_value = "test-user"
+        results_mixin.xray.get_test_run_comment.return_value = (
+            "Test executed successfully"
+        )
+        results_mixin.xray.get_test_run_defects.return_value = []
+        results_mixin.xray.get_test_run_steps.return_value = (
+            MOCK_XRAY_TEST_STEPS_RESPONSE
+        )
+
+        output = results_mixin.get_test_run_full_results(12345)
+
+        assert output["run_id"] == 12345
+        assert output["status"] == "PASS"
+        assert output["assignee"] == "test-user"
+        assert output["comment"] == "Test executed successfully"
+        assert output["defects"] == []
+        assert output["steps"] == MOCK_XRAY_TEST_STEPS_RESPONSE
+        assert output["details"] == MOCK_XRAY_TEST_RUN_RESPONSE
+
+    def test_get_test_run_full_results_calls_all_sub_apis(self, results_mixin):
+        """All six Xray sub-API calls are made exactly once."""
+        results_mixin.xray.get_test_run.return_value = {}
+        results_mixin.xray.get_test_run_status.return_value = "FAIL"
+        results_mixin.xray.get_test_run_assignee.return_value = "user"
+        results_mixin.xray.get_test_run_comment.return_value = ""
+        results_mixin.xray.get_test_run_defects.return_value = ["BUG-001"]
+        results_mixin.xray.get_test_run_steps.return_value = []
+
+        results_mixin.get_test_run_full_results(99)
+
+        results_mixin.xray.get_test_run.assert_called_once_with(99)
+        results_mixin.xray.get_test_run_status.assert_called_once_with(99)
+        results_mixin.xray.get_test_run_assignee.assert_called_once_with(99)
+        results_mixin.xray.get_test_run_comment.assert_called_once_with(99)
+        results_mixin.xray.get_test_run_defects.assert_called_once_with(99)
+        results_mixin.xray.get_test_run_steps.assert_called_once_with(99)
+
+    def test_get_test_run_full_results_normalises_non_list_defects(self, results_mixin):
+        """Non-list defects response is normalised to an empty list."""
+        results_mixin.xray.get_test_run.return_value = {}
+        results_mixin.xray.get_test_run_status.return_value = "TODO"
+        results_mixin.xray.get_test_run_assignee.return_value = None
+        results_mixin.xray.get_test_run_comment.return_value = None
+        results_mixin.xray.get_test_run_defects.return_value = None  # bad response
+        results_mixin.xray.get_test_run_steps.return_value = []
+
+        output = results_mixin.get_test_run_full_results(1)
+
+        assert output["defects"] == []
+
+    def test_get_test_run_full_results_normalises_non_list_steps(self, results_mixin):
+        """Non-list steps response is normalised to an empty list."""
+        results_mixin.xray.get_test_run.return_value = {}
+        results_mixin.xray.get_test_run_status.return_value = "TODO"
+        results_mixin.xray.get_test_run_assignee.return_value = None
+        results_mixin.xray.get_test_run_comment.return_value = None
+        results_mixin.xray.get_test_run_defects.return_value = []
+        results_mixin.xray.get_test_run_steps.return_value = None  # bad response
+
+        output = results_mixin.get_test_run_full_results(1)
+
+        assert output["steps"] == []
+
+    # ------------------------------------------------------------------ #
+    # get_test_run_evidences                                               #
+    # ------------------------------------------------------------------ #
+
+    def test_get_test_run_evidences_returns_list(self, results_mixin):
+        """get_test_run_evidences returns the list from the API call."""
+        results_mixin.xray.resource_url.return_value = (
+            "rest/raven/1.0/api/testrun/12345/attachment"
+        )
+        results_mixin.xray.get.return_value = MOCK_XRAY_EVIDENCE_LIST
+
+        output = results_mixin.get_test_run_evidences(12345)
+
+        assert output == MOCK_XRAY_EVIDENCE_LIST
+        results_mixin.xray.resource_url.assert_called_once_with(
+            "testrun/12345/attachment"
+        )
+
+    def test_get_test_run_evidences_empty_response(self, results_mixin):
+        """Non-list API response is normalised to an empty list."""
+        results_mixin.xray.resource_url.return_value = (
+            "rest/raven/1.0/api/testrun/1/attachment"
+        )
+        results_mixin.xray.get.return_value = None
+
+        output = results_mixin.get_test_run_evidences(1)
+
+        assert output == []
+
+    def test_get_test_run_evidences_no_attachments(self, results_mixin):
+        """Empty list from API is returned as-is."""
+        results_mixin.xray.resource_url.return_value = (
+            "rest/raven/1.0/api/testrun/1/attachment"
+        )
+        results_mixin.xray.get.return_value = MOCK_XRAY_EVIDENCE_LIST_EMPTY
+
+        output = results_mixin.get_test_run_evidences(1)
+
+        assert output == []
+
+    # ------------------------------------------------------------------ #
+    # get_test_execution_evidences                                         #
+    # ------------------------------------------------------------------ #
+
+    def test_get_test_execution_evidences_aggregates_runs(self, results_mixin):
+        """Evidences embedded in the detailed response are collected per run."""
+        detailed = [
+            {
+                "id": 12345,
+                "key": "TEST-001",
+                "evidences": [{"id": 301, "fileName": "img.png"}],
+            },
+            {
+                "id": 12346,
+                "key": "TEST-002",
+                "evidences": [],
+            },
+        ]
+        results_mixin.xray.get_tests_with_test_execution.return_value = detailed
+
+        output = results_mixin.get_test_execution_evidences("EXEC-001")
+
+        assert output["execution_key"] == "EXEC-001"
+        assert output["total_runs"] == 2
+        assert output["total_evidences"] == 1
+        assert output["evidences"][0]["run_id"] == 12345
+        assert output["evidences"][0]["attachments"] == [
+            {"id": 301, "fileName": "img.png"}
+        ]
+        assert output["evidences"][1]["attachments"] == []
+
+    def test_get_test_execution_evidences_falls_back_to_api(self, results_mixin):
+        """When embedded evidences field is absent, get_test_run_evidences is called."""
+        detailed = [{"id": 99, "key": "TEST-003"}]  # no 'evidences' key
+        results_mixin.xray.get_tests_with_test_execution.return_value = detailed
+        results_mixin.xray.resource_url.return_value = "url"
+        results_mixin.xray.get.return_value = MOCK_XRAY_EVIDENCE_LIST
+
+        output = results_mixin.get_test_execution_evidences("EXEC-002")
+
+        assert output["total_evidences"] == len(MOCK_XRAY_EVIDENCE_LIST)
+        results_mixin.xray.get.assert_called_once()
+
+    def test_get_test_execution_evidences_empty_execution(self, results_mixin):
+        """Empty execution returns zero runs and zero evidences."""
+        results_mixin.xray.get_tests_with_test_execution.return_value = []
+
+        output = results_mixin.get_test_execution_evidences("EXEC-EMPTY")
+
+        assert output["total_runs"] == 0
+        assert output["total_evidences"] == 0
+        assert output["evidences"] == []
+
+    def test_get_test_execution_evidences_forwards_pagination(self, results_mixin):
+        """Pagination parameters are forwarded to get_tests_with_test_execution."""
+        results_mixin.xray.get_tests_with_test_execution.return_value = []
+
+        results_mixin.get_test_execution_evidences("EXEC-001", page=3, limit=20)
+
+        results_mixin.xray.get_tests_with_test_execution.assert_called_once_with(
+            "EXEC-001", detailed=True, page=3, limit=20
+        )
+
+    # ------------------------------------------------------------------ #
+    # download_test_run_evidence                                           #
+    # ------------------------------------------------------------------ #
+
+    def test_download_test_run_evidence_returns_base64_when_no_path(
+        self, results_mixin
+    ):
+        """When target_path is None, content is returned Base64-encoded."""
+        file_content = b"hello\n"
+        mock_response = MagicMock()
+        mock_response.content = file_content
+        mock_response.headers = {
+            "Content-Type": "text/plain",
+            "Content-Disposition": 'attachment; filename="log.txt"',
+        }
+        mock_response.raise_for_status = MagicMock()
+        results_mixin.xray._session.get.return_value = mock_response
+        results_mixin.xray.resource_url.return_value = (
+            "rest/raven/1.0/api/testrun/1/attachment/10"
+        )
+        results_mixin.xray.url = "http://example.com"
+
+        output = results_mixin.download_test_run_evidence(1, 10)
+
+        assert output["run_id"] == 1
+        assert output["attachment_id"] == 10
+        assert output["file_name"] == "log.txt"
+        assert output["content_type"] == "text/plain"
+        assert output["size_bytes"] == len(file_content)
+        assert output["saved_to"] is None
+        assert output["content_base64"] == base64.b64encode(file_content).decode()
+
+    def test_download_test_run_evidence_saves_to_disk(self, results_mixin, tmp_path):
+        """When target_path is provided, the file is saved and saved_to is set."""
+        file_content = b"binary data"
+        mock_response = MagicMock()
+        mock_response.content = file_content
+        mock_response.headers = {
+            "Content-Type": "application/octet-stream",
+            "Content-Disposition": "",
+        }
+        mock_response.raise_for_status = MagicMock()
+        results_mixin.xray._session.get.return_value = mock_response
+        results_mixin.xray.resource_url.return_value = (
+            "rest/raven/1.0/api/testrun/2/attachment/20"
+        )
+        results_mixin.xray.url = "http://example.com"
+
+        dest = str(tmp_path / "evidence.bin")
+        output = results_mixin.download_test_run_evidence(2, 20, target_path=dest)
+
+        assert output["saved_to"] == dest
+        assert output["content_base64"] is None
+        assert open(dest, "rb").read() == file_content
+
+    def test_download_test_run_evidence_fallback_filename(self, results_mixin):
+        """When Content-Disposition is absent, file_name falls back to attachment_{id}."""
+        mock_response = MagicMock()
+        mock_response.content = b"data"
+        mock_response.headers = {"Content-Type": "application/octet-stream"}
+        mock_response.raise_for_status = MagicMock()
+        results_mixin.xray._session.get.return_value = mock_response
+        results_mixin.xray.resource_url.return_value = "url"
+        results_mixin.xray.url = "http://example.com"
+
+        output = results_mixin.download_test_run_evidence(5, 99)
+
+        assert output["file_name"] == "attachment_99"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Adds Xray test result retrieval and evidence download capabilities to the MCP Atlassian server. Previously, users had no way to query execution-level test results, inspect per-run step outcomes, or download evidence attachments through the MCP interface. This PR introduces a new `MixTestResults` mixin and six corresponding MCP tools to cover these workflows end-to-end.

Also fixes Xray enablement in `stdio` mode, where HTTP headers are unavailable and the `X-Atlassian-Enable-Xray` environment variable was previously ignored.

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

- Added `src/mcp_atlassian/xray/results.py` — new `MixTestResults` mixin with methods: `get_test_execution_results`, `get_test_run_full_results`, `get_test_run_evidences`, `get_test_execution_evidences`, and `download_test_run_evidence`.
- Registered `MixTestResults` into `XrayFetcher` and exported it from `xray/__init__.py`.
- Added six new MCP tools in `servers/xray.py`: `get_test_runs_in_context`, `get_test_execution_results`, `get_test_run_full_results`, `get_test_run_evidences`, `get_test_execution_evidences`, and `download_test_run_evidence` (supports save-to-disk or Base64 return).
- Fixed `servers/main.py` to fall back to the `X-Atlassian-Enable-Xray` environment variable when no HTTP header is present (fixes Xray tool visibility in `stdio` mode).

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `Queried JDVE-890 test run (ID 2776414) via MCP; verified PASS status, step results, and evidence metadata returned correctly`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).