### PR TITLE
Large JQL queries routed through the Jira MCP

### DIFF
--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -1,6 +1,7 @@
 """Module for Jira search operations."""
 
 import logging
+from typing import Any
 
 import requests
 from requests.exceptions import HTTPError
@@ -85,74 +86,33 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             else:
                 fields_param = fields
 
-            if self.config.is_cloud:
-                actual_total = -1
-                try:
-                    # Call 1: Get metadata (including total) using standard search API
-                    metadata_params = {"jql": jql, "maxResults": 0}
-                    metadata_response = self.jira.get(
-                        self.jira.resource_url("search"), params=metadata_params
-                    )
+            # Use POST for all JQL searches to avoid URL length limits with large
+            # queries (e.g. 150-180 AND/OR clauses). The Jira REST API accepts
+            # POST on /rest/api/2/search with the JQL and options in the body,
+            # which has no practical length limit unlike GET query parameters.
+            response = self._jql_search_post(
+                jql=jql,
+                fields_param=fields_param,
+                start=start,
+                limit=limit,
+                expand=expand,
+                is_cloud=self.config.is_cloud,
+            )
 
-                    if (
-                        isinstance(metadata_response, dict)
-                        and "total" in metadata_response
-                    ):
-                        try:
-                            actual_total = int(metadata_response["total"])
-                        except (ValueError, TypeError):
-                            logger.warning(
-                                f"Could not parse 'total' from metadata response for JQL: {jql}. Received: {metadata_response.get('total')}"
-                            )
-                    else:
-                        logger.warning(
-                            f"Could not retrieve total count from metadata response for JQL: {jql}. Response type: {type(metadata_response)}"
-                        )
-                except Exception as meta_err:
-                    logger.error(
-                        f"Error fetching metadata for JQL '{jql}': {str(meta_err)}"
-                    )
-
-                # Call 2: Get the actual issues using the enhanced method
-                issues_response_list = self.jira.enhanced_jql_get_list_of_tickets(
-                    jql, fields=fields_param, limit=limit, expand=expand
+            if not isinstance(response, dict):
+                msg = (
+                    "Unexpected return value type from JQL POST search:"
+                    f" {type(response)}"
                 )
+                logger.error(msg)
+                raise TypeError(msg)
 
-                if not isinstance(issues_response_list, list):
-                    msg = f"Unexpected return value type from `jira.enhanced_jql_get_list_of_tickets`: {type(issues_response_list)}"
-                    logger.error(msg)
-                    raise TypeError(msg)
-
-                response_dict_for_model = {
-                    "issues": issues_response_list,
-                    "total": actual_total,
-                }
-
-                search_result = JiraSearchResult.from_api_response(
-                    response_dict_for_model,
-                    base_url=self.config.url,
-                    requested_fields=fields_param,
-                )
-
-                # Return the full search result object
-                return search_result
-            else:
-                limit = min(limit, 50)
-                response = self.jira.jql(
-                    jql, fields=fields_param, start=start, limit=limit, expand=expand
-                )
-                if not isinstance(response, dict):
-                    msg = f"Unexpected return value type from `jira.jql`: {type(response)}"
-                    logger.error(msg)
-                    raise TypeError(msg)
-
-                # Convert the response to a search result model
-                search_result = JiraSearchResult.from_api_response(
-                    response, base_url=self.config.url, requested_fields=fields_param
-                )
-
-                # Return the full search result object
-                return search_result
+            search_result = JiraSearchResult.from_api_response(
+                response,
+                base_url=self.config.url,
+                requested_fields=fields_param,
+            )
+            return search_result
 
         except HTTPError as http_err:
             if http_err.response is not None and http_err.response.status_code in [
@@ -172,6 +132,65 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             logger.error(f"Error searching issues with JQL '{jql}': {str(e)}")
             msg = f"Error searching issues: {str(e)}"
             raise Exception(msg) from e
+
+    def _jql_search_post(
+        self,
+        jql: str,
+        fields_param: str | None,
+        start: int,
+        limit: int,
+        expand: str | None,
+        *,
+        is_cloud: bool,
+    ) -> dict[str, Any]:
+        """Execute a JQL search using HTTP POST to avoid URL length limits.
+
+        The Jira REST API accepts POST on /rest/api/2/search with all search
+        parameters in the JSON body. This sidesteps the URL query-string length
+        limits that cause GET requests with large JQL strings (≥ ~150 AND/OR
+        clauses) to fail silently or with HTTP 414/400 errors.
+
+        Args:
+            jql: JQL query string (may be arbitrarily long).
+            fields_param: Comma-separated field list, "*all", or None for default.
+            start: Zero-based starting offset for pagination.
+            limit: Maximum number of issues to return.
+            expand: Optional comma-separated list of items to expand.
+            is_cloud: Whether the target is Jira Cloud (caps maxResults at 100).
+
+        Returns:
+            Raw dict response from /rest/api/2/search containing ``issues``,
+            ``total``, ``startAt``, and ``maxResults``.
+        """
+        max_results = min(limit, 100) if is_cloud else min(limit, 50)
+
+        body: dict[str, Any] = {
+            "jql": jql,
+            "startAt": start,
+            "maxResults": max_results,
+        }
+
+        if fields_param:
+            if fields_param == "*all":
+                body["fields"] = ["*all"]
+            else:
+                body["fields"] = [
+                    f.strip() for f in fields_param.split(",") if f.strip()
+                ]
+
+        if expand:
+            body["expand"] = [e.strip() for e in expand.split(",") if e.strip()]
+
+        url = self.jira.resource_url("search")
+        logger.debug("JQL POST search to %s (jql length=%d)", url, len(jql))
+        response = self.jira.post(url, json=body)
+
+        if not isinstance(response, dict):
+            msg = f"Unexpected response type from JQL POST search: {type(response)}"
+            logger.error(msg)
+            raise TypeError(msg)
+
+        return response
 
     def get_board_issues(
         self,

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -86,26 +86,78 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             else:
                 fields_param = fields
 
-            # Use POST for all JQL searches to avoid URL length limits with large
-            # queries (e.g. 150-180 AND/OR clauses). The Jira REST API accepts
-            # POST on /rest/api/2/search with the JQL and options in the body,
-            # which has no practical length limit unlike GET query parameters.
+            if self.config.is_cloud:
+                # Jira Cloud: the legacy POST /rest/api/2/search endpoint has
+                # been removed by Atlassian. Use the enhanced JQL API (which
+                # itself POSTs to /rest/api/3/search/jql and therefore also
+                # avoids URL-length limits for large queries).
+                actual_total = -1
+                try:
+                    # Call 1: Get metadata (including total) using the search API
+                    metadata_params = {"jql": jql, "maxResults": 0}
+                    metadata_response = self.jira.get(
+                        self.jira.resource_url("search"), params=metadata_params
+                    )
+
+                    if (
+                        isinstance(metadata_response, dict)
+                        and "total" in metadata_response
+                    ):
+                        try:
+                            actual_total = int(metadata_response["total"])
+                        except (ValueError, TypeError):
+                            logger.warning(
+                                f"Could not parse 'total' from metadata response "
+                                f"for JQL: {jql}. Received: "
+                                f"{metadata_response.get('total')}"
+                            )
+                    else:
+                        logger.warning(
+                            f"Could not retrieve total count from metadata "
+                            f"response for JQL: {jql}. Response type: "
+                            f"{type(metadata_response)}"
+                        )
+                except Exception as meta_err:
+                    logger.error(
+                        f"Error fetching metadata for JQL '{jql}': {str(meta_err)}"
+                    )
+
+                # Call 2: Get the actual issues using the enhanced method
+                issues_response_list = self.jira.enhanced_jql_get_list_of_tickets(
+                    jql, fields=fields_param, limit=limit, expand=expand
+                )
+
+                if not isinstance(issues_response_list, list):
+                    msg = (
+                        "Unexpected return value type from "
+                        "`jira.enhanced_jql_get_list_of_tickets`: "
+                        f"{type(issues_response_list)}"
+                    )
+                    logger.error(msg)
+                    raise TypeError(msg)
+
+                response_dict_for_model = {
+                    "issues": issues_response_list,
+                    "total": actual_total,
+                }
+
+                search_result = JiraSearchResult.from_api_response(
+                    response_dict_for_model,
+                    base_url=self.config.url,
+                    requested_fields=fields_param,
+                )
+                return search_result
+
+            # Jira Server/DC: use POST on /rest/api/2/search to avoid URL length
+            # limits with large queries (e.g. 150-180 AND/OR clauses). The body
+            # has no practical length limit unlike GET query parameters.
             response = self._jql_search_post(
                 jql=jql,
                 fields_param=fields_param,
                 start=start,
                 limit=limit,
                 expand=expand,
-                is_cloud=self.config.is_cloud,
             )
-
-            if not isinstance(response, dict):
-                msg = (
-                    "Unexpected return value type from JQL POST search:"
-                    f" {type(response)}"
-                )
-                logger.error(msg)
-                raise TypeError(msg)
 
             search_result = JiraSearchResult.from_api_response(
                 response,
@@ -140,15 +192,14 @@ class SearchMixin(JiraClient, IssueOperationsProto):
         start: int,
         limit: int,
         expand: str | None,
-        *,
-        is_cloud: bool,
     ) -> dict[str, Any]:
         """Execute a JQL search using HTTP POST to avoid URL length limits.
 
-        The Jira REST API accepts POST on /rest/api/2/search with all search
-        parameters in the JSON body. This sidesteps the URL query-string length
-        limits that cause GET requests with large JQL strings (≥ ~150 AND/OR
-        clauses) to fail silently or with HTTP 414/400 errors.
+        Used for Jira Server/DC, where ``POST /rest/api/2/search`` remains
+        supported. It accepts all search parameters in the JSON body, which
+        sidesteps the URL query-string length limits that cause GET requests
+        with large JQL strings (≥ ~150 AND/OR clauses) to fail with HTTP
+        414/400 errors.
 
         Args:
             jql: JQL query string (may be arbitrarily long).
@@ -156,13 +207,12 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             start: Zero-based starting offset for pagination.
             limit: Maximum number of issues to return.
             expand: Optional comma-separated list of items to expand.
-            is_cloud: Whether the target is Jira Cloud (caps maxResults at 100).
 
         Returns:
             Raw dict response from /rest/api/2/search containing ``issues``,
             ``total``, ``startAt``, and ``maxResults``.
         """
-        max_results = min(limit, 100) if is_cloud else min(limit, 50)
+        max_results = min(limit, 50)
 
         body: dict[str, Any] = {
             "jql": jql,

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -52,19 +52,42 @@ class TestSearchMixin:
             "maxResults": 50,
         }
 
+    @staticmethod
+    def _setup_dual_mocks(search_mixin, issues_response):
+        """Mock both the Cloud (enhanced JQL) and Server/DC (POST) code paths."""
+        search_mixin.jira.post = MagicMock(return_value=issues_response)
+        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
+            return_value=issues_response["issues"]
+        )
+        search_mixin.jira.get = MagicMock(
+            return_value={"total": issues_response.get("total", 0)}
+        )
+
+    @staticmethod
+    def _constructed_jql(search_mixin, is_cloud):
+        """Return the JQL actually sent, regardless of deployment path."""
+        if is_cloud:
+            return search_mixin.jira.enhanced_jql_get_list_of_tickets.call_args[0][0]
+        return search_mixin.jira.post.call_args[1]["json"]["jql"]
+
+    @staticmethod
+    def _reset_dual_mocks(search_mixin):
+        search_mixin.jira.post.reset_mock()
+        search_mixin.jira.enhanced_jql_get_list_of_tickets.reset_mock()
+
     @pytest.mark.parametrize("is_cloud", [True, False])
-    def test_search_issues_uses_post_for_all_queries(
+    def test_search_issues_routes_by_deployment(
         self,
         search_mixin: SearchMixin,
         mock_issues_response,
         is_cloud,
     ):
-        """Both Cloud and DC use POST /rest/api/2/search to avoid URL length limits."""
+        """Cloud uses the enhanced JQL API; Server/DC uses POST /rest/api/2/search."""
         search_mixin.config.is_cloud = is_cloud
         search_mixin.config.projects_filter = None
         search_mixin.config.url = "https://test.example.com"
 
-        search_mixin.jira.post = MagicMock(return_value=mock_issues_response)
+        self._setup_dual_mocks(search_mixin, mock_issues_response)
 
         jql_query = "project = TEST"
         result = search_mixin.search_issues(jql_query, limit=10, start=0)
@@ -72,12 +95,19 @@ class TestSearchMixin:
         assert isinstance(result, JiraSearchResult)
         assert len(result.issues) > 0
 
-        search_mixin.jira.post.assert_called_once()
-        call_kwargs = search_mixin.jira.post.call_args[1]
-        body = call_kwargs["json"]
-        assert body["jql"] == jql_query
-        assert body["startAt"] == 0
-        assert "maxResults" in body
+        if is_cloud:
+            search_mixin.jira.enhanced_jql_get_list_of_tickets.assert_called_once()
+            assert (
+                search_mixin.jira.enhanced_jql_get_list_of_tickets.call_args[0][0]
+                == jql_query
+            )
+            search_mixin.jira.post.assert_not_called()
+        else:
+            search_mixin.jira.post.assert_called_once()
+            body = search_mixin.jira.post.call_args[1]["json"]
+            assert body["jql"] == jql_query
+            assert body["startAt"] == 0
+            assert "maxResults" in body
 
     def test_search_issues_basic(self, search_mixin: SearchMixin):
         """Test basic search functionality."""
@@ -516,24 +546,24 @@ class TestSearchMixin:
         search_mixin.config.projects_filter = None
         search_mixin.config.url = "https://test.example.com"
 
-        search_mixin.jira.post = MagicMock(return_value=mock_issues_response)
+        self._setup_dual_mocks(search_mixin, mock_issues_response)
 
         # Single project filter
         search_mixin.search_issues("text ~ 'test'", projects_filter="TEST")
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == "(text ~ 'test') AND project = \"TEST\""
-        search_mixin.jira.post.reset_mock()
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == "(text ~ 'test') AND project = \"TEST\""
+        self._reset_dual_mocks(search_mixin)
 
         # Multiple projects filter
         search_mixin.search_issues("text ~ 'test'", projects_filter="TEST, DEV")
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == '(text ~ \'test\') AND project IN ("TEST", "DEV")'
-        search_mixin.jira.post.reset_mock()
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == '(text ~ \'test\') AND project IN ("TEST", "DEV")'
+        self._reset_dual_mocks(search_mixin)
 
         # Existing JQL already contains project filter — not wrapped
         search_mixin.search_issues("project = OTHER", projects_filter="TEST")
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == "project = OTHER"
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == "project = OTHER"
 
     @pytest.mark.parametrize("is_cloud", [True, False])
     def test_search_issues_with_config_projects_filter_jql_construction(
@@ -544,18 +574,18 @@ class TestSearchMixin:
         search_mixin.config.projects_filter = "CONF1,CONF2"
         search_mixin.config.url = "https://test.example.com"
 
-        search_mixin.jira.post = MagicMock(return_value=mock_issues_response)
+        self._setup_dual_mocks(search_mixin, mock_issues_response)
 
         # Use config filter
         search_mixin.search_issues("text ~ 'test'")
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == '(text ~ \'test\') AND project IN ("CONF1", "CONF2")'
-        search_mixin.jira.post.reset_mock()
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == '(text ~ \'test\') AND project IN ("CONF1", "CONF2")'
+        self._reset_dual_mocks(search_mixin)
 
         # Override config filter with parameter
         search_mixin.search_issues("text ~ 'test'", projects_filter="OVERRIDE")
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == "(text ~ 'test') AND project = \"OVERRIDE\""
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == "(text ~ 'test') AND project = \"OVERRIDE\""
 
     @pytest.mark.parametrize("is_cloud", [True, False])
     def test_search_issues_with_empty_jql_and_projects_filter(
@@ -567,24 +597,24 @@ class TestSearchMixin:
         search_mixin.config.projects_filter = None
         search_mixin.config.url = "https://test.example.com"
 
-        search_mixin.jira.post = MagicMock(return_value=mock_issues_response)
+        self._setup_dual_mocks(search_mixin, mock_issues_response)
 
         # Test 1: Empty string JQL with single project
         search_mixin.search_issues("", projects_filter="PROJ1")
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == 'project = "PROJ1"'
-        search_mixin.jira.post.reset_mock()
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == 'project = "PROJ1"'
+        self._reset_dual_mocks(search_mixin)
 
         # Test 2: Empty string JQL with multiple projects
         search_mixin.search_issues("", projects_filter="PROJ1,PROJ2")
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == 'project IN ("PROJ1", "PROJ2")'
-        search_mixin.jira.post.reset_mock()
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == 'project IN ("PROJ1", "PROJ2")'
+        self._reset_dual_mocks(search_mixin)
 
         # Test 3: None JQL with projects filter
         result = search_mixin.search_issues(None, projects_filter="PROJ1")
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == 'project = "PROJ1"'
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == 'project = "PROJ1"'
         assert isinstance(result, JiraSearchResult)
 
     @pytest.mark.parametrize("is_cloud", [True, False])
@@ -597,34 +627,34 @@ class TestSearchMixin:
         search_mixin.config.projects_filter = None
         search_mixin.config.url = "https://test.example.com"
 
-        search_mixin.jira.post = MagicMock(return_value=mock_issues_response)
+        self._setup_dual_mocks(search_mixin, mock_issues_response)
 
         # Test 1: ORDER BY with single project
         search_mixin.search_issues("ORDER BY created DESC", projects_filter="PROJ1")
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == 'project = "PROJ1" ORDER BY created DESC'
-        search_mixin.jira.post.reset_mock()
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == 'project = "PROJ1" ORDER BY created DESC'
+        self._reset_dual_mocks(search_mixin)
 
         # Test 2: ORDER BY with multiple projects
         search_mixin.search_issues(
             "ORDER BY created DESC", projects_filter="PROJ1,PROJ2"
         )
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == 'project IN ("PROJ1", "PROJ2") ORDER BY created DESC'
-        search_mixin.jira.post.reset_mock()
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == 'project IN ("PROJ1", "PROJ2") ORDER BY created DESC'
+        self._reset_dual_mocks(search_mixin)
 
         # Test 3: Case insensitive ORDER BY
         search_mixin.search_issues("order by updated ASC", projects_filter="PROJ1")
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == 'project = "PROJ1" order by updated ASC'
-        search_mixin.jira.post.reset_mock()
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == 'project = "PROJ1" order by updated ASC'
+        self._reset_dual_mocks(search_mixin)
 
         # Test 4: ORDER BY with extra spaces
         search_mixin.search_issues(
             "  ORDER BY priority DESC  ", projects_filter="PROJ1"
         )
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["jql"] == 'project = "PROJ1"   ORDER BY priority DESC  '
+        jql = self._constructed_jql(search_mixin, is_cloud)
+        assert jql == 'project = "PROJ1"   ORDER BY priority DESC  '
 
     def test_search_issues_large_jql_uses_post_body(self, search_mixin: SearchMixin):
         """Large JQL with many OR clauses must be passed via POST body unchanged."""
@@ -648,7 +678,8 @@ class TestSearchMixin:
         body = search_mixin.jira.post.call_args[1]["json"]
         # Full JQL must be in the request body — not truncated or URL-encoded
         assert body["jql"] == large_jql
-        assert len(body["jql"]) > 2000  # Confirms we exceed typical URL length limits
+        # Confirms we exceed typical URL length limits
+        assert len(body["jql"]) > 2000
 
     def test_search_issues_post_body_fields_star_all(self, search_mixin: SearchMixin):
         """fields='*all' is correctly serialised to ['*all'] in the POST body."""
@@ -685,16 +716,16 @@ class TestSearchMixin:
         body = search_mixin.jira.post.call_args[1]["json"]
         assert body["maxResults"] <= 50
 
-    def test_search_issues_cloud_caps_max_results_at_100(
-        self, search_mixin: SearchMixin
-    ):
-        """Cloud path caps maxResults at 100."""
+    def test_search_issues_cloud_uses_enhanced_jql(self, search_mixin: SearchMixin):
+        """Cloud path uses the enhanced JQL API, passing the requested limit."""
         search_mixin.config.is_cloud = True
-        search_mixin.jira.post = MagicMock(
-            return_value={"issues": [], "total": 0, "startAt": 0, "maxResults": 100}
-        )
+        search_mixin.jira.get = MagicMock(return_value={"total": 0})
+        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(return_value=[])
+        search_mixin.jira.post = MagicMock()
 
         search_mixin.search_issues("project = TEST", limit=200)
 
-        body = search_mixin.jira.post.call_args[1]["json"]
-        assert body["maxResults"] <= 100
+        search_mixin.jira.enhanced_jql_get_list_of_tickets.assert_called_once()
+        _, kwargs = search_mixin.jira.enhanced_jql_get_list_of_tickets.call_args
+        assert kwargs["limit"] == 200
+        search_mixin.jira.post.assert_not_called()

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -1,6 +1,6 @@
 """Tests for the Jira Search mixin."""
 
-from unittest.mock import ANY, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 import requests
@@ -52,69 +52,32 @@ class TestSearchMixin:
             "maxResults": 50,
         }
 
-    @pytest.mark.parametrize(
-        "is_cloud, expected_method_name",
-        [
-            (True, "enhanced_jql_get_list_of_tickets"),  # Cloud scenario
-            (False, "jql"),  # Server/DC scenario
-        ],
-    )
-    def test_search_issues_calls_correct_method(
+    @pytest.mark.parametrize("is_cloud", [True, False])
+    def test_search_issues_uses_post_for_all_queries(
         self,
         search_mixin: SearchMixin,
         mock_issues_response,
         is_cloud,
-        expected_method_name,
     ):
-        """Test that the correct Jira API method is called based on Cloud/Server setting."""
-        # Setup: Mock config.is_cloud
+        """Both Cloud and DC use POST /rest/api/2/search to avoid URL length limits."""
         search_mixin.config.is_cloud = is_cloud
-        search_mixin.config.projects_filter = None  # No filter for this test
-        search_mixin.config.url = (
-            "https://test.example.com"  # Model creation needs this
-        )
+        search_mixin.config.projects_filter = None
+        search_mixin.config.url = "https://test.example.com"
 
-        # Setup: Mock response for both API methods
-        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
-            return_value=mock_issues_response["issues"]
-        )
-        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
+        search_mixin.jira.post = MagicMock(return_value=mock_issues_response)
 
-        # Determine other method name for assertion
-        other_method_name = (
-            "jql"
-            if expected_method_name == "enhanced_jql_get_list_of_tickets"
-            else "enhanced_jql_get_list_of_tickets"
-        )
-
-        # Act
         jql_query = "project = TEST"
         result = search_mixin.search_issues(jql_query, limit=10, start=0)
 
-        # Assert: Basic result verification
         assert isinstance(result, JiraSearchResult)
-        assert len(result.issues) > 0  # Based on mocked response
+        assert len(result.issues) > 0
 
-        # Assert: Correct method call verification
-        expected_method_mock = getattr(search_mixin.jira, expected_method_name)
-
-        # Define expected kwargs based on whether it's Cloud or Server
-        expected_kwargs = {
-            "limit": 10,
-            "expand": None,
-        }
-
-        # Add start param only for Server/DC
-        if not is_cloud:
-            expected_kwargs["start"] = 0
-
-        expected_method_mock.assert_called_once_with(
-            jql_query, fields=ANY, **expected_kwargs
-        )
-
-        # Assert: Other method was not called
-        other_method_mock = getattr(search_mixin.jira, other_method_name)
-        other_method_mock.assert_not_called()
+        search_mixin.jira.post.assert_called_once()
+        call_kwargs = search_mixin.jira.post.call_args[1]
+        body = call_kwargs["json"]
+        assert body["jql"] == jql_query
+        assert body["startAt"] == 0
+        assert "maxResults" in body
 
     def test_search_issues_basic(self, search_mixin: SearchMixin):
         """Test basic search functionality."""
@@ -139,19 +102,17 @@ class TestSearchMixin:
             "startAt": 0,
             "maxResults": 50,
         }
-        search_mixin.jira.jql.return_value = mock_issues
+        search_mixin.jira.post = MagicMock(return_value=mock_issues)
 
         # Call the method
         result = search_mixin.search_issues("project = TEST")
 
-        # Verify
-        search_mixin.jira.jql.assert_called_once_with(
-            "project = TEST",
-            fields=ANY,
-            start=0,
-            limit=50,
-            expand=None,
-        )
+        # Verify POST call with correct body
+        search_mixin.jira.post.assert_called_once()
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == "project = TEST"
+        assert body["startAt"] == 0
+        assert body["maxResults"] == 50
 
         # Verify results
         assert isinstance(result, JiraSearchResult)
@@ -173,7 +134,6 @@ class TestSearchMixin:
         assert issue.priority is not None
         assert issue.priority.name == "High"
 
-        # Remove backward compatibility checks
         assert "Issue description" in issue.description
         assert issue.key == "TEST-123"
 
@@ -199,7 +159,7 @@ class TestSearchMixin:
             "startAt": 0,
             "maxResults": 50,
         }
-        search_mixin.jira.jql.return_value = mock_issues
+        search_mixin.jira.post = MagicMock(return_value=mock_issues)
 
         # Call the method
         result = search_mixin.search_issues("project = TEST")
@@ -211,7 +171,6 @@ class TestSearchMixin:
         assert result.issues[0].description is None
         assert result.issues[0].summary == "Test issue"
 
-        # Update to use direct properties instead of backward compatibility
         assert "Test issue" in result.issues[0].summary
 
     def test_search_issues_with_missing_fields(self, search_mixin: SearchMixin):
@@ -231,7 +190,7 @@ class TestSearchMixin:
             "startAt": 0,
             "maxResults": 50,
         }
-        search_mixin.jira.jql.return_value = mock_issues
+        search_mixin.jira.post = MagicMock(return_value=mock_issues)
 
         # Call the method
         result = search_mixin.search_issues("project = TEST")
@@ -247,7 +206,9 @@ class TestSearchMixin:
     def test_search_issues_with_empty_results(self, search_mixin: SearchMixin):
         """Test search with no results."""
         # Setup mock response
-        search_mixin.jira.jql.return_value = {"issues": []}
+        search_mixin.jira.post = MagicMock(
+            return_value={"issues": [], "total": 0, "startAt": 0, "maxResults": 50}
+        )
 
         # Call the method
         result = search_mixin.search_issues("project = NONEXISTENT")
@@ -255,12 +216,11 @@ class TestSearchMixin:
         # Verify results
         assert isinstance(result, JiraSearchResult)
         assert len(result.issues) == 0
-        assert result.total == -1
 
     def test_search_issues_with_error(self, search_mixin: SearchMixin):
         """Test search with API error."""
         # Setup mock to raise exception
-        search_mixin.jira.jql.side_effect = Exception("API Error")
+        search_mixin.jira.post = MagicMock(side_effect=Exception("API Error"))
 
         # Call the method and verify it raises the expected exception
         with pytest.raises(Exception, match="Error searching issues"):
@@ -285,30 +245,22 @@ class TestSearchMixin:
             "startAt": 0,
             "maxResults": 50,
         }
