### PR TITLE
feat(jira): add workflow and workflow property tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,13 @@ A per-product header always takes precedence over the global header for that pro
 - `jira_summarize_attachments`: Extract readable text from PDF/Office/CSV/JSON attachments (via Microsoft MarkItDown)
 - `jira_get_attachment_images`: Fetch image attachments as viewable image content so a vision-capable client model can describe them
 
+**Workflow Tools**
+
+- `jira_get_all_workflows`: List all workflows (requires admin on Server/DC)
+- `jira_get_workflows_paginated`: Search/list workflows with optional expansion of statuses and transition details (Cloud)
+- `jira_get_workflow_status_properties`: Retrieve status-level properties for workflows — including `jira.permission.edit.denied`, `jira.issue.editable`, `jira.permission.link.denied`, and other permission flags that control issue actions
+- `jira_check_issue_workflow_permissions`: For a specific issue, inspect its current workflow-status properties and return `is_editable`, `denied_permissions` list, and the full `status_properties` dict
+
 #### Confluence Tools
 
 - `confluence_search`: Search Confluence content using CQL
@@ -1072,13 +1079,13 @@ A per-product header always takes precedence over the global header for that pro
 |           | `jira_get_user_profile`       |                                |                                    | `get_tests_with_test_plan`        |
 |           | `jira_download_attachments`   |                                |                                    | `get_test_executions_with_test_plan` |
 |           | `jira_get_project_versions`   |                                |                                    | `get_tests_with_test_execution`   |
-|           |                               |                                |                                    | `get_test_run`                    |
-|           | `jira_summarize_attachments`  |                                |                                    | `get_test_run_assignee`           |
-|           | `jira_get_attachment_images`  |                                |                                    | `get_test_run_iteration`          |
-|           |                               |                                |                                    | `get_test_run_status`             |
-|           |                               |                                |                                    | `get_test_run_defects`            |
-|           |                               |                                |                                    | `get_test_run_comment`            |
-|           |                               |                                |                                    | `get_test_run_steps`              |
+|           | `jira_get_all_workflows`      |                                |                                    | `get_test_run`                    |
+|           | `jira_get_workflows_paginated`|                                |                                    | `get_test_run_assignee`           |
+|           |                               |                                |                                    | `get_test_run_iteration`          |
+|           | `jira_get_workflow_status_properties` |                         |                                    | `get_test_run_status`             |
+|           | `jira_check_issue_workflow_permissions` |                       |                                    | `get_test_run_defects`            |
+|           | `jira_summarize_attachments`  |                                |                                    | `get_test_run_comment`            |
+|           | `jira_get_attachment_images`  |                                |                                    | `get_test_run_steps`              |
 |           |                               |                                |                                    |                                   |
 |           |                               |                                |                                    |                                   |
 |           |                               |                                |                                    |                                   |

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -24,6 +24,7 @@ from .users import UsersMixin
 from .worklog import WorklogMixin
 from .boards import BoardsMixin
 from .attachments import AttachmentsMixin
