### PR TITLE
feat(xray): add get_test_runs_in_context tool for retrieving test run…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1042,6 +1042,9 @@ A per-product header always takes precedence over the global header for that pro
 - `get_tests`: Retrieve information about specific tests
 - `get_test_statuses`: Get all available test statuses
 - `get_test_runs`: Get test runs for a specific test
+- `get_test_runs_in_context`: Get test runs from a Test Execution,
+  optionally including selected Test issue custom fields
+- `get_test_run`: Get an individual run with its execution metadata and steps
 - `get_test_executions`: Get test executions for a test
 - `get_test_plans`: Get test plans associated with a test
 - `create_test_step`: Create a new test step for a test
@@ -1058,18 +1061,19 @@ A per-product header always takes precedence over the global header for that pro
 |           | `jira_get_issue`              | `confluence_get_page`          | `list_repositories`                | `get_test_statuses`               |
 |           | `jira_get_all_projects`       | `confluence_get_page_children` | `get_repository_info`              | `get_test_runs`                   |
 |           | `jira_get_project_issues`     | `confluence_get_comments`      | `list_branches`                    | `get_test_runs_with_environment`  |
-|           | `jira_get_worklog`            | `confluence_get_labels`        | `get_default_branch`               | `get_test_preconditions`          |
-|           | `jira_get_transitions`        | `confluence_search_user`       | `get_file_content`                 | `get_test_sets`                   |
-|           | `jira_search_fields`          |                                | `list_directory`                   | `get_test_executions`             |
-|           | `jira_get_agile_boards`       |                                | `list_pull_requests`               | `get_test_plans`                  |
-|           | `jira_get_board_issues`       |                                | `pull_request_activities`          | `get_test_step_statuses`          |
-|           | `jira_get_sprints_from_board` |                                | `get_pull_request`                 | `get_test_step`                   |
-|           | `jira_get_sprint_issues`      |                                | `get_commit_changes`               | `get_test_steps`                  |
-|           | `jira_get_issue_link_types`   |                                | `get_commits`                      | `get_tests_with_precondition`     |
-|           | `jira_batch_get_changelogs`*  |                                |                                    | `get_tests_with_test_set`         |
-|           | `jira_get_user_profile`       |                                |                                    | `get_tests_with_test_plan`        |
-|           | `jira_download_attachments`   |                                |                                    | `get_test_executions_with_test_plan` |
-|           | `jira_get_project_versions`   |                                |                                    | `get_tests_with_test_execution`   |
+|           | `jira_get_worklog`            | `confluence_get_labels`        | `get_default_branch`               | `get_test_runs_in_context`        |
+|           | `jira_get_transitions`        | `confluence_search_user`       | `get_file_content`                 | `get_test_preconditions`          |
+|           | `jira_search_fields`          |                                | `list_directory`                   | `get_test_sets`                   |
+|           | `jira_get_agile_boards`       |                                | `list_pull_requests`               | `get_test_executions`             |
+|           | `jira_get_board_issues`       |                                | `pull_request_activities`          | `get_test_plans`                  |
+|           | `jira_get_sprints_from_board` |                                | `get_pull_request`                 | `get_test_step_statuses`          |
+|           | `jira_get_sprint_issues`      |                                | `get_commit_changes`               | `get_test_step`                   |
+|           | `jira_get_issue_link_types`   |                                | `get_commits`                      | `get_test_steps`                  |
+|           | `jira_batch_get_changelogs`*  |                                |                                    | `get_tests_with_precondition`     |
+|           | `jira_get_user_profile`       |                                |                                    | `get_tests_with_test_set`         |
+|           | `jira_download_attachments`   |                                |                                    | `get_tests_with_test_plan`        |
+|           | `jira_get_project_versions`   |                                |                                    | `get_test_executions_with_test_plan` |
+|           |                               |                                |                                    | `get_tests_with_test_execution`   |
 |           |                               |                                |                                    | `get_test_run`                    |
 |           |                               |                                |                                    | `get_test_run_assignee`           |
 |           |                               |                                |                                    | `get_test_run_iteration`          |

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -794,10 +794,11 @@ async def create_issue(
 async def batch_create_issues(
     ctx: Context,
     issues: Annotated[
-        str,
+        list[dict[str, Any]] | str,
         Field(
             description=(
-                "JSON array of issue objects. Each object should contain:\n"
+                "Array of issue objects. A JSON-encoded array string is also "
+                "accepted for backward compatibility. Each object should contain:\n"
                 "- project_key (required): The project key (e.g., 'PROJ')\n"
                 "- summary (required): Issue summary/title\n"
                 "- issue_type (required): Type of issue (e.g., 'Task', 'Bug')\n"
@@ -823,26 +824,28 @@ async def batch_create_issues(
 
     Args:
         ctx: The FastMCP context.
-        issues: JSON array string of issue objects.
+        issues: Issue objects as an array or a JSON-encoded array string.
         validate_only: If true, only validates without creating.
 
     Returns:
         JSON string indicating success and listing created issues (or validation result).
 
     Raises:
-        ValueError: If in read-only mode, Jira client unavailable, or invalid JSON.
+        ValueError: If in read-only mode, Jira client unavailable, or input is invalid.
     """
     jira = await get_jira_fetcher(ctx)
-    # Parse issues from JSON string
-    try:
-        issues_list = json.loads(issues)
-        if not isinstance(issues_list, list):
-            raise ValueError("Input 'issues' must be a JSON array string.")
-    except json.JSONDecodeError:
-        raise ValueError("Invalid JSON in issues")
-    except Exception as e:
-        msg = f"Invalid input for issues: {e}"
-        raise ValueError(msg) from e
+    if isinstance(issues, str):
+        try:
+            issues_list = json.loads(issues)
+        except json.JSONDecodeError as e:
+            raise ValueError("Invalid JSON in issues") from e
+    else:
+        issues_list = issues
+
+    if not isinstance(issues_list, list) or not all(
+        isinstance(issue, dict) for issue in issues_list
+    ):
+        raise ValueError("Input 'issues' must be an array of issue objects.")
 
     # Create issues in batch
     created_issues = jira.batch_create_issues(issues_list, validate_only=validate_only)

--- a/src/mcp_atlassian/servers/xray.py
+++ b/src/mcp_atlassian/servers/xray.py
@@ -146,6 +146,82 @@ async def get_test_runs_with_environment(
 
 
 @xray_mcp.tool(tags={"xray", "read"})
+async def get_test_runs_in_context(
+    ctx: Context,
+    test_exec_key: Annotated[
+        str,
+        Field(description="The Test Execution issue key (e.g., 'EXEC-001')"),
+    ],
+    test_key: Annotated[
+        str | None,
+        Field(
+            description="Optional Test issue key used to limit the results",
+            default=None,
+        ),
+    ] = None,
+    include_test_fields: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Optional comma-separated Test issue fields to include, such as "
+                "'summary,customfield_12345'"
+            ),
+            default=None,
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Field(
+            description="Maximum number of test runs per page (default: 10)",
+            default=10,
+            ge=1,
+            le=100,
+        ),
+    ] = 10,
+    page: Annotated[
+        int,
+        Field(description="Page number (default: 1)", default=1, ge=1),
+    ] = 1,
+) -> str:
+    """Retrieve detailed test runs from a Test Execution context.
+
+    This exposes Xray's contextual test-run endpoint, including run IDs, status,
+    execution metadata, steps when available, evidence, and requested custom fields
+    from the associated Test issue. A returned run ID can also be passed to
+    ``get_test_run`` for the complete individual run representation.
+
+    Args:
+        ctx: The FastMCP context.
+        test_exec_key: The Test Execution issue key.
+        test_key: Optional Test issue key used to limit the results.
+        include_test_fields: Optional comma-separated Test issue fields to include.
+        limit: Maximum number of test runs per page.
+        page: Page number.
+
+    Returns:
+        JSON string containing the contextual test runs.
+
+    Raises:
+        ValueError: If the Xray client is not configured or available.
+    """
+    xray = await get_xray_fetcher(ctx)
+    try:
+        result = xray.get_test_runs_in_context(
+            test_exec_key=test_exec_key,
+            test_key=test_key,
+            include_test_fields=include_test_fields,
+            limit=limit,
+            page=page,
+        )
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        logger.error(
+            f"Error retrieving test runs in Test Execution {test_exec_key}: {e}"
+        )
+        raise
+
+
+@xray_mcp.tool(tags={"xray", "read"})
 async def get_test_preconditions(
     ctx: Context,
     test_key: Annotated[

--- a/src/mcp_atlassian/xray/client.py
+++ b/src/mcp_atlassian/xray/client.py
@@ -129,3 +129,42 @@ class XrayClient:
             logger.debug(
                 f"Added custom headers: {get_masked_session_headers(self.config.custom_headers)}"
             )
+
+    def get_test_runs_in_context(
+        self,
+        test_exec_key: str,
+        test_key: str | None = None,
+        include_test_fields: str | None = None,
+        limit: int | None = None,
+        page: int | None = None,
+    ) -> Any:
+        """Retrieve test runs from a Test Execution using Xray REST API v2.
+
+        The contextual endpoint returns the run status and execution metadata and
+        can include selected custom fields from the associated Test issue. The
+        upstream Xray client defaults to API v1, so this method builds the v2 URL
+        explicitly without changing the API version used by other operations.
+
+        Args:
+            test_exec_key: Test Execution issue key.
+            test_key: Optional Test issue key used to limit the results.
+            include_test_fields: Optional comma-separated Test issue fields to
+                include in each result.
+            limit: Optional maximum number of test runs per page.
+            page: Optional page number.
+
+        Returns:
+            The response returned by the Xray contextual test-runs endpoint.
+        """
+        params: dict[str, str | int] = {"testExecKey": test_exec_key}
+        if test_key:
+            params["testKey"] = test_key
+        if include_test_fields:
+            params["includeTestFields"] = include_test_fields
+        if limit is not None:
+            params["limit"] = limit
+        if page is not None:
+            params["page"] = page
+
+        url = self.xray.resource_url("testruns", api_version="2.0")
+        return self.xray.get(url, params=params)

--- a/tests/fixtures/xray_mocks.py
+++ b/tests/fixtures/xray_mocks.py
@@ -155,6 +155,34 @@ MOCK_XRAY_TEST_RUNS_RESPONSE = [
     },
 ]
 
+MOCK_XRAY_TEST_RUNS_IN_CONTEXT_RESPONSE = [
+    {
+        "id": 12345,
+        "testExecKey": "EXEC-001",
+        "testKey": "TEST-001",
+        "status": "PASS",
+        "steps": [
+            {
+                "status": "PASS",
+                "actualResult": "Application login completed successfully",
+                "defects": [],
+                "evidences": [],
+            }
+        ],
+        "evidences": [
+            {
+                "filename": "execution-log.txt",
+                "contentType": "text/plain",
+                "data": "https://jira.example.com/xray/evidence/9001",
+            }
+        ],
+        "testIssueFields": {
+            "summary": "Validate application login",
+            "customfield_12345": "Automated",
+        },
+    }
+]
+
 # Mock Test Status Data - Updated with real API response
 MOCK_XRAY_TEST_STATUSES_RESPONSE = [
     {

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -892,6 +892,34 @@ async def test_batch_get_changelogs_tool(jira_client, mock_jira_fetcher):
 
 
 @pytest.mark.anyio
+async def test_batch_create_issues_accepts_native_array(jira_client, mock_jira_fetcher):
+    """Test that MCP callers can pass issues as a native JSON array."""
+    test_issues = [
+        {
+            "project_key": "TEST",
+            "summary": "Test Issue 1",
+            "issue_type": "Task",
+        },
+        {
+            "project_key": "TEST",
+            "summary": "Test Issue 2",
+            "issue_type": "Bug",
+        },
+    ]
+
+    response = await jira_client.call_tool(
+        "jira_batch_create_issues",
+        {"issues": test_issues, "validate_only": False},
+    )
+
+    content = json.loads(response.content[0].text)
+    assert len(content["issues"]) == 2
+    mock_jira_fetcher.batch_create_issues.assert_called_once_with(
+        test_issues, validate_only=False
+    )
+
+
+@pytest.mark.anyio
 async def test_batch_get_changelogs_not_cloud(jira_client, mock_jira_fetcher):
     """Ensure jira_batch_get_changelogs errors on server/DC."""
     mock_jira_fetcher.config.is_cloud = False

--- a/tests/unit/servers/test_xray_server.py
+++ b/tests/unit/servers/test_xray_server.py
@@ -25,6 +25,7 @@ from tests.fixtures.xray_mocks import (
     MOCK_XRAY_TEST_EXECUTIONS_WITH_TEST_PLAN_RESPONSE,
     MOCK_XRAY_TEST_PLANS_RESPONSE,
     MOCK_XRAY_TEST_RUN_RESPONSE,
+    MOCK_XRAY_TEST_RUNS_IN_CONTEXT_RESPONSE,
     MOCK_XRAY_TEST_RUNS_RESPONSE,
     MOCK_XRAY_TEST_SETS_RESPONSE,
     MOCK_XRAY_TEST_STATUSES_RESPONSE,
@@ -82,6 +83,19 @@ def mock_xray_fetcher():
     mock_fetcher.xray.get_test_runs_with_environment.side_effect = (
         mock_get_test_runs_with_environment
     )
+
+    def mock_get_test_runs_in_context(
+        test_exec_key,
+        test_key=None,
+        include_test_fields=None,
+        limit=10,
+        page=1,
+    ):
+        if not test_exec_key:
+            raise ValueError("Test Execution key is required")
+        return MOCK_XRAY_TEST_RUNS_IN_CONTEXT_RESPONSE
+
+    mock_fetcher.get_test_runs_in_context.side_effect = mock_get_test_runs_in_context
 
     # Configure get_test_preconditions
     def mock_get_test_preconditions(test_key):
@@ -560,6 +574,36 @@ async def test_get_test_runs_with_environment(xray_client, mock_xray_fetcher):
     assert len(content) == 2
     mock_xray_fetcher.xray.get_test_runs_with_environment.assert_called_once_with(
         "TEST-001", "Android,iOS"
+    )
+
+
+@pytest.mark.anyio
+async def test_get_test_runs_in_context(xray_client, mock_xray_fetcher):
+    """Test detailed test-run retrieval from a Test Execution context."""
+    response = await xray_client.call_tool(
+        "xray_get_test_runs_in_context",
+        {
+            "test_exec_key": "EXEC-001",
+            "test_key": "TEST-001",
+            "include_test_fields": "summary,customfield_12345",
+            "limit": 10,
+            "page": 1,
+        },
+    )
+
+    content = json.loads(response.content[0].text)
+    test_run = content[0]
+    assert test_run["id"] == 12345
+    assert test_run["status"] == "PASS"
+    assert test_run["steps"][0]["actualResult"]
+    assert "evidences" in test_run["steps"][0]
+    assert test_run["testIssueFields"]["customfield_12345"] == "Automated"
+    mock_xray_fetcher.get_test_runs_in_context.assert_called_once_with(
+        test_exec_key="EXEC-001",
+        test_key="TEST-001",
+        include_test_fields="summary,customfield_12345",
+        limit=10,
+        page=1,
     )
 
 

--- a/tests/unit/xray/test_xray_client.py
+++ b/tests/unit/xray/test_xray_client.py
@@ -442,3 +442,42 @@ def test_init_empty_custom_headers():
         mock_session.headers.update.assert_not_called()
 
         assert client.config == config
+
+
+def test_get_test_runs_in_context_uses_v2_endpoint():
+    """Contextual test runs should use API v2 without changing other endpoints."""
+    with (
+        patch("mcp_atlassian.xray.client.Xray") as mock_xray,
+        patch("mcp_atlassian.xray.client.configure_ssl_verification"),
+    ):
+        config = XrayConfig(
+            url="https://xray.example.com",
+            auth_type="pat",
+            personal_token="test_token",
+        )
+        client = XrayClient(config=config)
+        expected = [{"id": 12345}]
+        mock_xray.return_value.get.return_value = expected
+
+        result = client.get_test_runs_in_context(
+            test_exec_key="EXEC-001",
+            test_key="TEST-001",
+            include_test_fields="summary,customfield_12345",
+            limit=25,
+            page=2,
+        )
+
+        assert result == expected
+        mock_xray.return_value.resource_url.assert_called_once_with(
+            "testruns", api_version="2.0"
+        )
+        mock_xray.return_value.get.assert_called_once_with(
+            mock_xray.return_value.resource_url.return_value,
+            params={
+                "testExecKey": "EXEC-001",
+                "testKey": "TEST-001",
+                "includeTestFields": "summary,customfield_12345",
+                "limit": 25,
+                "page": 2,
+            },
+        )


### PR DESCRIPTION
## Description

1. Adds xray_get_test_runs_in_context tool to retrieve all test runs within a Test Execution using Xray REST API v2. This enables discovering run IDs, status, and execution metadata directly from a Test Execution key, which can then be passed to the existing get_test_run for detailed individual run information.
2. Fixes jira_batch_create_issues tool to accept native JSON arrays from MCP clients. Previously, the tool only accepted JSON-encoded strings, causing failures when MCP clients sent issues as native arrays (the expected behavior for JSON parameters in MCP).

##Changes
- Added XrayClient.get_test_runs_in_context() method using Xray API v2 endpoint
- Added xray_get_test_runs_in_context MCP tool with pagination support (limit: 1-100, page: ≥1)
- Added optional test filtering and custom Test issue field inclusion
- Added comprehensive unit tests for client and server (3 tests, all passing)
- Changed input type signature from str to [list[dict[str, Any]] | str] in jira_batch_create_issues tool