-        search_mixin.jira.jql.return_value = mock_issues
+        search_mixin.jira.post = MagicMock(return_value=mock_issues)
         search_mixin.config.url = "https://example.atlassian.net"
 
         # Test with single project filter
         result = search_mixin.search_issues("text ~ 'test'", projects_filter="TEST")
-        search_mixin.jira.jql.assert_called_with(
-            "(text ~ 'test') AND project = \"TEST\"",
-            fields=ANY,
-            start=0,
-            limit=50,
-            expand=None,
-        )
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == "(text ~ 'test') AND project = \"TEST\""
         assert len(result.issues) == 1
         assert result.total == 1
 
+        search_mixin.jira.post.reset_mock()
+
         # Test with multiple project filter
         result = search_mixin.search_issues("text ~ 'test'", projects_filter="TEST,DEV")
-        search_mixin.jira.jql.assert_called_with(
-            '(text ~ \'test\') AND project IN ("TEST", "DEV")',
-            fields=ANY,
-            start=0,
-            limit=50,
-            expand=None,
-        )
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == '(text ~ \'test\') AND project IN ("TEST", "DEV")'
         assert len(result.issues) == 1
         assert result.total == 1
 
@@ -331,45 +283,34 @@ class TestSearchMixin:
             "startAt": 0,
             "maxResults": 50,
         }