+from .workflows import WorkflowsMixin
 
 
 class JiraFetcher(
@@ -41,6 +42,7 @@ class JiraFetcher(
     SprintsMixin,
     AttachmentsMixin,
     LinksMixin,
+    WorkflowsMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.
@@ -60,6 +62,7 @@ class JiraFetcher(
     - SprintsMixin: Sprint operations
     - AttachmentsMixin: Attachment download operations
     - LinksMixin: Issue link operations
+    - WorkflowsMixin: Workflow operations
 
     The class structure is designed to maintain backward compatibility while
     improving code organization and maintainability.
@@ -68,4 +71,4 @@ class JiraFetcher(
     pass
 
 
-__all__ = ["JiraFetcher", "JiraConfig", "JiraClient", "Jira"]
+__all__ = ["JiraFetcher", "JiraConfig", "JiraClient", "Jira", "WorkflowsMixin"]

--- a/src/mcp_atlassian/jira/workflows.py
+++ b/src/mcp_atlassian/jira/workflows.py
@@ -1,0 +1,554 @@
+"""Module for Jira workflow operations."""
+
+import logging
+from typing import Any, NoReturn
+
+from requests.exceptions import HTTPError
+
+from ..exceptions import MCPAtlassianAuthenticationError
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+# Well-known workflow status property keys
+KNOWN_STATUS_PROPERTY_KEYS = {
+    "jira.issue.editable",
+    "jira.permission.edit.denied",
+    "jira.permission.link.denied",
+    "jira.permission.subtask.link.denied",
+    "jira.permission.attach.denied",
+    "jira.permission.assign.denied",
+    "jira.permission.resolve.denied",
+    "jira.permission.comment.denied",
+    "jira.permission.delete.denied",
+    "jira.permission.worklog.denied",
+    "jira.permission.move.denied",
+}
+
+# Jira mypermissions key -> workflow-style denied key used in this tool output.
+PERMISSION_KEY_TO_DENIED_PROPERTY = {
+    "EDIT_ISSUES": "jira.permission.edit.denied",
+    "LINK_ISSUES": "jira.permission.link.denied",
+    "CREATE_ATTACHMENTS": "jira.permission.attach.denied",
+    "ADD_COMMENTS": "jira.permission.comment.denied",
+    "ASSIGN_ISSUES": "jira.permission.assign.denied",
+    "RESOLVE_ISSUES": "jira.permission.resolve.denied",
+    "DELETE_ISSUES": "jira.permission.delete.denied",
+    "WORK_ON_ISSUES": "jira.permission.worklog.denied",
+}
+
+
+class WorkflowsMixin(JiraClient):
+    """Mixin for Jira workflow operations."""
+
+    # ------------------------------------------------------------------ #
+    # Workflow listing                                                      #
+    # ------------------------------------------------------------------ #
+
+    def get_all_workflows(self) -> list[dict[str, Any]]:
+        """
+        Get all workflows (requires admin permissions on Server/DC).
+
+        Returns:
+            List of workflow dictionaries
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails (401/403)
+            Exception: On other API errors
+        """
+        try:
+            result = self.jira.get_all_workflows()
+            if isinstance(result, list):
+                return result
+            # Some versions return a dict with a list inside
+            if isinstance(result, dict):
+                return result.get("values", [result])
+            return []
+        except HTTPError as http_err:
+            self._raise_auth_error_or_reraise(http_err, "getting all workflows")
+        except Exception as e:
+            msg = f"Error getting all workflows: {e}"
+            logger.error(msg)
+            raise Exception(msg) from e
+
+    def get_workflows_paginated(
+        self,
+        start_at: int = 0,
+        max_results: int = 50,
+        workflow_name: str | None = None,
+        expand: str | None = None,
+    ) -> dict[str, Any]:
+        """
+                Search workflows with pagination.
+
+                API strategy by deployment type:
+
+                - Cloud: use Jira Cloud paginated endpoint via
+                    ``jira.get_workflows_paginated`` (``/rest/api/2/workflow/search``)
+                - Server/Data Center: use Jira DC endpoint
+                    ``/rest/api/2/workflow`` and then apply pagination/filtering locally
+                    to return a consistent response shape
+
+        Expand options (comma-separated):
+            - ``transitions``                    include transitions
+            - ``transitions.rules``              include transition rules
+            - ``statuses``                       include statuses
+            - ``statuses.properties``            include status properties
+              (e.g. ``jira.permission.edit.denied``, ``jira.issue.editable``)
+
+        Args:
+            start_at: Page offset (0-based)
+            max_results: Max items per page
+            workflow_name: Optional name filter
+            expand: Comma-separated expand fields
+
+        Returns:
+            Raw paginated response dict with ``values``, ``total``, etc.
+
+        Raises:
+            MCPAtlassianAuthenticationError: On 401/403
+            Exception: On other errors
+        """
+        try:
+            if self.config.is_cloud:
+                result = self.jira.get_workflows_paginated(
+                    start_at=start_at,
+                    max_results=max_results,
+                    workflow_name=workflow_name,
+                    expand=expand,
+                )
+                return result if isinstance(result, dict) else {}
+
+            # Data Center / Server path:
+            # Use explicit DC endpoint and normalize output to paginated shape.
+            raw = self.jira.get(self.jira.resource_url("workflow"))
+
+            if isinstance(raw, list):
+                workflows = raw
+            elif isinstance(raw, dict):
+                workflows = raw.get("values", [raw])
+            else:
+                workflows = []
+
+            if workflow_name:
+                workflows = [
+                    wf
+                    for wf in workflows
+                    if isinstance(wf, dict) and wf.get("name") == workflow_name
+                ]
+
+            total = len(workflows)
+            page = workflows[start_at : start_at + max_results]
+            return {
+                "startAt": start_at,
+                "maxResults": max_results,
+                "total": total,
+                "isLast": (start_at + max_results) >= total,
+                "values": page,
+            }
+        except HTTPError as http_err:
+            self._raise_auth_error_or_reraise(http_err, "getting paginated workflows")
+        except Exception as e:
+            msg = f"Error getting paginated workflows: {e}"
+            logger.error(msg)
+            raise Exception(msg) from e
+
+    def get_workflow_paginated(
+        self,
+        start_at: int = 0,
+        max_results: int = 50,
+        workflow_name: str | None = None,
+        expand: str | None = None,
+    ) -> dict[str, Any]:
+        """Backward-compatible alias for :meth:`get_workflows_paginated`.
+
+        This keeps compatibility with older callers that used the singular
+        method name.
+        """
+        return self.get_workflows_paginated(
+            start_at=start_at,
+            max_results=max_results,
+            workflow_name=workflow_name,
+            expand=expand,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Workflow transition properties                                        #
+    # ------------------------------------------------------------------ #
+
+    def get_workflow_properties(
+        self,
+        workflow_name: str,
+        transition_id: int | str,
+        workflow_mode: str = "live",
+        key: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Get properties set on a workflow transition.
+
+        Jira Data Center exposes properties via transition endpoints:
+        ``/rest/api/2/workflow/transitions/{transitionId}/properties``.
+        Properties are key-value pairs attached to a specific transition.
+
+        Args:
+            workflow_name: The workflow name
+            transition_id: Transition ID within the workflow
+            workflow_mode: ``live`` (default) or ``draft``
+            key: Optional property key filter
+
+        Returns:
+            List of ``{"key": ..., "value": ...}`` dicts
+
+        Raises:
+            MCPAtlassianAuthenticationError: On 401/403
+            Exception: On other errors
+        """
+        try:
+            url = f"workflow/transitions/{transition_id}/properties"
+            params: dict[str, Any] = {"workflowName": workflow_name}
+            if workflow_mode:
+                params["workflowMode"] = workflow_mode
+            if key:
+                params["key"] = key
+            result = self.jira.get(self.jira.resource_url(url), params=params)
+            if isinstance(result, list):
+                return result
+            if isinstance(result, dict):
+                # Key-filtered responses are usually a single object.
+                return [result]
+            return []
+        except HTTPError as http_err:
+            self._raise_auth_error_or_reraise(
+                http_err,
+                f"getting properties for workflow '{workflow_name}'",
+            )
+        except Exception as e:
+            msg = f"Error getting properties for workflow '{workflow_name}': {e}"
+            logger.error(msg)
+            raise Exception(msg) from e
+
+    # ------------------------------------------------------------------ #
+    # Workflow status properties (permission / editability flags)           #
+    # ------------------------------------------------------------------ #
+
+    def get_workflow_status_properties(
+        self,
+        workflow_name: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Get statuses and their associated properties for one or all workflows.
+
+        This retrieves status-level properties such as:
+        - ``jira.issue.editable``           – whether the issue is editable
+        - ``jira.permission.edit.denied``   – blocks the *Edit Issue* permission
+        - ``jira.permission.link.denied``   – blocks the *Link Issue* permission
+        - ``jira.permission.attach.denied`` – blocks the *Attach Files* permission
+        - ``jira.permission.comment.denied``– blocks the *Add Comment* permission
+        - (and other ``jira.permission.*`` keys)
+
+        On Jira Cloud, uses the paginated workflows API with
+        ``expand=statuses.properties``. On Server/DC, uses
+        ``/rest/api/2/workflow`` with the same expand param.
+
+        Args:
+            workflow_name: Optional workflow name to filter results
+
+        Returns:
+            List of dicts, one per workflow:
+            ::
+
+                [
+                  {
+                    "workflow_name": "...",
+                    "statuses": [
+                      {
+                        "id": "...",
+                        "name": "...",
+                        "properties": {
+                          "jira.issue.editable": "true",
+                          "jira.permission.edit.denied": "...",
+                          ...
+                        }
+                      },
+                      ...
+                    ]
+                  },
+                  ...
+                ]
+
+        Raises:
+            MCPAtlassianAuthenticationError: On 401/403
+            Exception: On other errors
+        """
+        try:
+            if self.config.is_cloud:
+                expand = "statuses,statuses.properties"
+                raw = self.jira.get_workflows_paginated(
+                    workflow_name=workflow_name,
+                    expand=expand,
+                )
+                workflows_list = raw.get("values", []) if isinstance(raw, dict) else []
+            else:
+                # Jira Data Center commonly returns the workflow list at this route,
+                # while the expand form does not reliably include statuses/statuses.properties.
+                # Use the workflow list endpoint and filter locally so we preserve the
+                # actual workflow objects returned by the server.
+                raw = self.get_all_workflows()
+                workflows_list = raw if isinstance(raw, list) else []
+
+                if workflow_name:
+                    workflows_list = [
+                        wf
+                        for wf in workflows_list
+                        if isinstance(wf, dict) and wf.get("name") == workflow_name
+                    ]
+
+            return self._parse_workflow_status_properties(workflows_list)
+        except HTTPError as http_err:
+            self._raise_auth_error_or_reraise(
+                http_err, "getting workflow status properties"
+            )
+        except Exception as e:
+            msg = f"Error getting workflow status properties: {e}"
+            logger.error(msg)
+            raise Exception(msg) from e
+
+    def check_issue_workflow_permissions(self, issue_key: str) -> dict[str, Any]:
+        """
+        Check workflow-based permission properties for an issue's current status.
+
+        Retrieves the status properties set on the *current* status of the issue
+        in its project workflow, including keys like:
+
+        - ``jira.issue.editable``
+        - ``jira.permission.edit.denied``
+        - ``jira.permission.link.denied``
+
+        Args:
+            issue_key: Jira issue key (e.g. ``PROJ-123``)
+
+        Returns:
+            Dict with:
+            - ``issue_key``: the issue key
+            - ``current_status``: name of current status
+            - ``status_properties``: dict of property key → value for the current status
+                        - ``is_editable``: bool | None – explicit editability when properties are
+                            available, otherwise ``None`` (undetermined)
+                        - ``evaluation_status``: ``"determined"`` or
+                            ``"missing_status_properties"``
+            - ``denied_permissions``: list of permission keys that are denied
+
+        Raises:
+            MCPAtlassianAuthenticationError: On 401/403
+            Exception: On other errors
+        """
+        try:
+            # 1. Get the issue to find project key and current status name
+            issue_data = self.jira.issue(issue_key, fields="status,project,issuetype")
+            if not isinstance(issue_data, dict):
+                msg = f"Unexpected response for issue {issue_key}"
+                raise ValueError(msg)
+
+            fields = issue_data.get("fields", {})
+            current_status_name: str = fields.get("status", {}).get("name", "") or ""
+            current_status_id: str = fields.get("status", {}).get("id", "") or ""
+            project_key: str = fields.get("project", {}).get("key", "") or ""
+
+            # 2. Get workflow status properties
+            #    (filtered by project workflow if possible)
+            all_wf_statuses = self.get_workflow_status_properties()
+
+            # 3. Find the matching status across workflows relevant to this project
+            status_properties: dict[str, str] = {}
+            for wf in all_wf_statuses:
+                for status in wf.get("statuses", []):
+                    name_match = status.get("name") == current_status_name
+                    id_match = status.get("id") == current_status_id
+                    if name_match or id_match:
+                        status_properties = status.get("properties", {})
+                        break
+                if status_properties:
+                    break
+
+            # 4. Evaluate editability and denied permissions.
+            # When DC workflow payload doesn't include status properties,
+            # use Jira effective permissions for the specific issue.
+            if status_properties:
+                is_editable = self._evaluate_editability(status_properties)
+                evaluation_status = "determined_workflow_properties"
+                denied_permissions = [
+                    k
+                    for k, v in status_properties.items()
+                    if k.startswith("jira.permission.") and v in ("true", "True", "1")
+                ]
+            else:
+                (
+                    is_editable,
+                    denied_permissions,
+                    evaluation_status,
+                ) = self._get_effective_issue_permissions(issue_key)
+
+            return {
+                "issue_key": issue_key,
+                "project_key": project_key,
+                "current_status": current_status_name,
+                "status_id": current_status_id,
+                "status_properties": status_properties,
+                "is_editable": is_editable,
+                "evaluation_status": evaluation_status,
+                "denied_permissions": denied_permissions,
+            }
+        except HTTPError as http_err:
+            self._raise_auth_error_or_reraise(
+                http_err,
+                f"checking workflow permissions for issue {issue_key}",
+            )
+        except Exception as e:
+            msg = f"Error checking workflow permissions for issue {issue_key}: {e}"
+            logger.error(msg)
+            raise Exception(msg) from e
+
+    # ------------------------------------------------------------------ #
+    # Private helpers                                                       #
+    # ------------------------------------------------------------------ #
+
+    def _raise_auth_error_or_reraise(
+        self, http_err: HTTPError, context: str
+    ) -> NoReturn:
+        """Re-raise auth errors as MCPAtlassianAuthenticationError; re-raise others."""
+        if http_err.response is not None and http_err.response.status_code in (
+            401,
+            403,
+        ):
+            msg = (
+                f"Authentication failed while {context} "
+                f"({http_err.response.status_code}). "
+                "Token may be expired or invalid. Please verify credentials."
+            )
+            logger.error(msg)
+            raise MCPAtlassianAuthenticationError(msg) from http_err
+        logger.error(f"HTTP error while {context}: {http_err}", exc_info=False)
+        raise http_err
+
+    @staticmethod
+    def _parse_workflow_status_properties(
+        workflows_list: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """
+        Extract status properties from a raw workflow list response.
+
+        Handles both Cloud (``get_workflows_paginated``) and Server/DC
+        (``get_all_workflows``) response shapes.
+        """
+        result: list[dict[str, Any]] = []
+        for wf in workflows_list:
+            if not isinstance(wf, dict):
+                continue
+
+            wf_name = wf.get("name") or wf.get("id") or "unknown"
+            raw_statuses: list[dict[str, Any]] = wf.get("statuses", [])
+
+            parsed_statuses: list[dict[str, Any]] = []
+            for st in raw_statuses:
+                if not isinstance(st, dict):
+                    continue
+
+                # Status properties live under "properties" key (Cloud)
+                # or under "properties.property" (Server/DC XML-derived)
+                props: dict[str, str] = {}
+
+                raw_props = st.get("properties", {})
+                if isinstance(raw_props, dict):
+                    for k, v in raw_props.items():
+                        props[k] = str(v)
+                elif isinstance(raw_props, list):
+                    # Server/DC sometimes returns [{"key": ..., "value": ...}]
+                    for item in raw_props:
+                        if isinstance(item, dict) and "key" in item:
+                            props[item["key"]] = str(item.get("value", ""))
+
+                parsed_statuses.append(
+                    {
+                        "id": st.get("id") or st.get("statusId", ""),
+                        "name": st.get("name", ""),
+                        "properties": props,
+                    }
+                )
+
+            # If Jira returns the workflow without embedded statuses, keep the
+            # workflow entry so callers can still see which workflows were found.
+            # This mirrors the actual Server/DC response shape we observed.
+            if not parsed_statuses:
+                result.append(
+                    {
+                        "workflow_name": wf_name,
+                        "statuses": [],
+                    }
+                )
+                continue
+
+            result.append(
+                {
+                    "workflow_name": wf_name,
+                    "statuses": parsed_statuses,
+                }
+            )
+        return result
+
+    @staticmethod
+    def _evaluate_editability(props: dict[str, str]) -> bool | None:
+        """
+        Return explicit editability state from workflow status properties.
+
+        Logic:
+        - If ``jira.issue.editable`` is present, use its value (``"true"`` → editable).
+        - If ``jira.permission.edit.denied`` is ``"true"`` the issue is NOT editable.
+        - If neither property is present, returns ``None`` (undetermined).
+        """
+        if "jira.issue.editable" in props:
+            return props["jira.issue.editable"].lower() in ("true", "1", "yes")
+        if "jira.permission.edit.denied" in props:
+            denied = props["jira.permission.edit.denied"].lower()
+            return denied not in ("true", "1", "yes")
+        return None
+
+    def _get_effective_issue_permissions(
+        self,
+        issue_key: str,
+    ) -> tuple[bool | None, list[str], str]:
+        """Fetch effective permissions for an issue from Jira.
+
+        Returns:
+            (is_editable, denied_permissions, evaluation_status)
+        """
+        permissions_param = ",".join(PERMISSION_KEY_TO_DENIED_PROPERTY.keys())
+        raw = self.jira.get(
+            self.jira.resource_url("mypermissions"),
+            params={"issueKey": issue_key, "permissions": permissions_param},
+        )
+
+        if not isinstance(raw, dict):
+            return None, [], "missing_status_properties"
+
+        permissions = raw.get("permissions", {})
+        if not isinstance(permissions, dict):
+            return None, [], "missing_status_properties"
+        if not permissions:
+            return None, [], "missing_status_properties"
+
+        denied_permissions: list[str] = []
+        is_editable: bool | None = None
+
+        for jira_key, denied_key in PERMISSION_KEY_TO_DENIED_PROPERTY.items():
+            node = permissions.get(jira_key, {})
+            if not isinstance(node, dict):
+                continue
+
+            has_permission = node.get("havePermission")
+            if has_permission is False:
+                denied_permissions.append(denied_key)
+
+            if jira_key == "EDIT_ISSUES" and isinstance(has_permission, bool):
+                is_editable = has_permission
+
+        return is_editable, denied_permissions, "determined_permissions_api"

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -48,13 +48,12 @@ _SUMMARIZABLE_EXTENSIONS: frozenset[str] = frozenset(
     }
 )
 
-# Image extensions — returned as viewable image content by
-# ``jira_get_attachment_images`` so a vision-capable client model can see them.
+# Image extensions used by jira_get_attachment_images.
 _IMAGE_EXTENSIONS: frozenset[str] = frozenset(
     {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".webp"}
 )
 
-# Image file extension -> format string accepted by MCP ImageContent / vision models.
+# Image file extension -> format string accepted by MCP ImageContent.
 _IMAGE_FORMAT_MAP: dict[str, str] = {
     ".jpg": "jpeg",
     ".jpeg": "jpeg",
@@ -72,13 +71,7 @@ def _summarize_content_with_markitdown(
     filename: str,
     md_instance: Any | None = None,
 ) -> str:
-    """Convert raw attachment bytes to Markdown text using MarkItDown.
-
-    Supports PDFs (text extraction), images (EXIF metadata), and Office
-    documents.  Raises ``ImportError`` if ``markitdown`` is not installed.
-    Pass a pre-built ``md_instance`` to avoid re-initialization overhead when
-    processing multiple files.
-    """
+    """Convert raw attachment bytes to Markdown text using MarkItDown."""
     if md_instance is None:
         try:
             from markitdown import MarkItDown  # type: ignore[import-untyped]
@@ -488,13 +481,13 @@ async def download_attachments(
     """Download attachments from a Jira issue to disk, MCP resources, or both.
 
     When resource caching is enabled, each attachment is immediately available in the MCP
-    resource browser via a static URI — no cache key required:
+    resource browser via a static URI with no cache key required:
 
         jira://attachments/{issue_key}/{filename}
 
     Examples:
-        jira://attachments/JDQU-2322/desktop-screenshot-1.png   ← renders as image
-        jira://attachments/JDQU-2322/SPyDR%20Metadata.txt       ← opens as text
+        jira://attachments/JDQU-2322/desktop-screenshot-1.png  renders as image
+        jira://attachments/JDQU-2322/SPyDR%20Metadata.txt      opens as text
 
     Cached resources are valid for 10 minutes. Re-run this tool to refresh.
 
@@ -530,7 +523,7 @@ async def download_attachments(
     if should_return_content:
         # Dynamically register a concrete static MCP resource URI for every
         # downloaded attachment so they appear as direct clickable links in the
-        # VS Code MCP resource browser — no manual input required.
+        # VS Code MCP resource browser with no manual input required.
         for item in result.get("downloaded", []):
             filename = item.get("filename")
             if filename:
@@ -1842,7 +1835,7 @@ def _register_static_attachment_resource(issue_key: str, filename: str) -> None:
     """Dynamically register a concrete (non-template) MCP resource URI.
 
     Calling ``jira_mcp.add_resource_fn()`` at runtime creates a static entry in
-    the MCP resource list, which VS Code shows as a direct clickable link — no
+    the MCP resource list, which VS Code shows as a direct clickable link with no
     manual text input required by the user.
 
     The registered function checks the live cache, so it returns a clear error
@@ -1872,7 +1865,7 @@ def _register_static_attachment_resource(issue_key: str, filename: str) -> None:
     resource = FunctionResource.from_function(
         _resource_fn,
         uri=uri,
-        name=f"{issue_key} — {filename}",
+        name=f"{issue_key} - {filename}",
         description=f"Jira attachment '{filename}' from issue {issue_key}",
         mime_type=mime_type,
     )
@@ -1902,7 +1895,7 @@ def get_attachment_by_issue_resource(issue_key: str, filename: str) -> bytes:
     Serve a cached Jira attachment directly by issue key and filename.
 
     These static URIs are auto-generated when download_attachments is called and
-    are valid for 10 minutes.  No cache key is required — just use the issue key
+    are valid for 10 minutes. No cache key is required; just use the issue key
     and the original filename (URL-encoded).
 
     Example URIs (rendered automatically in VS Code / MCP clients):
@@ -1914,7 +1907,7 @@ def get_attachment_by_issue_resource(issue_key: str, filename: str) -> bytes:
         filename: URL-encoded attachment filename (e.g., 'desktop-screenshot-1.png')
 
     Returns:
-        Raw binary content — images render inline in MCP clients that support it.
+        Raw binary content. Images render inline in MCP clients that support it.
 
     Raises:
         ValueError: If no matching entry is found or it has expired (10-min TTL).
@@ -1990,7 +1983,7 @@ async def save_attachment_to_disk(
 ) -> str:
     """Save a cached attachment to the MCP SERVER's filesystem.
 
-    ⚠️ WARNING: This saves to the SERVER's filesystem, NOT your local client machine!
+        WARNING: This saves to the SERVER's filesystem, NOT your local client machine!
 
     Use cases:
     - MCP server is running locally on your machine
@@ -2115,7 +2108,7 @@ async def list_cached_attachments(ctx: Context) -> str:
         "usage_instructions": {
             "open_in_browser": "Click static_resource_uri in the MCP resource browser",
             "images": "PNG/JPEG files render inline automatically",
-            "expiry": "Resources expire after 10 minutes — re-run download_attachments to refresh",
+            "expiry": "Resources expire after 10 minutes; re-run download_attachments to refresh",
         },
     }
 
@@ -2194,9 +2187,9 @@ async def construct_upload_endpoint(ctx: Context) -> str:
                 "5. Call jira_upload_attachment with issue_key and those uri value(s)."
             ),
             "path_with_spaces_note": (
-                "Windows PowerShell — outer single quotes, path in double quotes: "
+                "Windows PowerShell: outer single quotes, path in double quotes: "
                 "-F 'file=@\"C:\\My Docs\\file.pdf\"'  |  "
-                "Linux/macOS bash — path in single quotes inside double quotes: "
+                "Linux/macOS bash: path in single quotes inside double quotes: "
                 "-F \"file=@'/my docs/file.pdf'\""
             ),
         },
@@ -2301,7 +2294,7 @@ async def jira_upload_attachment(
     and POSTing files to /upload).
 
     Each upload:// URI is resolved from the server-side staging store, then
-    uploaded directly to Jira via the REST API — no base64, no context-window
+    uploaded directly to Jira via the REST API with no base64 and no context-window
     overhead.
 
     Staged files are removed from the store after a successful upload.
@@ -2390,6 +2383,317 @@ async def jira_upload_attachment(
     )
 
 
+# ---------------------------------------------------------------------------
+# Workflow tools
+# ---------------------------------------------------------------------------
+
+
+@jira_mcp.tool(tags={"jira", "read"})
+async def get_all_workflows(ctx: Context) -> str:
+    """Get all workflows available in Jira (requires admin permissions on Server/DC).
+
+    Returns basic information about each workflow including its name, description,
+    and whether it is a default workflow.
+
+    Args:
+        ctx: The FastMCP context.
+
+    Returns:
+        JSON string representing a list of workflow objects.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    try:
+        workflows = jira.get_all_workflows()
+        return json.dumps(workflows, indent=2, ensure_ascii=False)
+    except MCPAtlassianAuthenticationError as e:
+        return json.dumps(
+            {"success": False, "error": f"Authentication/Permission Error: {e}"},
+            indent=2,
+        )
+    except Exception as e:
+        logger.error(f"Error in get_all_workflows: {e}", exc_info=True)
+        return json.dumps({"success": False, "error": str(e)}, indent=2)
+
+
+@jira_mcp.tool(tags={"jira", "read"})
+async def get_workflows_paginated(
+    ctx: Context,
+    workflow_name: Annotated[
+        str | None,
+        Field(description="(Optional) Filter by workflow name", default=None),
+    ] = None,
+    expand: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comma-separated list of fields to expand. Options:\n"
+                "- 'transitions': include transitions\n"
+                "- 'transitions.rules': include transition rules\n"
+                "- 'statuses': include statuses for each workflow\n"
+                "- 'statuses.properties': include status properties (e.g. "
+                "jira.permission.edit.denied, jira.issue.editable)"
+            ),
+            default=None,
+        ),
+    ] = None,
+    start_at: Annotated[
+        int,
+        Field(description="Starting index for pagination (0-based)", default=0, ge=0),
+    ] = 0,
+    max_results: Annotated[
+        int,
+        Field(description="Maximum number of results", default=50, ge=1, le=200),
+    ] = 50,
+) -> str:
+    """Search and list Jira workflows with optional expansion of statuses and transitions.
+
+    Use ``expand='statuses,statuses.properties'`` to retrieve the workflow status
+    properties that control issue editability and link permissions (e.g.
+    ``jira.permission.edit.denied``, ``jira.issue.editable``,
+    ``jira.permission.link.denied``).
+
+    Args:
+        ctx: The FastMCP context.
+        workflow_name: Optional filter by workflow name.
+        expand: Comma-separated fields to expand.
+        start_at: Pagination offset.
+        max_results: Maximum results to return.
+
+    Returns:
+        JSON string with paginated workflow results.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    try:
+        result = jira.get_workflows_paginated(
+            start_at=start_at,
+            max_results=max_results,
+            workflow_name=workflow_name,
+            expand=expand,
+        )
+        return json.dumps(result, indent=2, ensure_ascii=False)
+    except MCPAtlassianAuthenticationError as e:
+        return json.dumps(
+            {"success": False, "error": f"Authentication/Permission Error: {e}"},
+            indent=2,
+        )
+    except Exception as e:
+        logger.error(f"Error in get_workflows_paginated: {e}", exc_info=True)
+        return json.dumps({"success": False, "error": str(e)}, indent=2)
+
+
+@jira_mcp.tool(tags={"jira", "read"})
+async def get_workflow_paginated(
+    ctx: Context,
+    workflow_name: Annotated[
+        str | None,
+        Field(description="(Optional) Filter by workflow name", default=None),
+    ] = None,
+    expand: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comma-separated list of fields to expand. Options:\n"
+                "- 'transitions': include transitions\n"
+                "- 'transitions.rules': include transition rules\n"
+                "- 'statuses': include statuses for each workflow\n"
+                "- 'statuses.properties': include status properties (e.g. "
+                "jira.permission.edit.denied, jira.issue.editable)"
+            ),
+            default=None,
+        ),
+    ] = None,
+    start_at: Annotated[
+        int,
+        Field(description="Starting index for pagination (0-based)", default=0, ge=0),
+    ] = 0,
+    max_results: Annotated[
+        int,
+        Field(description="Maximum number of results", default=50, ge=1, le=200),
+    ] = 50,
+) -> str:
+    """Backward-compatible alias for ``jira_get_workflows_paginated``."""
+    return await get_workflows_paginated.fn(
+        ctx,
+        workflow_name=workflow_name,
+        expand=expand,
+        start_at=start_at,
+        max_results=max_results,
+    )
+
+
+@jira_mcp.tool(tags={"jira", "read"})
+async def get_workflow_properties(
+    ctx: Context,
+    workflow_name: Annotated[str, Field(description="The exact name of the workflow")],
+    transition_id: Annotated[
+        int,
+        Field(description="Transition ID within the workflow"),
+    ],
+    workflow_mode: Annotated[
+        str,
+        Field(
+            description="Workflow mode: 'live' (default) or 'draft'",
+            default="live",
+        ),
+    ] = "live",
+    key: Annotated[
+        str | None,
+        Field(description="(Optional) Property key filter", default=None),
+    ] = None,
+) -> str:
+    """Get properties set on a Jira workflow transition.
+
+    Jira Data Center exposes transition properties via
+    ``/rest/api/2/workflow/transitions/{transitionId}/properties``.
+
+    Args:
+        ctx: The FastMCP context.
+        workflow_name: The exact name of the workflow.
+        transition_id: Transition ID within the workflow.
+        workflow_mode: 'live' or 'draft'.
+        key: Optional property key filter.
+
+    Returns:
+        JSON string representing a list of ``{"key": ..., "value": ...}`` property objects.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    try:
+        props = jira.get_workflow_properties(
+            workflow_name=workflow_name,
+            transition_id=transition_id,
+            workflow_mode=workflow_mode,
+            key=key,
+        )
+        return json.dumps(props, indent=2, ensure_ascii=False)
+    except MCPAtlassianAuthenticationError as e:
+        return json.dumps(
+            {"success": False, "error": f"Authentication/Permission Error: {e}"},
+            indent=2,
+        )
+    except Exception as e:
+        logger.error(f"Error in get_workflow_properties: {e}", exc_info=True)
+        return json.dumps({"success": False, "error": str(e)}, indent=2)
+
+
+@jira_mcp.tool(tags={"jira", "read"})
+async def get_workflow_status_properties(
+    ctx: Context,
+    workflow_name: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Filter results to a specific workflow by name",
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Get status-level properties for Jira workflows.
+
+    Status properties control what users can do when an issue is in a given
+    status.  Common property keys include:
+
+    | Key | Meaning |
+    |---|---|
+    | ``jira.issue.editable`` | ``"true"`` / ``"false"`` means the issue can be edited |
+    | ``jira.permission.edit.denied`` | ``"true"`` blocks the *Edit Issue* action |
+    | ``jira.permission.link.denied`` | ``"true"`` blocks the *Link Issue* action |
+    | ``jira.permission.attach.denied`` | ``"true"`` blocks file attachments |
+    | ``jira.permission.comment.denied`` | ``"true"`` blocks adding comments |
+    | ``jira.permission.assign.denied`` | ``"true"`` blocks re-assignment |
+    | ``jira.permission.resolve.denied`` | ``"true"`` blocks resolving the issue |
+    | ``jira.permission.delete.denied`` | ``"true"`` blocks deletion |
+    | ``jira.permission.worklog.denied`` | ``"true"`` blocks worklog entries |
+
+    Args:
+        ctx: The FastMCP context.
+        workflow_name: Optional workflow name to filter results.
+
+    Returns:
+        JSON string listing workflows with their statuses and status properties.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    try:
+        result = jira.get_workflow_status_properties(workflow_name=workflow_name)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+    except MCPAtlassianAuthenticationError as e:
+        return json.dumps(
+            {"success": False, "error": f"Authentication/Permission Error: {e}"},
+            indent=2,
+        )
+    except Exception as e:
+        logger.error(f"Error in get_workflow_status_properties: {e}", exc_info=True)
+        return json.dumps({"success": False, "error": str(e)}, indent=2)
+
+
+@jira_mcp.tool(tags={"jira", "read"})
+async def check_issue_workflow_permissions(
+    ctx: Context,
+    issue_key: Annotated[str, Field(description="Jira issue key (e.g., 'PROJ-123')")],
+) -> str:
+    """Check workflow-based permission properties for a Jira issue's current status.
+
+    Determines whether the issue can be edited, linked, commented on, etc. based
+    on the workflow status properties configured for the issue's *current* status.
+
+        The response includes:
+        - ``current_status``: the name of the issue's current workflow status
+        - ``status_properties``: all status property key/value pairs found
+        - ``is_editable``: ``true`` / ``false`` when properties are available,
+            or ``null`` when status properties are missing
+        - ``evaluation_status``: one of:
+            ``"determined_workflow_properties"``, ``"determined_permissions_api"``,
+            ``"missing_status_properties"``
+        - ``denied_permissions``: list of ``jira.permission.*`` keys that are set to ``"true"``
+            (i.e. the corresponding actions are denied)
+
+    Common denied permission keys:
+    - ``jira.permission.edit.denied``
+    - ``jira.permission.link.denied``
+    - ``jira.permission.attach.denied``
+    - ``jira.permission.comment.denied``
+    - ``jira.permission.assign.denied``
+    - ``jira.permission.resolve.denied``
+    - ``jira.permission.delete.denied``
+    - ``jira.permission.worklog.denied``
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+
+    Returns:
+        JSON string with issue editability and permission details.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    try:
+        result = jira.check_issue_workflow_permissions(issue_key=issue_key)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+    except MCPAtlassianAuthenticationError as e:
+        return json.dumps(
+            {"success": False, "error": f"Authentication/Permission Error: {e}"},
+            indent=2,
+        )
+    except Exception as e:
+        logger.error(
+            f"Error in check_issue_workflow_permissions for {issue_key}: {e}",
+            exc_info=True,
+        )
+        return json.dumps({"success": False, "error": str(e)}, indent=2)
+
+
 _ATTACHMENT_DOWNLOAD_TIMEOUT = 60  # seconds per attachment download
 
 # Maximum bytes to download per attachment. Prevents memory exhaustion from
@@ -2436,7 +2740,7 @@ def _build_attachment_summary(
     """Process a single Jira attachment dict into a summary entry.
 
     Returns:
-        (skip_filename, summary_dict) — exactly one of the two is *not* ``None``.
+        (skip_filename, summary_dict): exactly one of the two is *not* ``None``.
         ``skip_filename`` is set when the file should be skipped (unsupported type
         or filtered out).  ``summary_dict`` is set for processed / failed files.
 
@@ -2482,7 +2786,7 @@ def _build_attachment_summary(
     if max_chars and len(markdown_text) > max_chars:
         markdown_text = (
             markdown_text[:max_chars]
-            + f"\n\n[...truncated — {len(markdown_text):,} chars total]"
+            + f"\n\n[...truncated: {len(markdown_text):,} chars total]"
         )
     return None, {**base_info, "success": True, "markdown_content": markdown_text}
 
@@ -2522,19 +2826,19 @@ async def summarize_attachments(
 
     Uses Microsoft MarkItDown to extract readable content from each supported attachment:
 
-    • **PDF**          → full text extracted via pdfminer
-    • **Images**       → EXIF metadata (for a visual description use jira_get_attachment_images)
-    • **DOCX / PPTX / XLSX** → document text and structure as Markdown
-    • **CSV / JSON / XML**   → raw content rendered as Markdown
+        **PDF**: full text extracted via pdfminer
+        **Images**: EXIF metadata (for a visual description use jira_get_attachment_images)
+        **DOCX / PPTX / XLSX**: document text and structure as Markdown
+        **CSV / JSON / XML**: raw content rendered as Markdown
 
     Unsupported file types (e.g., zip, mp4, exe) are skipped and listed under
     ``"skipped"`` in the response.
 
-    Requires the ``markitdown`` package — add it with:
+    Requires the ``markitdown`` package. Add it with:
         uv add 'markitdown[pdf]'
 
     To have a vision-capable model *see* image attachments (screenshots, diagrams,
-    charts), use ``jira_get_attachment_images`` instead — it returns the raw images
+    charts), use ``jira_get_attachment_images`` instead. It returns the raw images
     as content blocks your model can view directly.
 
     Args:
@@ -2689,12 +2993,12 @@ async def get_attachment_images(
     """Fetch image attachments from a Jira issue as viewable image content.
 
     Returns each image as an MCP image content block so a vision-capable model can
-    see and describe it directly — no MarkItDown text extraction and no MCP
+    see and describe it directly with no MarkItDown text extraction and no MCP
     sampling required. Works with any client whose own model supports images
     (e.g., Claude, GPT-4o, Bedrock vision models).
 
     Non-image attachments are ignored; use ``jira_summarize_attachments`` for
-    documents (PDF / DOCX / XLSX / CSV / …).
+    documents (PDF / DOCX / XLSX / CSV / etc.).
 
     Args:
         ctx: The FastMCP context.

--- a/tests/unit/jira/test_workflows.py
+++ b/tests/unit/jira/test_workflows.py
@@ -1,0 +1,533 @@
+"""Tests for the Jira WorkflowsMixin."""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.workflows import WorkflowsMixin
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _http_error(status_code: int) -> HTTPError:
+    """Create a minimal HTTPError with the given status code."""
+    response = MagicMock()
+    response.status_code = status_code
+    err = HTTPError(response=response)
+    return err
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def wf_mixin(jira_fetcher: JiraFetcher) -> JiraFetcher:
+    """Return the shared JiraFetcher (which includes WorkflowsMixin)."""
+    return jira_fetcher
+
+
+# ---------------------------------------------------------------------------
+# get_all_workflows
+# ---------------------------------------------------------------------------
+
+
+class TestGetAllWorkflows:
+    def test_returns_list(self, wf_mixin):
+        wf_mixin.jira.get_all_workflows.return_value = [
+            {"name": "Software Simplified Workflow", "default": True},
+            {"name": "Classic Default Workflow", "default": False},
+        ]
+        result = wf_mixin.get_all_workflows()
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["name"] == "Software Simplified Workflow"
+
+    def test_returns_empty_list_on_empty_response(self, wf_mixin):
+        wf_mixin.jira.get_all_workflows.return_value = []
+        assert wf_mixin.get_all_workflows() == []
+
+    def test_handles_dict_response_with_values_key(self, wf_mixin):
+        wf_mixin.jira.get_all_workflows.return_value = {"values": [{"name": "WF1"}]}
+        result = wf_mixin.get_all_workflows()
+        assert result == [{"name": "WF1"}]
+
+    def test_raises_auth_error_on_401(self, wf_mixin):
+        wf_mixin.jira.get_all_workflows.side_effect = _http_error(401)
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            wf_mixin.get_all_workflows()
+
+    def test_raises_auth_error_on_403(self, wf_mixin):
+        wf_mixin.jira.get_all_workflows.side_effect = _http_error(403)
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            wf_mixin.get_all_workflows()
+
+    def test_raises_generic_exception_on_other_http_error(self, wf_mixin):
+        wf_mixin.jira.get_all_workflows.side_effect = _http_error(500)
+        with pytest.raises(HTTPError):
+            wf_mixin.get_all_workflows()
+
+    def test_raises_exception_on_unexpected_error(self, wf_mixin):
+        wf_mixin.jira.get_all_workflows.side_effect = RuntimeError("boom")
+        with pytest.raises(Exception, match="Error getting all workflows"):
+            wf_mixin.get_all_workflows()
+
+
+# ---------------------------------------------------------------------------
+# get_workflows_paginated
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkflowsPaginated:
+    def test_returns_dict(self, wf_mixin):
+        expected = {"values": [{"name": "WF1"}], "total": 1}
+        wf_mixin.jira.get_workflows_paginated.return_value = expected
+        result = wf_mixin.get_workflows_paginated()
+        assert result == expected
+
+    def test_passes_params(self, wf_mixin):
+        wf_mixin.jira.get_workflows_paginated.return_value = {}
+        wf_mixin.get_workflows_paginated(
+            start_at=10,
+            max_results=25,
+            workflow_name="My Workflow",
+            expand="statuses,statuses.properties",
+        )
+        wf_mixin.jira.get_workflows_paginated.assert_called_once_with(
+            start_at=10,
+            max_results=25,
+            workflow_name="My Workflow",
+            expand="statuses,statuses.properties",
+        )
+
+    def test_returns_empty_dict_on_non_dict_response(self, wf_mixin):
+        wf_mixin.jira.get_workflows_paginated.return_value = None
+        assert wf_mixin.get_workflows_paginated() == {}
+
+    def test_raises_auth_error_on_401(self, wf_mixin):
+        wf_mixin.jira.get_workflows_paginated.side_effect = _http_error(401)
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            wf_mixin.get_workflows_paginated()
+
+    def test_datacenter_uses_workflow_endpoint_and_paginates(self, wf_mixin):
+        wf_mixin.jira.resource_url.return_value = "http://dc/rest/api/2/workflow"
+        wf_mixin.jira.get.return_value = [
+            {"name": "WF-1"},
+            {"name": "WF-2"},
+            {"name": "WF-3"},
+        ]
+
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=False
+        ):
+            result = wf_mixin.get_workflows_paginated(start_at=1, max_results=1)
+
+        assert result["startAt"] == 1
+        assert result["maxResults"] == 1
+        assert result["total"] == 3
+        assert result["isLast"] is False
+        assert result["values"] == [{"name": "WF-2"}]
+        wf_mixin.jira.resource_url.assert_called_once_with("workflow")
+        wf_mixin.jira.get.assert_called_once_with("http://dc/rest/api/2/workflow")
+        wf_mixin.jira.get_workflows_paginated.assert_not_called()
+
+    def test_datacenter_applies_workflow_name_filter(self, wf_mixin):
+        wf_mixin.jira.resource_url.return_value = "http://dc/rest/api/2/workflow"
+        wf_mixin.jira.get.return_value = [
+            {"name": "WF-1"},
+            {"name": "WF-2"},
+        ]
+
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=False
+        ):
+            result = wf_mixin.get_workflows_paginated(workflow_name="WF-2")
+
+        assert result["total"] == 1
+        assert result["values"] == [{"name": "WF-2"}]
+
+    def test_datacenter_handles_dict_response_with_values(self, wf_mixin):
+        wf_mixin.jira.resource_url.return_value = "http://dc/rest/api/2/workflow"
+        wf_mixin.jira.get.return_value = {"values": [{"name": "WF-1"}]}
+
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=False
+        ):
+            result = wf_mixin.get_workflows_paginated()
+
+        assert result["total"] == 1
+        assert result["values"] == [{"name": "WF-1"}]
+
+    def test_singular_alias_delegates_to_plural(self, wf_mixin):
+        expected = {"values": [{"name": "WF1"}], "total": 1}
+        wf_mixin.jira.get_workflows_paginated.return_value = expected
+
+        result = wf_mixin.get_workflow_paginated(
+            start_at=5,
+            max_results=10,
+            workflow_name="My Workflow",
+            expand="statuses",
+        )
+
+        assert result == expected
+        wf_mixin.jira.get_workflows_paginated.assert_called_once_with(
+            start_at=5,
+            max_results=10,
+            workflow_name="My Workflow",
+            expand="statuses",
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_workflow_properties
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkflowProperties:
+    def test_returns_list(self, wf_mixin):
+        expected = [{"key": "jira.field.resolution.required", "value": "true"}]
+        wf_mixin.jira.get.return_value = expected
+        result = wf_mixin.get_workflow_properties("My Workflow", transition_id=1)
+        assert result == expected
+
+    def test_handles_dict_response(self, wf_mixin):
+        wf_mixin.jira.get.return_value = {"key": "k1", "value": "v1"}
+        result = wf_mixin.get_workflow_properties("My Workflow", transition_id=1)
+        assert result == [{"key": "k1", "value": "v1"}]
+
+    def test_uses_transition_properties_endpoint(self, wf_mixin):
+        wf_mixin.jira.get.return_value = []
+        wf_mixin.get_workflow_properties(
+            "My Workflow", transition_id=1, workflow_mode="draft"
+        )
+        wf_mixin.jira.resource_url.assert_called_once_with(
+            "workflow/transitions/1/properties"
+        )
+        call_kwargs = wf_mixin.jira.get.call_args
+        assert call_kwargs[1]["params"]["workflowName"] == "My Workflow"
+        assert call_kwargs[1]["params"]["workflowMode"] == "draft"
+
+    def test_raises_auth_error_on_403(self, wf_mixin):
+        wf_mixin.jira.get.side_effect = _http_error(403)
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            wf_mixin.get_workflow_properties("WF", transition_id=1)
+
+    def test_raises_exception_on_unexpected_error(self, wf_mixin):
+        wf_mixin.jira.get.side_effect = RuntimeError("nope")
+        with pytest.raises(Exception, match="Error getting properties"):
+            wf_mixin.get_workflow_properties("WF", transition_id=1)
+
+
+# ---------------------------------------------------------------------------
+# get_workflow_status_properties
+# ---------------------------------------------------------------------------
+
+SAMPLE_CLOUD_RESPONSE = {
+    "values": [
+        {
+            "name": "My Software Workflow",
+            "statuses": [
+                {
+                    "id": "1",
+                    "name": "Open",
+                    "properties": {
+                        "jira.issue.editable": "true",
+                    },
+                },
+                {
+                    "id": "5",
+                    "name": "Closed",
+                    "properties": {
+                        "jira.issue.editable": "false",
+                        "jira.permission.edit.denied": "true",
+                        "jira.permission.link.denied": "true",
+                    },
+                },
+            ],
+        }
+    ],
+    "total": 1,
+}
+
+SAMPLE_SERVER_RESPONSE = [
+    {
+        "name": "Classic Default Workflow",
+        "statuses": [
+            {
+                "id": "1",
+                "name": "Open",
+                "properties": [
+                    {"key": "jira.issue.editable", "value": "true"},
+                ],
+            },
+        ],
+    }
+]
+
+
+class TestGetWorkflowStatusProperties:
+    def test_cloud_parses_statuses_from_paginated_response(self, wf_mixin):
+        wf_mixin.jira.get_workflows_paginated.return_value = SAMPLE_CLOUD_RESPONSE
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=True
+        ):
+            result = wf_mixin.get_workflow_status_properties()
+
+        assert len(result) == 1
+        wf = result[0]
+        assert wf["workflow_name"] == "My Software Workflow"
+        assert len(wf["statuses"]) == 2
+
+        open_status = wf["statuses"][0]
+        assert open_status["name"] == "Open"
+        assert open_status["properties"]["jira.issue.editable"] == "true"
+
+        closed_status = wf["statuses"][1]
+        assert closed_status["properties"]["jira.permission.edit.denied"] == "true"
+        assert closed_status["properties"]["jira.permission.link.denied"] == "true"
+
+    def test_server_parses_statuses_from_list_response(self, wf_mixin):
+        wf_mixin.jira.get_all_workflows.return_value = SAMPLE_SERVER_RESPONSE
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=False
+        ):
+            result = wf_mixin.get_workflow_status_properties()
+
+        assert len(result) == 1
+        st = result[0]["statuses"][0]
+        assert st["properties"]["jira.issue.editable"] == "true"
+
+    def test_server_returns_workflow_entry_when_statuses_missing(self, wf_mixin):
+        wf_mixin.jira.get_all_workflows.return_value = [
+            {
+                "name": "jira",
+                "description": "The default Jira workflow",
+                "steps": 5,
+                "isDefault": True,
+            }
+        ]
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=False
+        ):
+            result = wf_mixin.get_workflow_status_properties(workflow_name="jira")
+
+        assert len(result) == 1
+        assert result[0]["workflow_name"] == "jira"
+        assert result[0]["statuses"] == []
+
+    def test_filters_by_workflow_name_cloud(self, wf_mixin):
+        wf_mixin.jira.get_workflows_paginated.return_value = {"values": []}
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=True
+        ):
+            wf_mixin.get_workflow_status_properties(workflow_name="My WF")
+        wf_mixin.jira.get_workflows_paginated.assert_called_once_with(
+            workflow_name="My WF", expand="statuses,statuses.properties"
+        )
+
+    def test_raises_auth_error_on_401(self, wf_mixin):
+        wf_mixin.jira.get_workflows_paginated.side_effect = _http_error(401)
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=True
+        ):
+            with pytest.raises(MCPAtlassianAuthenticationError):
+                wf_mixin.get_workflow_status_properties()
+
+
+# ---------------------------------------------------------------------------
+# check_issue_workflow_permissions
+# ---------------------------------------------------------------------------
+
+
+class TestCheckIssueWorkflowPermissions:
+    def _setup_issue(self, wf_mixin, status_name="Closed", status_id="5"):
+        wf_mixin.jira.issue.return_value = {
+            "key": "TEST-1",
+            "fields": {
+                "status": {"name": status_name, "id": status_id},
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Bug"},
+            },
+        }
+
+    def test_returns_not_editable_for_closed_issue(self, wf_mixin):
+        self._setup_issue(wf_mixin, "Closed", "5")
+        wf_mixin.jira.get_workflows_paginated.return_value = SAMPLE_CLOUD_RESPONSE
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=True
+        ):
+            result = wf_mixin.check_issue_workflow_permissions("TEST-1")
+
+        assert result["issue_key"] == "TEST-1"
+        assert result["current_status"] == "Closed"
+        assert result["is_editable"] is False
+        assert "jira.permission.edit.denied" in result["denied_permissions"]
+        assert "jira.permission.link.denied" in result["denied_permissions"]
+
+    def test_returns_editable_for_open_issue(self, wf_mixin):
+        self._setup_issue(wf_mixin, "Open", "1")
+        wf_mixin.jira.get_workflows_paginated.return_value = SAMPLE_CLOUD_RESPONSE
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=True
+        ):
+            result = wf_mixin.check_issue_workflow_permissions("TEST-1")
+
+        assert result["is_editable"] is True
+        assert result["denied_permissions"] == []
+
+    def test_undetermined_when_no_properties_found(self, wf_mixin):
+        self._setup_issue(wf_mixin, "Unknown Status", "99")
+        wf_mixin.jira.get_workflows_paginated.return_value = {"values": []}
+        wf_mixin.jira.get.return_value = {
+            "permissions": {
+                "EDIT_ISSUES": {"havePermission": True},
+                "LINK_ISSUES": {"havePermission": False},
+            }
+        }
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=True
+        ):
+            result = wf_mixin.check_issue_workflow_permissions("TEST-1")
+
+        assert result["is_editable"] is True
+        assert result["evaluation_status"] == "determined_permissions_api"
+        assert "jira.permission.link.denied" in result["denied_permissions"]
+        assert result["status_properties"] == {}
+
+    def test_permissions_api_missing_payload_keeps_undetermined(self, wf_mixin):
+        self._setup_issue(wf_mixin, "Unknown Status", "99")
+        wf_mixin.jira.get_workflows_paginated.return_value = {"values": []}
+        wf_mixin.jira.get.return_value = {}
+        config_cls = type(wf_mixin.config)
+        with patch.object(
+            config_cls, "is_cloud", new_callable=PropertyMock, return_value=True
+        ):
+            result = wf_mixin.check_issue_workflow_permissions("TEST-1")
+
+        assert result["is_editable"] is None
+        assert result["evaluation_status"] == "missing_status_properties"
+
+    def test_raises_auth_error_on_issue_fetch_401(self, wf_mixin):
+        wf_mixin.jira.issue.side_effect = _http_error(401)
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            wf_mixin.check_issue_workflow_permissions("TEST-1")
+
+    def test_raises_exception_on_unexpected_error(self, wf_mixin):
+        wf_mixin.jira.issue.side_effect = RuntimeError("db error")
+        with pytest.raises(Exception, match="Error checking workflow permissions"):
+            wf_mixin.check_issue_workflow_permissions("TEST-1")
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_editability (static helper)
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateEditability:
+    def test_editable_when_jira_issue_editable_true(self):
+        props = {"jira.issue.editable": "true"}
+        assert WorkflowsMixin._evaluate_editability(props) is True
+
+    def test_not_editable_when_jira_issue_editable_false(self):
+        props = {"jira.issue.editable": "false"}
+        assert WorkflowsMixin._evaluate_editability(props) is False
+
+    def test_not_editable_when_edit_denied_true(self):
+        assert (
+            WorkflowsMixin._evaluate_editability(
+                {"jira.permission.edit.denied": "true"}
+            )
+            is False
+        )
+
+    def test_editable_when_edit_denied_false(self):
+        assert (
+            WorkflowsMixin._evaluate_editability(
+                {"jira.permission.edit.denied": "false"}
+            )
+            is True
+        )
+
+    def test_undetermined_when_no_properties(self):
+        assert WorkflowsMixin._evaluate_editability({}) is None
+
+    def test_jira_issue_editable_takes_precedence(self):
+        # jira.issue.editable=true should win even if edit.denied is set
+        assert (
+            WorkflowsMixin._evaluate_editability(
+                {
+                    "jira.issue.editable": "true",
+                    "jira.permission.edit.denied": "true",
+                }
+            )
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# _parse_workflow_status_properties (static helper)
+# ---------------------------------------------------------------------------
+
+
+class TestParseWorkflowStatusProperties:
+    def test_parses_dict_properties(self):
+        raw = [
+            {
+                "name": "WF1",
+                "statuses": [
+                    {
+                        "id": "1",
+                        "name": "Open",
+                        "properties": {"jira.issue.editable": "true"},
+                    }
+                ],
+            }
+        ]
+        result = WorkflowsMixin._parse_workflow_status_properties(raw)
+        assert result[0]["workflow_name"] == "WF1"
+        assert result[0]["statuses"][0]["properties"]["jira.issue.editable"] == "true"
+
+    def test_parses_list_properties(self):
+        raw = [
+            {
+                "name": "WF2",
+                "statuses": [
+                    {
+                        "id": "2",
+                        "name": "Closed",
+                        "properties": [
+                            {"key": "jira.permission.edit.denied", "value": "true"}
+                        ],
+                    }
+                ],
+            }
+        ]
+        result = WorkflowsMixin._parse_workflow_status_properties(raw)
+        props = result[0]["statuses"][0]["properties"]
+        assert props["jira.permission.edit.denied"] == "true"
+
+    def test_skips_non_dict_items(self):
+        raw = ["not_a_dict", {"name": "WF3", "statuses": []}]
+        result = WorkflowsMixin._parse_workflow_status_properties(raw)
+        assert len(result) == 1
+        assert result[0]["workflow_name"] == "WF3"
+
+    def test_handles_empty_list(self):
+        assert WorkflowsMixin._parse_workflow_status_properties([]) == []

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2350,3 +2350,40 @@ async def test_get_attachment_images_issue_not_found(mock_jira_fetcher):
 
     assert result.structured_content["success"] is False
     assert "MISSING-1" in result.structured_content["error"]
+
+
+@pytest.mark.anyio
+async def test_get_workflow_paginated_alias_tool(mock_jira_fetcher):
+    """Singular alias tool returns the same payload as the plural tool."""
+    from fastmcp.server.context import Context
+
+    from mcp_atlassian.servers.jira import get_workflow_paginated
+
+    mock_jira_fetcher.get_workflows_paginated.return_value = {
+        "values": [{"name": "WF-1"}],
+        "total": 1,
+    }
+
+    ctx = MagicMock(spec=Context)
+    with patch(
+        "mcp_atlassian.servers.jira.get_jira_fetcher",
+        new_callable=AsyncMock,
+    ) as mock_get_fetcher:
+        mock_get_fetcher.return_value = mock_jira_fetcher
+        raw = await get_workflow_paginated.fn(
+            ctx,
+            workflow_name="WF",
+            expand="statuses",
+            start_at=0,
+            max_results=25,
+        )
+
+    data = json.loads(raw)
+    assert data["total"] == 1
+    assert data["values"][0]["name"] == "WF-1"
+    mock_jira_fetcher.get_workflows_paginated.assert_called_once_with(
+        start_at=0,
+        max_results=25,
+        workflow_name="WF",
+        expand="statuses",
+    )


### PR DESCRIPTION
## Description
Refines Jira workflow tooling for Data Center behavior and keeps only read/get workflow operations. Workflow-property write operations were removed.

## Changes
- Kept workflow read tools:
  - jira_get_all_workflows
  - jira_get_workflows_paginated
  - jira_get_workflow_status_properties
  - jira_check_issue_workflow_permissions
- Updated README tool sections and matrix to match current tool availability.

## Testing
- Ran: uv run pre-commit run --all-files
- Result: Passed
- Ran: uv run pytest
- Result: 1586 passed, 216 skipped, 2 warnings

## Checklist
- [x] Code follows project style guidelines
- [x] Tests added/updated for changes
- [x] All relevant tests pass locally
- [x] Documentation updated