### PR TITLE
Added repo creation and PR build tools

### DIFF
--- a/src/mcp_atlassian/bitbucket/pullrequests.py
+++ b/src/mcp_atlassian/bitbucket/pullrequests.py
@@ -111,7 +111,11 @@ class PullRequestsMixin(BitbucketClient):
             raise Exception(msg) from e
 
     def get_pull_request_commits(
-        self, workspace: str, repository: str, pull_request_id: int
+        self,
+        workspace: str,
+        repository: str,
+        pull_request_id: int,
+        limit: int | None = None,
     ) -> list[dict[str, Any]]:
         """
         Get commits associated with a pull request.
@@ -120,6 +124,7 @@ class PullRequestsMixin(BitbucketClient):
             workspace: Workspace name (Cloud) or project key (Server/DC)
             repository: Repository name
             pull_request_id: Pull request ID
+            limit: Maximum number of commits to return. If None, returns all commits.
 
         Returns:
             List of commit data
@@ -128,10 +133,13 @@ class PullRequestsMixin(BitbucketClient):
             MCPAtlassianAuthenticationError: If authentication fails with the Bitbucket API (401/403)
         """
         try:
-            # Use the base class method that implements the actual API call
-            return self.bitbucket.get_pull_requests_commits(
+            # SDK returns a generator — materialise entries up to limit, or all if limit is None
+            gen = self.bitbucket.get_pull_requests_commits(
                 workspace, repository, pull_request_id
             )
+            if limit is None:
+                return list(gen)
+            return [c for _, c in zip(range(limit), gen, strict=False)]
         except HTTPError as http_err:
             if http_err.response is not None and http_err.response.status_code in [
                 401,
@@ -150,6 +158,78 @@ class PullRequestsMixin(BitbucketClient):
             error_msg = f"Error getting commits for PR {pull_request_id} in {workspace}/{repository}: {str(e)}"
             logger.error(error_msg)
             msg = f"Error getting PR commits: {str(e)}"
+            raise Exception(msg) from e
+
+    def get_commit_builds(
+        self, workspace: str, repository: str, commit_id: str, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        """
+        Get all CI/CD build statuses for a specific commit.
+
+        Uses the Bitbucket UI API for Server/DC (returns full build details
+        including state, key, name, description, and URL for each pipeline).
+        Falls back to the build-status REST API for Cloud.
+
+        Args:
+            workspace: Workspace name (Cloud) or project key (Server/DC)
+            repository: Repository name
+            commit_id: Full commit hash
+            limit: Maximum number of builds to return. If None, returns all builds.
+
+        Returns:
+            List of build status dicts, each containing state, key, name, url, etc.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails (401/403)
+        """
+        try:
+            if self.config.is_cloud:
+                # Cloud: use the standard build-status REST API
+                endpoint = f"projects/{workspace}/repos/{repository}/commits/{commit_id}/builds"
+                params: dict[str, Any] = {} if limit is None else {"limit": limit}
+                response = self.bitbucket.get(endpoint, params=params)
+                if isinstance(response, dict):
+                    return response.get("values", [])
+                return []
+            else:
+                # Server/DC: use the UI API which returns rich build details
+                url = (
+                    f"{self.config.url.rstrip('/')}/rest/ui/latest"
+                    f"/projects/{workspace}/repos/{repository}/builds"
+                )
+                dc_params: dict[str, Any] = {
+                    "at": commit_id,
+                    "start": 0,
+                    "avatarSize": 48,
+                }
+                if limit is not None:
+                    dc_params["limit"] = limit
+                resp = self.bitbucket._session.get(url, params=dc_params)
+                resp.raise_for_status()
+                data = resp.json()
+                # Response structure varies: {"page": {"values": [...]}} or {"values": [...]}
+                if isinstance(data, dict):
+                    page = data.get("page", data)
+                    return page.get("values", []) if isinstance(page, dict) else []
+                return []
+        except HTTPError as http_err:
+            if http_err.response is not None and http_err.response.status_code in [
+                401,
+                403,
+            ]:
+                error_msg = (
+                    f"Authentication failed for Bitbucket API ({http_err.response.status_code}). "
+                    "Token may be expired or invalid. Please verify credentials."
+                )
+                logger.error(error_msg)
+                raise MCPAtlassianAuthenticationError(error_msg) from http_err
+            else:
+                logger.error(f"HTTP error during API call: {http_err}", exc_info=False)
+                raise http_err
+        except Exception as e:
+            error_msg = f"Error getting builds for commit {commit_id} in {workspace}/{repository}: {str(e)}"
+            logger.error(error_msg)
+            msg = f"Error getting commit builds: {str(e)}"
             raise Exception(msg) from e
 
     def get_pull_requests(

--- a/src/mcp_atlassian/bitbucket/pullrequests.py
+++ b/src/mcp_atlassian/bitbucket/pullrequests.py
@@ -184,8 +184,10 @@ class PullRequestsMixin(BitbucketClient):
         """
         try:
             if self.config.is_cloud:
-                # Cloud: use the standard build-status REST API
-                endpoint = f"projects/{workspace}/repos/{repository}/commits/{commit_id}/builds"
+                # Cloud: use the standard build-status (commit statuses) REST API
+                endpoint = (
+                    f"repositories/{workspace}/{repository}/commit/{commit_id}/statuses"
+                )
                 params: dict[str, Any] = {} if limit is None else {"limit": limit}
                 response = self.bitbucket.get(endpoint, params=params)
                 if isinstance(response, dict):

--- a/src/mcp_atlassian/bitbucket/repositories.py
+++ b/src/mcp_atlassian/bitbucket/repositories.py
@@ -212,3 +212,52 @@ class RepositoriesMixin(BitbucketClient):
             logger.error(error_msg)
             msg = f"Error getting repos: {str(e)}"
             raise Exception(msg) from e
+
+    def create_repository(
+        self,
+        workspace: str,
+        repo_slug: str,
+        is_private: bool = True,
+        forkable: bool = False,
+    ) -> BitbucketRepository:
+        """
+        Create a new repository in a workspace/project.
+
+        Args:
+            workspace: Workspace name (Cloud) or project key (Server/DC)
+            repo_slug: Repository name/slug to create
+            is_private: Whether the repository should be private (default: True)
+            forkable: Whether the repository can be forked (default: False)
+
+        Returns:
+            BitbucketRepository object for the created repository
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails with the Bitbucket API (401/403)
+        """
+        try:
+            repo_data = self.bitbucket.create_repo(
+                workspace, repo_slug, forkable=forkable, is_private=is_private
+            )
+            return BitbucketRepository.from_api_response(repo_data)
+        except HTTPError as http_err:
+            if http_err.response is not None and http_err.response.status_code in [
+                401,
+                403,
+            ]:
+                error_msg = (
+                    f"Authentication failed for Bitbucket API ({http_err.response.status_code}). "
+                    "Token may be expired or invalid. Please verify credentials."
+                )
+                logger.error(error_msg)
+                raise MCPAtlassianAuthenticationError(error_msg) from http_err
+            else:
+                logger.error(f"HTTP error during API call: {http_err}", exc_info=False)
+                raise http_err
+        except Exception as e:
+            error_msg = (
+                f"Error creating repository {repo_slug} in {workspace}: {str(e)}"
+            )
+            logger.error(error_msg)
+            msg = f"Error creating repository: {str(e)}"
+            raise Exception(msg) from e

--- a/src/mcp_atlassian/servers/bitbucket.py
+++ b/src/mcp_atlassian/servers/bitbucket.py
@@ -163,6 +163,75 @@ async def get_repository_info(
         return json.dumps(error_result, indent=2)
 
 
+@bitbucket_mcp.tool(tags={"bitbucket", "write"})
+@check_write_access
+async def create_repository(
+    ctx: Context,
+    workspace: Annotated[
+        str,
+        Field(description="Workspace name (Cloud) or project key (Server/DC)"),
+    ],
+    repo_slug: Annotated[
+        str,
+        Field(description="Repository name/slug to create"),
+    ],
+    is_private: Annotated[
+        bool,
+        Field(description="Whether the repository should be private"),
+    ] = True,
+    forkable: Annotated[
+        bool,
+        Field(description="Whether the repository can be forked"),
+    ] = False,
+) -> str:
+    """
+    Create a new repository in a workspace/project.
+
+    Args:
+        ctx: The MCP context.
+        workspace: Workspace name (Cloud) or project key (Server/DC).
+        repo_slug: Repository name/slug to create.
+        is_private: Whether the repository should be private (default: True).
+        forkable: Whether the repository can be forked (default: False).
+
+    Returns:
+        JSON string containing the created repository details.
+
+    Raises:
+        ValueError: If the Bitbucket client is not configured or available.
+    """
+    try:
+        bitbucket = await get_bitbucket_fetcher(ctx)
+        repo = bitbucket.create_repository(
+            workspace, repo_slug, is_private=is_private, forkable=forkable
+        )
+        return json.dumps(
+            {
+                "success": True,
+                "repository": repo.model_dump(mode="json", serialize_as_any=True),
+            },
+            indent=2,
+        )
+    except Exception as e:
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            error_message = f"Configuration Error: {str(e)}"
+        else:
+            error_message = f"An unexpected error occurred while creating repository {repo_slug} in {workspace}."
+            logger.exception("Unexpected error in bitbucket_create_repository:")
+
+        error_result = {
+            "success": False,
+            "error": error_message,
+        }
+        logger.log(log_level, f"bitbucket_create_repository failed: {error_message}")
+        return json.dumps(error_result, indent=2)
+
+
 @bitbucket_mcp.tool(tags={"bitbucket", "read"})
 async def list_branches(
     ctx: Context,
@@ -1455,4 +1524,160 @@ async def get_pull_request_diff(
         logger.log(
             log_level, f"bitbucket_get_pull_request_diff failed: {error_message}"
         )
+        return json.dumps(error_result, indent=2)
+
+
+@bitbucket_mcp.tool(tags={"bitbucket", "read"})
+async def get_pull_request_commits(
+    ctx: Context,
+    workspace: Annotated[
+        str,
+        Field(description="Workspace name (Cloud) or project key (Server/DC)"),
+    ],
+    repository: Annotated[
+        str,
+        Field(description="Repository name"),
+    ],
+    pull_request_id: Annotated[
+        int,
+        Field(description="Pull request ID"),
+    ],
+    limit: Annotated[
+        int | None,
+        Field(
+            description="Maximum number of commits to return. Omit or set to null to return all commits.",
+            default=None,
+            ge=1,
+        ),
+    ] = None,
+) -> str:
+    """
+    Get the list of commits included in a pull request.
+
+    Returns each commit's hash, author, timestamp, and commit message so you
+    can trace what changes were introduced and by whom.
+    If limit is not specified, all commits are returned.
+
+    Args:
+        workspace: Workspace name or project key.
+        repository: Repository name.
+        pull_request_id: Pull request ID.
+        limit: Maximum number of commits to return. If not specified, returns all commits.
+
+    Returns:
+        JSON string containing the list of commits for the pull request.
+
+    Raises:
+        ValueError: If the Bitbucket client is not configured or available.
+    """
+    try:
+        bitbucket = await get_bitbucket_fetcher(ctx)
+        commits = bitbucket.get_pull_request_commits(
+            workspace, repository, pull_request_id, limit=limit
+        )
+        return json.dumps(
+            {
+                "pull_request_id": pull_request_id,
+                "workspace": workspace,
+                "repository": repository,
+                "commit_count": len(commits),
+                "commits": commits,
+            },
+            indent=2,
+        )
+    except Exception as e:
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            error_message = f"Configuration Error: {str(e)}"
+        else:
+            error_message = f"An unexpected error occurred while fetching commits for PR {pull_request_id} in {workspace}/{repository}."
+            logger.exception("Unexpected error in bitbucket_get_pull_request_commits:")
+        error_result = {"success": False, "error": error_message}
+        logger.log(
+            log_level, f"bitbucket_get_pull_request_commits failed: {error_message}"
+        )
+        return json.dumps(error_result, indent=2)
+
+
+@bitbucket_mcp.tool(tags={"bitbucket", "read"})
+async def get_commit_builds(
+    ctx: Context,
+    workspace: Annotated[
+        str,
+        Field(description="Workspace name (Cloud) or project key (Server/DC)"),
+    ],
+    repository: Annotated[
+        str,
+        Field(description="Repository name"),
+    ],
+    commit_id: Annotated[
+        str,
+        Field(
+            description="Full commit hash (e.g., 'b602bc8ce4201b91808bd9e12ba6f9ed0ffdd64c')"
+        ),
+    ],
+    limit: Annotated[
+        int | None,
+        Field(
+            description="Maximum number of builds to return. Omit or set to null to return all builds.",
+            default=None,
+            ge=1,
+        ),
+    ] = None,
+) -> str:
+    """
+    Get all CI/CD build statuses for a specific commit.
+
+    Returns the full list of pipeline/build results associated with the commit,
+    including the build state (SUCCESSFUL, FAILED, INPROGRESS), build key, name,
+    description, and the URL to the build in the CI system (e.g. Jenkins, Bamboo).
+
+    Use this to check whether all required pipelines passed before merging a PR
+    or to identify which specific build failed.
+    If limit is not specified, all builds are returned.
+
+    Args:
+        workspace: Workspace name or project key.
+        repository: Repository name.
+        commit_id: Full commit hash to look up builds for.
+        limit: Maximum number of builds to return. If not specified, returns all builds.
+
+    Returns:
+        JSON string containing the list of builds with their status and details.
+
+    Raises:
+        ValueError: If the Bitbucket client is not configured or available.
+    """
+    try:
+        bitbucket = await get_bitbucket_fetcher(ctx)
+        builds = bitbucket.get_commit_builds(
+            workspace, repository, commit_id, limit=limit
+        )
+        return json.dumps(
+            {
+                "commit_id": commit_id,
+                "workspace": workspace,
+                "repository": repository,
+                "build_count": len(builds),
+                "builds": builds,
+            },
+            indent=2,
+        )
+    except Exception as e:
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            error_message = f"Configuration Error: {str(e)}"
+        else:
+            error_message = f"An unexpected error occurred while fetching builds for commit {commit_id} in {workspace}/{repository}."
+            logger.exception("Unexpected error in bitbucket_get_commit_builds:")
+        error_result = {"success": False, "error": error_message}
+        logger.log(log_level, f"bitbucket_get_commit_builds failed: {error_message}")
         return json.dumps(error_result, indent=2)

--- a/tests/unit/bitbucket/test_repositories.py
+++ b/tests/unit/bitbucket/test_repositories.py
@@ -411,4 +411,125 @@ class TestRepositoriesMixin:
                 assert hasattr(mixin, "get_file_content")
                 assert hasattr(mixin, "get_directory_content")
                 assert hasattr(mixin, "get_repositories")
+                assert hasattr(mixin, "create_repository")
                 assert hasattr(mixin, "config")  # From parent class
+
+
+class TestCreateRepository:
+    """Test cases for RepositoriesMixin.create_repository method."""
+
+    @pytest.fixture
+    def config(self):
+        return BitbucketConfig(
+            url="https://api.bitbucket.org/2.0",
+            auth_type="basic",
+            username="test@example.com",
+            app_password="app_password",
+        )
+
+    @pytest.fixture
+    def repositories_mixin(self, config):
+        with patch("mcp_atlassian.bitbucket.client.Bitbucket"):
+            with patch("mcp_atlassian.bitbucket.client.configure_ssl_verification"):
+                mixin = RepositoriesMixin(config)
+                mixin.bitbucket = MagicMock()
+                return mixin
+
+    @pytest.fixture
+    def sample_created_repo_data(self):
+        return {
+            "slug": "new-repo",
+            "name": "new-repo",
+            "description": "",
+            "state": "AVAILABLE",
+            "forkable": False,
+            "public": False,
+            "project": {"key": "TEST"},
+            "links": {},
+        }
+
+    def test_create_repository_success(
+        self, repositories_mixin, sample_created_repo_data
+    ):
+        """Test successful repository creation."""
+        repositories_mixin.bitbucket.create_repo.return_value = sample_created_repo_data
+
+        with patch.object(
+            BitbucketRepository,
+            "from_api_response",
+            return_value=MagicMock(spec=BitbucketRepository),
+        ) as mock_from_api:
+            result = repositories_mixin.create_repository("TEST", "new-repo")
+
+            assert isinstance(result, MagicMock)
+            repositories_mixin.bitbucket.create_repo.assert_called_once_with(
+                "TEST", "new-repo", forkable=False, is_private=True
+            )
+            mock_from_api.assert_called_once_with(sample_created_repo_data)
+
+    def test_create_repository_custom_flags(
+        self, repositories_mixin, sample_created_repo_data
+    ):
+        """Test repository creation with custom is_private and forkable flags."""
+        repositories_mixin.bitbucket.create_repo.return_value = sample_created_repo_data
+
+        with patch.object(
+            BitbucketRepository,
+            "from_api_response",
+            return_value=MagicMock(spec=BitbucketRepository),
+        ):
+            repositories_mixin.create_repository(
+                "TEST", "public-repo", is_private=False, forkable=True
+            )
+
+            repositories_mixin.bitbucket.create_repo.assert_called_once_with(
+                "TEST", "public-repo", forkable=True, is_private=False
+            )
+
+    def test_create_repository_http_401_error(self, repositories_mixin):
+        """Test handling of 401 HTTP error in create_repository."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        http_error = HTTPError()
+        http_error.response = mock_response
+        repositories_mixin.bitbucket.create_repo.side_effect = http_error
+
+        with pytest.raises(
+            MCPAtlassianAuthenticationError,
+            match="Authentication failed for Bitbucket API \\(401\\)",
+        ):
+            repositories_mixin.create_repository("TEST", "new-repo")
+
+    def test_create_repository_http_403_error(self, repositories_mixin):
+        """Test handling of 403 HTTP error in create_repository."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        http_error = HTTPError()
+        http_error.response = mock_response
+        repositories_mixin.bitbucket.create_repo.side_effect = http_error
+
+        with pytest.raises(
+            MCPAtlassianAuthenticationError,
+            match="Authentication failed for Bitbucket API \\(403\\)",
+        ):
+            repositories_mixin.create_repository("TEST", "new-repo")
+
+    def test_create_repository_http_409_conflict(self, repositories_mixin):
+        """Test handling of 409 conflict (repo already exists) in create_repository."""
+        mock_response = MagicMock()
+        mock_response.status_code = 409
+        http_error = HTTPError()
+        http_error.response = mock_response
+        repositories_mixin.bitbucket.create_repo.side_effect = http_error
+
+        with pytest.raises(HTTPError):
+            repositories_mixin.create_repository("TEST", "existing-repo")
+
+    def test_create_repository_general_exception(self, repositories_mixin):
+        """Test handling of general exceptions in create_repository."""
+        repositories_mixin.bitbucket.create_repo.side_effect = Exception(
+            "Network error"
+        )
+
+        with pytest.raises(Exception, match="Error creating repository: Network error"):
+            repositories_mixin.create_repository("TEST", "new-repo")


### PR DESCRIPTION
## Description

Adds two new Bitbucket MCP tools for CI/CD build inspection and PR commit history,
fixes a long-standing bug with Jira `fixVersions`/`versions` field names returning
empty values, and introduces controlled field-selection behaviour across Jira read tools.

Fixes: #

## Changes

- **[Bitbucket]** Added `get_pull_request_commits` MCP tool — returns commits for a PR
  with hash, author, timestamp, and message; supports a configurable `limit`
- **[Bitbucket]** Added `get_commit_builds` MCP tool — fetches CI/CD build pipeline
  results per commit (state, key, name, description, CI URL) via the Bitbucket UI API
  (`/rest/ui/latest/...`) for Server/DC and the build-status REST API for Cloud
- **[Bitbucket]** `PullRequestsMixin.get_commit_builds` added; `get_pull_request_commits`
  updated with `limit` parameter
- **[Jira]** Fixed wrong field names in `DEFAULT_READ_JIRA_FIELDS`:
  `fixVersion` → `fixVersions`, `affectedVersion` → `versions` — these were silently
  returning empty data on every issue lookup
- **[Jira]** Added `affects_versions` field to `JiraIssue` model, parsed from
  `fields["versions"]`
- **[Jira]** Replaced freeform `fields: str` parameter with `extra_fields: str | None = None`
  (three-mode: `None` = default set, `*all` = all fields, `"f1,f2"` = merged with defaults)
  across `get_issue`, `search`, `get_board_issues`, `get_sprint_issues` — prevents LLM
  from silently overriding field selection
- **[Logging]** Added `mcp_atlassian` (underscore) namespace to logger setup so all
  `mcp_atlassian.*` child loggers are correctly configured

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: verified `fixVersions` and `versions` fields return correct
      data on real Jira issues; tested `get_commit_builds` against Bitbucket Server —
      confirmed build state, key, and URL in response; tested `get_pull_request_commits`
      returns commits with correct limit enforcement

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).