-        search_mixin.jira.jql.return_value = mock_issues
+        search_mixin.jira.post = MagicMock(return_value=mock_issues)
         search_mixin.config.url = "https://example.atlassian.net"
         search_mixin.config.projects_filter = "TEST,DEV"
 
         # Test with config filter
         result = search_mixin.search_issues("text ~ 'test'")
-        search_mixin.jira.jql.assert_called_with(
-            '(text ~ \'test\') AND project IN ("TEST", "DEV")',
-            fields=ANY,
-            start=0,
-            limit=50,
-            expand=None,
-        )
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == '(text ~ \'test\') AND project IN ("TEST", "DEV")'
         assert len(result.issues) == 1
         assert result.total == 1
 
+        search_mixin.jira.post.reset_mock()
+
         # Test with override
         result = search_mixin.search_issues("text ~ 'test'", projects_filter="OVERRIDE")
-        search_mixin.jira.jql.assert_called_with(
-            "(text ~ 'test') AND project = \"OVERRIDE\"",
-            fields=ANY,
-            start=0,
-            limit=50,
-            expand=None,
-        )
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == "(text ~ 'test') AND project = \"OVERRIDE\""
         assert len(result.issues) == 1
         assert result.total == 1
+
+        search_mixin.jira.post.reset_mock()
 
         # Test with override - multiple projects
         result = search_mixin.search_issues(
             "text ~ 'test'", projects_filter="OVER1,OVER2"
         )
-        search_mixin.jira.jql.assert_called_with(
-            '(text ~ \'test\') AND project IN ("OVER1", "OVER2")',
-            fields=ANY,
-            start=0,
-            limit=50,
-            expand=None,
-        )
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == '(text ~ \'test\') AND project IN ("OVER1", "OVER2")'
         assert len(result.issues) == 1
         assert result.total == 1
 
@@ -402,7 +343,7 @@ class TestSearchMixin:
             "startAt": 0,
             "maxResults": 50,
         }
-        search_mixin.jira.jql.return_value = mock_issues
+        search_mixin.jira.post = MagicMock(return_value=mock_issues)
         search_mixin.config.url = "https://example.atlassian.net"
 
         # Call the method with specific fields
@@ -410,14 +351,12 @@ class TestSearchMixin:
             "project = TEST", fields="summary,assignee,customfield_10049"
         )
 
-        # Verify the JQL call includes the fields parameter
-        search_mixin.jira.jql.assert_called_once_with(
-            "project = TEST",
-            fields="summary,assignee,customfield_10049",
-            start=0,
-            limit=50,
-            expand=None,
-        )
+        # Verify POST body includes correct fields list
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == "project = TEST"
+        assert "summary" in body["fields"]
+        assert "assignee" in body["fields"]
+        assert "customfield_10049" in body["fields"]
 
         # Verify results
         assert isinstance(result, JiraSearchResult)
@@ -573,105 +512,50 @@ class TestSearchMixin:
         self, search_mixin: SearchMixin, mock_issues_response, is_cloud
     ):
         """Test that JQL string is correctly constructed when projects_filter is provided."""
-        # Setup
         search_mixin.config.is_cloud = is_cloud
-        search_mixin.config.projects_filter = (
-            None  # Don't use config filter for this test
-        )
+        search_mixin.config.projects_filter = None
         search_mixin.config.url = "https://test.example.com"
 
-        # Setup mock response for both API methods
-        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
-            return_value=mock_issues_response["issues"]
-        )
-        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
-        api_method_mock = getattr(
-            search_mixin.jira, "enhanced_jql_get_list_of_tickets" if is_cloud else "jql"
-        )
+        search_mixin.jira.post = MagicMock(return_value=mock_issues_response)
 
-        # Act: Single project filter
+        # Single project filter
         search_mixin.search_issues("text ~ 'test'", projects_filter="TEST")
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == "(text ~ 'test') AND project = \"TEST\""
+        search_mixin.jira.post.reset_mock()
 
-        # Define expected kwargs based on is_cloud
-        expected_kwargs = {
-            "fields": ANY,
-            "limit": ANY,
-            "expand": ANY,
-        }
-        # Add start parameter only for Server/DC
-        if not is_cloud:
-            expected_kwargs["start"] = ANY
-
-        # Assert: JQL verification
-        api_method_mock.assert_called_with(
-            "(text ~ 'test') AND project = \"TEST\"",  # Check constructed JQL
-            **expected_kwargs,
-        )
-
-        # Reset mock for next call
-        api_method_mock.reset_mock()
-
-        # Act: Multiple projects filter
+        # Multiple projects filter
         search_mixin.search_issues("text ~ 'test'", projects_filter="TEST, DEV")
-        # Assert: JQL verification
-        api_method_mock.assert_called_with(
-            '(text ~ \'test\') AND project IN ("TEST", "DEV")',  # Check constructed JQL
-            **expected_kwargs,
-        )
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == '(text ~ \'test\') AND project IN ("TEST", "DEV")'
+        search_mixin.jira.post.reset_mock()
 
-        # Reset mock for next call
-        api_method_mock.reset_mock()
-
-        # Act: Call with both JQL and filter
+        # Existing JQL already contains project filter — not wrapped
         search_mixin.search_issues("project = OTHER", projects_filter="TEST")
-        # Assert: JQL verification (existing JQL has priority)
-        api_method_mock.assert_called_with("project = OTHER", **expected_kwargs)
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == "project = OTHER"
 
     @pytest.mark.parametrize("is_cloud", [True, False])
     def test_search_issues_with_config_projects_filter_jql_construction(
         self, search_mixin: SearchMixin, mock_issues_response, is_cloud
     ):
         """Test that JQL string is correctly constructed when config.projects_filter is used."""
-        # Setup
         search_mixin.config.is_cloud = is_cloud
-        search_mixin.config.projects_filter = "CONF1,CONF2"  # Set config filter
+        search_mixin.config.projects_filter = "CONF1,CONF2"
         search_mixin.config.url = "https://test.example.com"
 
-        # Setup mock response for both API methods
-        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
-            return_value=mock_issues_response["issues"]
-        )
-        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
-        api_method_mock = getattr(
-            search_mixin.jira, "enhanced_jql_get_list_of_tickets" if is_cloud else "jql"
-        )
+        search_mixin.jira.post = MagicMock(return_value=mock_issues_response)
 
-        # Define expected kwargs based on is_cloud
-        expected_kwargs = {
-            "fields": ANY,
-            "limit": ANY,
-            "expand": ANY,
-        }
-        # Add start parameter only for Server/DC
-        if not is_cloud:
-            expected_kwargs["start"] = ANY
-
-        # Act: Use config filter
+        # Use config filter
         search_mixin.search_issues("text ~ 'test'")
-        # Assert: JQL verification
-        api_method_mock.assert_called_with(
-            '(text ~ \'test\') AND project IN ("CONF1", "CONF2")', **expected_kwargs
-        )
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == '(text ~ \'test\') AND project IN ("CONF1", "CONF2")'
+        search_mixin.jira.post.reset_mock()
 
-        # Reset mock for next call
-        api_method_mock.reset_mock()
-
-        # Act: Override config filter with parameter
+        # Override config filter with parameter
         search_mixin.search_issues("text ~ 'test'", projects_filter="OVERRIDE")
-        # Assert: JQL verification
-        api_method_mock.assert_called_with(
-            "(text ~ 'test') AND project = \"OVERRIDE\"", **expected_kwargs
-        )
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == "(text ~ 'test') AND project = \"OVERRIDE\""
 
     @pytest.mark.parametrize("is_cloud", [True, False])
     def test_search_issues_with_empty_jql_and_projects_filter(
@@ -683,44 +567,24 @@ class TestSearchMixin:
         search_mixin.config.projects_filter = None
         search_mixin.config.url = "https://test.example.com"
 
-        # Setup mock response for both API methods
-        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
-            return_value=mock_issues_response["issues"]
-        )
-        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
-        api_method_mock = getattr(
-            search_mixin.jira, "enhanced_jql_get_list_of_tickets" if is_cloud else "jql"
-        )
-
-        # Define expected kwargs based on is_cloud
-        expected_kwargs = {
-            "fields": ANY,
-            "limit": ANY,
-            "expand": ANY,
-        }
-        # Add start parameter only for Server/DC
-        if not is_cloud:
-            expected_kwargs["start"] = ANY
+        search_mixin.jira.post = MagicMock(return_value=mock_issues_response)
 
         # Test 1: Empty string JQL with single project
         search_mixin.search_issues("", projects_filter="PROJ1")
-        api_method_mock.assert_called_with('project = "PROJ1"', **expected_kwargs)
-
-        # Reset mock
-        api_method_mock.reset_mock()
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == 'project = "PROJ1"'
+        search_mixin.jira.post.reset_mock()
 
         # Test 2: Empty string JQL with multiple projects
         search_mixin.search_issues("", projects_filter="PROJ1,PROJ2")
-        api_method_mock.assert_called_with(
-            'project IN ("PROJ1", "PROJ2")', **expected_kwargs
-        )
-
-        # Reset mock
-        api_method_mock.reset_mock()
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == 'project IN ("PROJ1", "PROJ2")'
+        search_mixin.jira.post.reset_mock()
 
         # Test 3: None JQL with projects filter
         result = search_mixin.search_issues(None, projects_filter="PROJ1")
-        api_method_mock.assert_called_with('project = "PROJ1"', **expected_kwargs)
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == 'project = "PROJ1"'
         assert isinstance(result, JiraSearchResult)
 
     @pytest.mark.parametrize("is_cloud", [True, False])
@@ -733,58 +597,104 @@ class TestSearchMixin:
         search_mixin.config.projects_filter = None
         search_mixin.config.url = "https://test.example.com"
 
-        # Setup mock response for both API methods
-        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
-            return_value=mock_issues_response["issues"]
-        )
-        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
-        api_method_mock = getattr(
-            search_mixin.jira, "enhanced_jql_get_list_of_tickets" if is_cloud else "jql"
-        )
-
-        # Define expected kwargs based on is_cloud
-        expected_kwargs = {
-            "fields": ANY,
-            "limit": ANY,
-            "expand": ANY,
-        }
-        # Add start parameter only for Server/DC
-        if not is_cloud:
-            expected_kwargs["start"] = ANY
+        search_mixin.jira.post = MagicMock(return_value=mock_issues_response)
 
         # Test 1: ORDER BY with single project
         search_mixin.search_issues("ORDER BY created DESC", projects_filter="PROJ1")
-        api_method_mock.assert_called_with(
-            'project = "PROJ1" ORDER BY created DESC', **expected_kwargs
-        )
-
-        # Reset mock
-        api_method_mock.reset_mock()
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == 'project = "PROJ1" ORDER BY created DESC'
+        search_mixin.jira.post.reset_mock()
 
         # Test 2: ORDER BY with multiple projects
         search_mixin.search_issues(
             "ORDER BY created DESC", projects_filter="PROJ1,PROJ2"
         )
-        api_method_mock.assert_called_with(
-            'project IN ("PROJ1", "PROJ2") ORDER BY created DESC', **expected_kwargs
-        )
-
-        # Reset mock
-        api_method_mock.reset_mock()
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == 'project IN ("PROJ1", "PROJ2") ORDER BY created DESC'
+        search_mixin.jira.post.reset_mock()
 
         # Test 3: Case insensitive ORDER BY
         search_mixin.search_issues("order by updated ASC", projects_filter="PROJ1")
-        api_method_mock.assert_called_with(
-            'project = "PROJ1" order by updated ASC', **expected_kwargs
-        )
-
-        # Reset mock
-        api_method_mock.reset_mock()
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == 'project = "PROJ1" order by updated ASC'
+        search_mixin.jira.post.reset_mock()
 
         # Test 4: ORDER BY with extra spaces
         search_mixin.search_issues(
             "  ORDER BY priority DESC  ", projects_filter="PROJ1"
         )
-        api_method_mock.assert_called_with(
-            'project = "PROJ1"   ORDER BY priority DESC  ', **expected_kwargs
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["jql"] == 'project = "PROJ1"   ORDER BY priority DESC  '
+
+    def test_search_issues_large_jql_uses_post_body(self, search_mixin: SearchMixin):
+        """Large JQL with many OR clauses must be passed via POST body unchanged."""
+        # Build a query representative of the reported 150-180 clause failure
+        clauses = " OR ".join(f'key = "PROJ-{i}"' for i in range(1, 161))
+        large_jql = f"({clauses})"
+
+        search_mixin.jira.post = MagicMock(
+            return_value={
+                "issues": [],
+                "total": 0,
+                "startAt": 0,
+                "maxResults": 50,
+            }
         )
+
+        result = search_mixin.search_issues(large_jql, limit=50)
+
+        assert isinstance(result, JiraSearchResult)
+        search_mixin.jira.post.assert_called_once()
+        body = search_mixin.jira.post.call_args[1]["json"]
+        # Full JQL must be in the request body — not truncated or URL-encoded
+        assert body["jql"] == large_jql
+        assert len(body["jql"]) > 2000  # Confirms we exceed typical URL length limits
+
+    def test_search_issues_post_body_fields_star_all(self, search_mixin: SearchMixin):
+        """fields='*all' is correctly serialised to ['*all'] in the POST body."""
+        search_mixin.jira.post = MagicMock(
+            return_value={"issues": [], "total": 0, "startAt": 0, "maxResults": 50}
+        )
+
+        search_mixin.search_issues("project = TEST", fields="*all")
+
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["fields"] == ["*all"]
+
+    def test_search_issues_post_body_expand(self, search_mixin: SearchMixin):
+        """Expand parameter is included as a list in the POST body."""
+        search_mixin.jira.post = MagicMock(
+            return_value={"issues": [], "total": 0, "startAt": 0, "maxResults": 50}
+        )
+
+        search_mixin.search_issues("project = TEST", expand="renderedFields,changelog")
+
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert "renderedFields" in body["expand"]
+        assert "changelog" in body["expand"]
+
+    def test_search_issues_dc_caps_max_results_at_50(self, search_mixin: SearchMixin):
+        """Data Center path caps maxResults at 50."""
+        search_mixin.config.is_cloud = False
+        search_mixin.jira.post = MagicMock(
+            return_value={"issues": [], "total": 0, "startAt": 0, "maxResults": 50}
+        )
+
+        search_mixin.search_issues("project = TEST", limit=200)
+
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["maxResults"] <= 50
+
+    def test_search_issues_cloud_caps_max_results_at_100(
+        self, search_mixin: SearchMixin
+    ):
+        """Cloud path caps maxResults at 100."""
+        search_mixin.config.is_cloud = True
+        search_mixin.jira.post = MagicMock(
+            return_value={"issues": [], "total": 0, "startAt": 0, "maxResults": 100}
+        )
+
+        search_mixin.search_issues("project = TEST", limit=200)
+
+        body = search_mixin.jira.post.call_args[1]["json"]
+        assert body["maxResults"] <= 100


### PR DESCRIPTION
## Description

Large JQL queries routed through the Jira MCP `search` tool were failing when
the query contained approximately 150–180 AND/OR clauses. The root cause was
that `atlassian-python-api`'s `jql()` and `enhanced_jql_get_list_of_tickets()`
methods append the JQL string as a URL query parameter
(`GET /rest/api/2/search?jql=...`). Enterprise proxies and load balancers
commonly enforce URL length limits of 2–8 KB, which large queries easily
exceeded. The same queries executed successfully when called directly against the
Jira Data Center REST API using POST, confirming the limitation was in the MCP
wrapper layer.

Fixes: #

## Changes

- **`src/mcp_atlassian/jira/search.py`**: Replaced the Cloud/DC-branching
  `jira.jql()` / `enhanced_jql_get_list_of_tickets()` GET-based calls in
  `search_issues` with a single unified `POST /rest/api/2/search` code path for
  all environments. JQL and all search parameters (`startAt`, `maxResults`,
  `fields`, `expand`) are now sent in the JSON request body, which has no
  practical length limit.
- **`src/mcp_atlassian/jira/search.py`**: Added private helper
  `_jql_search_post` that constructs and dispatches the POST request, caps
  `maxResults` at 50 for Data Center and 100 for Cloud, and normalises
  `fields`/`expand` into list form as required by the REST API.
- **`tests/unit/jira/test_search.py`**: Updated all `search_issues` unit tests
  to mock `jira.post` instead of the now-unused `jira.jql` /
  `jira.enhanced_jql_get_list_of_tickets`. Added five new regression tests:
  large JQL body passthrough, `*all` fields serialisation, expand list
  serialisation, and `maxResults` caps for both DC and Cloud.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Live smoke test executed against a Jira Data
      Center instance using a 160-clause / 4,318-character OR query. Confirmed
      the full JQL reaches Jira intact via POST body, query returns results
      successfully, and the old GET path (`jira.jql`) is never invoked.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally (1488 passed, 5 skipped across full unit suite).
- [ ] Documentation updated (if needed).