### PR TITLE
Added Statless flag to run the server without the need for MCP sessio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,38 @@ Both transport types support single-user and multi-user authentication:
     ```
 </details>
 
+<details> <summary>Stateless HTTP (Horizontal Scaling)</summary>
+
+By default the `streamable-http` transport keeps per-session state in memory, which requires sticky sessions when running more than one replica. Enable **stateless mode** so any request can be served by any instance behind a round-robin load balancer — ideal for multi-replica / autoscaled deployments.
+
+Enable it with either the CLI flag or the environment variable:
+
+| Method | Value |
+| --- | --- |
+| CLI flag | `--stateless-http` |
+| Environment variable | `STATELESS_HTTP=true` |
+
+> [!NOTE]
+> - Applies to the `streamable-http` transport only (ignored for `stdio`).
+> - The CLI flag takes precedence over the `STATELESS_HTTP` environment variable.
+> - In stateless mode the server does not return an `mcp-session-id` header, so clients must not rely on session affinity.
+
+```bash
+# CLI flag
+docker run --rm -p 9000:9000 \
+  --env-file /path/to/your/.env \
+  ghcr.io/SharkyND/mcp-atlassian:latest \
+  --transport streamable-http --port 9000 --stateless-http -vv
+
+# OR via environment variable
+docker run --rm -p 9000:9000 \
+  --env-file /path/to/your/.env \
+  -e STATELESS_HTTP=true \
+  ghcr.io/SharkyND/mcp-atlassian:latest \
+  --transport streamable-http --port 9000 -vv
+```
+</details>
+
 <details> <summary>Multi-User Authentication Setup</summary>
 
 Here's a complete example of setting up multi-user authentication with streamable-HTTP transport:

--- a/charts/mcp-atlassian/templates/_helpers.tpl
+++ b/charts/mcp-atlassian/templates/_helpers.tpl
@@ -60,3 +60,24 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Whether shared storage should be mounted (enabled and a claim is available).
+*/}}
+{{- define "mcp-atlassian.sharedStorageEnabled" -}}
+{{- if and .Values.sharedStorage.enabled (or .Values.sharedStorage.existingClaim .Values.sharedStorage.storageClass) -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Name of the PVC to mount for shared storage. Prefers an existing claim, falling
+back to the chart-provisioned claim name.
+*/}}
+{{- define "mcp-atlassian.sharedStorageClaimName" -}}
+{{- if .Values.sharedStorage.existingClaim -}}
+{{- .Values.sharedStorage.existingClaim -}}
+{{- else -}}
+{{- printf "%s-shared" (include "mcp-atlassian.fullname" .) -}}
+{{- end -}}
+{{- end }}

--- a/charts/mcp-atlassian/templates/deployment.yaml
+++ b/charts/mcp-atlassian/templates/deployment.yaml
@@ -50,6 +50,18 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- if include "mcp-atlassian.sharedStorageEnabled" . }}
+            - name: STATELESS_HTTP
+              value: "true"
+            - name: UPLOAD_STAGING_BACKEND
+              value: "filesystem"
+            - name: UPLOAD_STAGING_DIR
+              value: {{ printf "%s/upload-staging" .Values.sharedStorage.mountPath | quote }}
+            - name: ATTACHMENT_DOWNLOAD_BACKEND
+              value: "filesystem"
+            - name: ATTACHMENT_DOWNLOAD_DIR
+              value: {{ printf "%s/attachment-downloads" .Values.sharedStorage.mountPath | quote }}
+            {{- end }}
             {{- if and .Values.secrets .Values.secrets.jiraApiToken }}
             - name: JIRA_API_TOKEN
               valueFrom:
@@ -103,13 +115,26 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
+          {{- if or .Values.volumeMounts (include "mcp-atlassian.sharedStorageEnabled" .) }}
           volumeMounts:
+            {{- if include "mcp-atlassian.sharedStorageEnabled" . }}
+            - name: shared-state
+              mountPath: {{ .Values.sharedStorage.mountPath }}
+            {{- end }}
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-      {{- with .Values.volumes }}
+      {{- if or .Values.volumes (include "mcp-atlassian.sharedStorageEnabled" .) }}
       volumes:
+        {{- if include "mcp-atlassian.sharedStorageEnabled" . }}
+        - name: shared-state
+          persistentVolumeClaim:
+            claimName: {{ include "mcp-atlassian.sharedStorageClaimName" . }}
+        {{- end }}
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/mcp-atlassian/templates/httproute.yaml
+++ b/charts/mcp-atlassian/templates/httproute.yaml
@@ -12,15 +12,20 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.gatewayApi.gatewayNamespace }}
   parentRefs:
+  {{- if .Values.gatewayApi.listenerSet.enabled }}
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: {{ $fullName }}
+      namespace: {{ .Release.Namespace }}
+      sectionName: {{ .Values.gatewayApi.listenerSet.listenerName | default "https" }}
+  {{- else if .Values.gatewayApi.gatewayNamespace }}
     - name: {{ .Values.gatewayApi.gatewayName }}
       namespace: {{ .Values.gatewayApi.gatewayNamespace }}
       {{- if .Values.gatewayApi.sectionName }}
       sectionName: {{ .Values.gatewayApi.sectionName }}
       {{- end }}
   {{- else }}
-  parentRefs:
     - name: {{ .Values.gatewayApi.gatewayName }}
       {{- if .Values.gatewayApi.sectionName }}
       sectionName: {{ .Values.gatewayApi.sectionName }}

--- a/charts/mcp-atlassian/templates/listenerset.yaml
+++ b/charts/mcp-atlassian/templates/listenerset.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.gatewayApi.enabled .Values.gatewayApi.listenerSet.enabled -}}
+{{- $fullName := include "mcp-atlassian.fullname" . -}}
+{{- $ls := .Values.gatewayApi.listenerSet -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-atlassian.labels" . | nindent 4 }}
+    {{- with $ls.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $ls.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRef:
+    {{- toYaml $ls.parentRef | nindent 4 }}
+  listeners:
+    {{- if $ls.listeners }}
+    {{- toYaml $ls.listeners | nindent 4 }}
+    {{- else }}
+    - name: {{ $ls.listenerName }}
+      port: {{ $ls.port }}
+      protocol: {{ $ls.protocol }}
+      hostname: {{ tpl ($ls.hostname | default (first .Values.gatewayApi.hostnames)) $ }}
+      {{- if $ls.tls.enabled }}
+      tls:
+        mode: {{ $ls.tls.mode }}
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: {{ $ls.tls.secretName | default (printf "%s-tls" $fullName) }}
+      {{- end }}
+      allowedRoutes:
+        {{- toYaml $ls.allowedRoutes | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/mcp-atlassian/templates/persistentvolumeclaim.yaml
+++ b/charts/mcp-atlassian/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.sharedStorage.enabled (not .Values.sharedStorage.existingClaim) .Values.sharedStorage.storageClass -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mcp-atlassian.fullname" . }}-shared
+  labels:
+    {{- include "mcp-atlassian.labels" . | nindent 4 }}
+  {{- with .Values.sharedStorage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.sharedStorage.accessModes | nindent 4 }}
+  storageClassName: {{ .Values.sharedStorage.storageClass | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.sharedStorage.size | quote }}
+{{- end }}

--- a/charts/mcp-atlassian/values.yaml
+++ b/charts/mcp-atlassian/values.yaml
@@ -90,6 +90,49 @@ gatewayApi:
   gatewayNamespace: ""
   # Listener section name on the Gateway (optional)
   sectionName: ""
+  # Optional ListenerSet: attach an HTTPS listener (with a cert-manager-issued
+  # cert) to the Gateway, and point the HTTPRoute at it instead of the Gateway.
+  # Use when the shared Gateway exposes no HTTPS listener and expects each app to
+  # bring its own (Envoy Gateway `allowedListeners.from: All`).
+  # Follows the same value structure as the upstream Argo CD chart.
+  listenerSet:
+    enabled: false
+    # Extra labels for the ListenerSet
+    labels: {}
+    # Extra annotations for the ListenerSet
+    # (e.g. cert-manager.io/cluster-issuer: sectigo)
+    annotations: {}
+    # Gateway API parentRef for the ListenerSet, passed through verbatim. Must
+    # reference an existing Gateway. Unlike HTTPRoute, ListenerSet accepts
+    # exactly one parentRef. Required when listenerSet is enabled.
+    parentRef: {}
+      # group: gateway.networking.k8s.io
+      # kind: Gateway
+      # name: example-gateway
+      # namespace: example-gateway-namespace
+    # Hostname for the synthesized listener (defaults to first gatewayApi.hostnames)
+    hostname: ""
+    # Name of the synthesized listener. Also used as the sectionName in the
+    # auto-derived HTTPRoute parentRef.
+    listenerName: https
+    # Port for the synthesized listener
+    port: 443
+    # Protocol for the synthesized listener
+    protocol: HTTPS
+    # TLS configuration for the synthesized listener
+    tls:
+      enabled: true
+      # TLS termination mode
+      mode: Terminate
+      # Secret the listener terminates with (defaults to <fullname>-tls)
+      secretName: ""
+    # allowedRoutes for the synthesized listener
+    allowedRoutes:
+      namespaces:
+        from: Same
+    # Listeners to attach verbatim. When non-empty, used as-is and all the
+    # synthesized listener fields above are ignored.
+    listeners: []
   # Annotations to add to the HTTPRoute
   annotations: {}
   # Hostnames to match (optional, defaults to all hostnames on the listener)
@@ -176,6 +219,42 @@ volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
+
+# Shared storage for stateless, multi-replica deployments.
+# When enabled, upload staging and attachment download tokens are persisted to a
+# shared volume (e.g. an EFS / Azure Files / NFS / any RWX backed PVC) so any
+# replica can serve them. This lets you run replicaCount > 1 WITHOUT sticky
+# sessions. Leave disabled for single-replica deployments (in-memory default),
+# where each pod uses only its own memory.
+#
+# Provide storage in one of two ways:
+#   1. Set `storageClass` (and optionally `size`) to let the chart provision an
+#      RWX PersistentVolumeClaim for you.
+#   2. Set `existingClaim` to mount a PVC you provisioned yourself (Terraform,
+#      etc.). `existingClaim` takes precedence over `storageClass`.
+sharedStorage:
+  enabled: false
+  # Name of a pre-provisioned ReadWriteMany PVC to mount. Takes precedence over
+  # storageClass when set.
+  existingClaim: ""
+  # StorageClass used to provision an RWX PVC when existingClaim is empty.
+  # Must support ReadWriteMany (e.g. efs-sc, azurefile-csi, nfs).
+  storageClass: ""
+  # Requested size for the provisioned PVC.
+  size: 1Gi
+  # Access modes for the provisioned PVC.
+  accessModes:
+    - ReadWriteMany
+  # Extra annotations for the provisioned PVC.
+  annotations: {}
+  # Mount path inside the container for shared state.
+  mountPath: /var/lib/mcp-atlassian
+  # When enabled, these env vars are injected automatically:
+  #   STATELESS_HTTP=true
+  #   UPLOAD_STAGING_BACKEND=filesystem
+  #   UPLOAD_STAGING_DIR=<mountPath>/upload-staging
+  #   ATTACHMENT_DOWNLOAD_BACKEND=filesystem
+  #   ATTACHMENT_DOWNLOAD_DIR=<mountPath>/attachment-downloads
 
 nodeSelector: {}
 

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -70,6 +70,13 @@ logger = setup_logging(logging_level, logging_stream)
     help="Path for Streamable HTTP transport (e.g., /mcp).",
 )
 @click.option(
+    "--stateless-http",
+    is_flag=True,
+    help="Run Streamable HTTP transport in stateless mode (no per-session "
+    "transport state), so any request can be served by any instance behind a "
+    "round-robin load balancer.",
+)
+@click.option(
     "--confluence-url",
     help="Confluence URL (e.g., https://your-domain.atlassian.net/wiki)",
 )
@@ -164,6 +171,7 @@ def main(
     port: int,
     host: str,
     path: str | None,
+    stateless_http: bool,
     confluence_url: str | None,
     confluence_username: str | None,
     confluence_token: str | None,
@@ -282,6 +290,12 @@ def main(
         f"Final path for Streamable HTTP: {final_path if final_path else 'FastMCP default'}"
     )
 
+    # Stateless HTTP precedence
+    final_stateless_http = is_env_truthy("STATELESS_HTTP", "false")
+    if click_ctx and was_option_provided(click_ctx, "stateless_http"):
+        final_stateless_http = stateless_http
+    logger.debug(f"Final stateless_http for HTTP transports: {final_stateless_http}")
+
     cli_read_only_value = str(read_only).lower()
     os.environ["CLI_READ_ONLY_MODE"] = cli_read_only_value
 
@@ -357,6 +371,7 @@ def main(
         run_kwargs["host"] = final_host
         run_kwargs["port"] = final_port
         run_kwargs["log_level"] = logging.getLevelName(current_logging_level).lower()
+        run_kwargs["stateless_http"] = final_stateless_http
 
         if final_path is not None:
             run_kwargs["path"] = final_path

--- a/src/mcp_atlassian/jira/attachment_cache.py
+++ b/src/mcp_atlassian/jira/attachment_cache.py
@@ -1,13 +1,22 @@
 """In-memory cache for Jira attachments to expose via MCP resources."""
 
 import hashlib
+import importlib
+import json
 import logging
+import os
+import re
 import secrets
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger("mcp-jira")
+
+# Download tokens are URL-safe (token_urlsafe); validate before using on disk.
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def _utcnow() -> datetime:
@@ -15,23 +24,269 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _parse_dt(value: Any) -> datetime | None:
+    """Parse an ISO-8601 string into an aware datetime, or None."""
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+class DownloadTokenStore(ABC):
+    """Pluggable store mapping a download token to self-contained file bytes.
+
+    Tokens are self-contained: each carries its own content and expiry, so a
+    token minted on one instance can be resolved by any other instance sharing
+    the store. Point the ``filesystem`` backend at a shared volume (EFS, Azure
+    Files, NFS, ...) for stateless multi-instance downloads; the default
+    in-memory store keeps single-instance behavior with no extra dependencies.
+    """
+
+    @abstractmethod
+    def create(
+        self,
+        issue_key: str,
+        filename: str,
+        mime_type: str,
+        content: bytes,
+        expires_at: datetime,
+    ) -> str:
+        """Persist a token entry and return the opaque token."""
+
+    @abstractmethod
+    def get(self, token: str) -> dict[str, Any] | None:
+        """Resolve a token to its entry, or None if unknown / expired."""
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Remove all tokens."""
+
+    @abstractmethod
+    def sweep_expired(self) -> int:
+        """Delete every expired token entry; return the number removed."""
+
+
+class MemoryDownloadTokenStore(DownloadTokenStore):
+    """Process-local, in-memory download token store (single instance)."""
+
+    def __init__(self) -> None:
+        self._tokens: dict[str, dict[str, Any]] = {}
+
+    def create(
+        self,
+        issue_key: str,
+        filename: str,
+        mime_type: str,
+        content: bytes,
+        expires_at: datetime,
+    ) -> str:
+        self.sweep_expired()
+        token = secrets.token_urlsafe(24)
+        self._tokens[token] = {
+            "issue_key": issue_key,
+            "filename": filename,
+            "mime_type": mime_type,
+            "content": content,
+            "expires_at": expires_at,
+        }
+        return token
+
+    def get(self, token: str) -> dict[str, Any] | None:
+        entry = self._tokens.get(token)
+        if not entry:
+            return None
+        if _utcnow() > entry["expires_at"]:
+            self._tokens.pop(token, None)
+            return None
+        return dict(entry)
+
+    def clear(self) -> None:
+        self._tokens.clear()
+
+    def sweep_expired(self) -> int:
+        now = _utcnow()
+        expired = [k for k, v in self._tokens.items() if now > v["expires_at"]]
+        for token in expired:
+            self._tokens.pop(token, None)
+        return len(expired)
+
+
+class FilesystemDownloadTokenStore(DownloadTokenStore):
+    """Download token store backed by a (optionally shared) directory.
+
+    Point ``root_dir`` at a volume shared by every instance so any instance can
+    serve a token minted elsewhere. Each token is a ``<token>.bin`` (content)
+    plus ``<token>.json`` (metadata + expiry) pair.
+    """
+
+    def __init__(self, root_dir: str) -> None:
+        self._root = Path(root_dir)
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def create(
+        self,
+        issue_key: str,
+        filename: str,
+        mime_type: str,
+        content: bytes,
+        expires_at: datetime,
+    ) -> str:
+        token = secrets.token_urlsafe(24)
+        self._atomic_write_bytes(self._root / f"{token}.bin", content)
+        self._atomic_write_bytes(
+            self._root / f"{token}.json",
+            json.dumps(
+                {
+                    "issue_key": issue_key,
+                    "filename": filename,
+                    "mime_type": mime_type,
+                    "expires_at": expires_at.isoformat(),
+                }
+            ).encode("utf-8"),
+        )
+        return token
+
+    def get(self, token: str) -> dict[str, Any] | None:
+        if not _TOKEN_RE.match(token):
+            return None
+        meta_path = self._root / f"{token}.json"
+        bin_path = self._root / f"{token}.bin"
+        if not meta_path.is_file() or not bin_path.is_file():
+            return None
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        expires_at = _parse_dt(meta.get("expires_at"))
+        if expires_at is None or _utcnow() > expires_at:
+            self._remove_token(token)
+            return None
+        try:
+            content = bin_path.read_bytes()
+        except OSError:
+            return None
+        return {
+            "issue_key": meta.get("issue_key"),
+            "filename": meta.get("filename"),
+            "mime_type": meta.get("mime_type"),
+            "content": content,
+            "expires_at": expires_at,
+        }
+
+    def clear(self) -> None:
+        for child in self._root.iterdir():
+            if child.is_file() and child.suffix in (".bin", ".json"):
+                child.unlink(missing_ok=True)
+
+    def sweep_expired(self) -> int:
+        removed = 0
+        now = _utcnow()
+        try:
+            metas = list(self._root.glob("*.json"))
+        except OSError:
+            return 0
+        for meta_path in metas:
+            token = meta_path.stem
+            if not _TOKEN_RE.match(token):
+                continue
+            try:
+                meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                meta = None
+            expires_at = _parse_dt(meta.get("expires_at")) if meta else None
+            if expires_at is None or now > expires_at:
+                self._remove_token(token)
+                removed += 1
+        # Reap temp files orphaned by interrupted atomic writes, guarded by age
+        # so an in-flight write on another instance is never deleted mid-flight.
+        cutoff = now - timedelta(hours=1)
+        for tmp in self._root.glob("*.tmp"):
+            try:
+                mtime = datetime.fromtimestamp(tmp.stat().st_mtime, tz=timezone.utc)
+            except OSError:
+                continue
+            if mtime < cutoff:
+                tmp.unlink(missing_ok=True)
+        return removed
+
+    def _remove_token(self, token: str) -> None:
+        for suffix in (".bin", ".json"):
+            (self._root / f"{token}{suffix}").unlink(missing_ok=True)
+
+    @staticmethod
+    def _atomic_write_bytes(path: Path, data: bytes) -> None:
+        tmp = path.with_name(f"{path.name}.{secrets.token_hex(4)}.tmp")
+        tmp.write_bytes(data)
+        tmp.replace(path)
+
+
+def _build_download_token_store() -> DownloadTokenStore:
+    """Build the configured download token store from environment settings.
+
+    ``ATTACHMENT_DOWNLOAD_BACKEND`` selects the backend:
+      - ``memory`` (default): process-local store (single instance).
+      - ``filesystem``: shared dir from ``ATTACHMENT_DOWNLOAD_DIR`` (multi-instance).
+      - ``package.module:ClassName``: a user-provided store (e.g. S3/DynamoDB).
+    """
+    raw = os.environ.get("ATTACHMENT_DOWNLOAD_BACKEND", "memory").strip()
+    if ":" in raw:
+        module_name, _, class_name = raw.partition(":")
+        if not module_name or not class_name:
+            raise ValueError(
+                f"Invalid ATTACHMENT_DOWNLOAD_BACKEND path '{raw}'. "
+                "Expected format 'package.module:ClassName'."
+            )
+        module = importlib.import_module(module_name)
+        store = getattr(module, class_name)()
+        if not isinstance(store, DownloadTokenStore):
+            raise TypeError(
+                f"{raw} must be a subclass of DownloadTokenStore, "
+                f"got {type(store).__name__}."
+            )
+        return store
+
+    name = raw.lower()
+    if name in ("", "memory", "in-memory", "inmemory"):
+        return MemoryDownloadTokenStore()
+    if name in ("filesystem", "fs", "disk"):
+        root_dir = os.environ.get("ATTACHMENT_DOWNLOAD_DIR")
+        if not root_dir:
+            raise ValueError(
+                "ATTACHMENT_DOWNLOAD_BACKEND=filesystem requires "
+                "ATTACHMENT_DOWNLOAD_DIR to point at a (shared) directory."
+            )
+        return FilesystemDownloadTokenStore(root_dir)
+    raise ValueError(
+        f"Unknown ATTACHMENT_DOWNLOAD_BACKEND '{raw}'. "
+        "Expected 'memory', 'filesystem', or 'package.module:ClassName'."
+    )
+
+
 class AttachmentCache:
     """Thread-safe in-memory cache for storing attachment data temporarily."""
 
-    def __init__(self, ttl_minutes: int = 10, max_size_mb: int = 100) -> None:
+    def __init__(
+        self,
+        ttl_minutes: int = 10,
+        max_size_mb: int = 100,
+        token_store: DownloadTokenStore | None = None,
+    ) -> None:
         """
         Initialize the attachment cache.
 
         Args:
             ttl_minutes: Time-to-live for cached items in minutes (default: 10)
             max_size_mb: Maximum total cache size in MB (default: 100)
+            token_store: Backend for download tokens (default: in-memory)
         """
         self._cache: dict[str, dict[str, Any]] = {}
         self._ttl_minutes = ttl_minutes
         self._max_size_bytes = max_size_mb * 1024 * 1024
         self._current_size_bytes = 0
         self._remove_listeners: list[Callable[[str, str], None]] = []
-        self._download_tokens: dict[str, dict[str, Any]] = {}
+        self._token_store = token_store or MemoryDownloadTokenStore()
 
     def add_remove_listener(self, listener: Callable[[str, str], None]) -> None:
         """Register a callback for when the last cached copy of a file is removed."""
@@ -51,14 +306,6 @@ class AttachmentCache:
         ]
         for key in expired_keys:
             self._remove(key)
-
-        expired_tokens = [
-            token
-            for token, value in self._download_tokens.items()
-            if now > value["expires_at"]
-        ]
-        for token in expired_tokens:
-            del self._download_tokens[token]
 
     def _evict_lru(self) -> None:
         """Remove least recently used entries to free space."""
@@ -89,7 +336,6 @@ class AttachmentCache:
                 for cached_item in self._cache.values()
             )
             if not has_remaining_copy:
-                self._revoke_download_tokens(issue_key, filename)
                 for listener in self._remove_listeners:
                     try:
                         listener(issue_key, filename)
@@ -119,16 +365,6 @@ class AttachmentCache:
 
         matches.sort(key=lambda x: x[1]["created_at"], reverse=True)
         return matches[0]
-
-    def _revoke_download_tokens(self, issue_key: str, filename: str) -> None:
-        """Remove outstanding download tokens for a cached attachment."""
-        matching_tokens = [
-            token
-            for token, value in self._download_tokens.items()
-            if value["issue_key"] == issue_key and value["filename"] == filename
-        ]
-        for token in matching_tokens:
-            del self._download_tokens[token]
 
     def store(
         self, issue_key: str, filename: str, content: bytes, mime_type: str
@@ -233,13 +469,13 @@ class AttachmentCache:
         _, item = match
         requested_expiry = _utcnow() + timedelta(minutes=ttl_minutes)
         expires_at = min(requested_expiry, item["expires_at"])
-        token = secrets.token_urlsafe(24)
-
-        self._download_tokens[token] = {
-            "issue_key": issue_key,
-            "filename": filename,
-            "expires_at": expires_at,
-        }
+        token = self._token_store.create(
+            issue_key=issue_key,
+            filename=filename,
+            mime_type=item["mime_type"],
+            content=item["content"],
+            expires_at=expires_at,
+        )
 
         return {
             "token": token,
@@ -250,23 +486,18 @@ class AttachmentCache:
         }
 
     def get_by_download_token(self, token: str) -> dict[str, Any] | None:
-        """Resolve a download token to the current cached attachment content."""
-        self._evict_expired()
-        token_data = self._download_tokens.get(token)
-        if not token_data:
+        """Resolve a download token to its self-contained attachment content."""
+        entry = self._token_store.get(token)
+        if not entry:
             logger.debug(f"Download token miss: {token}")
             return None
 
-        attachment = self.get_by_issue_and_filename(
-            token_data["issue_key"], token_data["filename"]
-        )
-        if not attachment:
-            del self._download_tokens[token]
-            return None
-
         return {
-            **attachment,
-            "expires_at": token_data["expires_at"],
+            "content": entry["content"],
+            "mime_type": entry["mime_type"],
+            "filename": entry["filename"],
+            "issue_key": entry["issue_key"],
+            "expires_at": entry["expires_at"],
         }
 
     def get(self, cache_key: str) -> dict[str, Any] | None:
@@ -301,7 +532,21 @@ class AttachmentCache:
         count = len(self._cache)
         for key in list(self._cache):
             self._remove(key)
+        self._token_store.clear()
         logger.info(f"Cleared attachment cache ({count} items)")
+
+    def sweep_expired(self) -> int:
+        """Proactively evict expired cache entries and download tokens.
+
+        The per-read checks only reclaim entries that are accessed again; this
+        also reclaims download tokens (and their shared-disk files) that are
+        minted but never fetched.
+        """
+        before = len(self._cache)
+        self._evict_expired()
+        removed = before - len(self._cache)
+        removed += self._token_store.sweep_expired()
+        return removed
 
     def get_stats(self) -> dict[str, Any]:
         """Get cache statistics."""
@@ -319,7 +564,7 @@ class AttachmentCache:
 
 
 # Global cache instance
-_attachment_cache = AttachmentCache()
+_attachment_cache = AttachmentCache(token_store=_build_download_token_store())
 
 
 def get_attachment_cache() -> AttachmentCache:

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -300,6 +300,79 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
             "failed": failed,
         }
 
+    def fetch_and_cache_attachment(self, issue_key: str, filename: str) -> bool:
+        """Fetch a single attachment's content from Jira and store it in the cache.
+
+        Enables the stateless download-URL flow: any instance can populate its
+        (optionally shared) attachment cache on demand, instead of relying on a
+        prior ``download_issue_attachments`` call having run on the same instance.
+
+        Args:
+            issue_key: The Jira issue key (e.g., 'PROJ-123').
+            filename: The attachment filename to fetch.
+
+        Returns:
+            True if the attachment was found and cached, False otherwise.
+        """
+        issue_data = self.jira.issue(issue_key, fields="attachment")
+        if not isinstance(issue_data, dict) or "fields" not in issue_data:
+            return False
+
+        target: JiraAttachment | None = None
+        for raw in issue_data.get("fields", {}).get("attachment", []):
+            if not isinstance(raw, dict):
+                continue
+            candidate = JiraAttachment.from_api_response(raw)
+            if candidate.filename == filename and candidate.url:
+                target = candidate
+                break
+
+        if target is None or not target.url:
+            return False
+
+        from .attachment_cache import AttachmentCache
+
+        cache = get_attachment_cache()
+        max_download_bytes = (
+            cache._max_size_bytes
+            if isinstance(cache, AttachmentCache)
+            else 100 * 1024 * 1024
+        )
+
+        response = self.jira._session.get(target.url, stream=True)
+        response.raise_for_status()
+        content_buffer = bytearray()
+        try:
+            bytes_read = 0
+            for chunk in response.iter_content(chunk_size=8192):
+                if not chunk:
+                    continue
+                bytes_read += len(chunk)
+                if bytes_read > max_download_bytes:
+                    logger.error(
+                        f"Attachment '{filename}' exceeds maximum size "
+                        f"({max_download_bytes} bytes), aborting download"
+                    )
+                    return False
+                content_buffer.extend(chunk)
+        finally:
+            response.close()
+
+        mime_type = target.content_type or "application/octet-stream"
+        cache.store(
+            issue_key=issue_key,
+            filename=filename,
+            content=bytes(content_buffer),
+            mime_type=mime_type,
+        )
+        logger.info(
+            "On-demand cached attachment '%s' from %s (%d bytes)",
+            filename,
+            issue_key,
+            len(content_buffer),
+        )
+        return True
+
     def upload_attachment(self, issue_key: str, file_path: str) -> dict[str, Any]:
         """
         Upload a single attachment to a Jira issue.

--- a/src/mcp_atlassian/jira/upload_staging.py
+++ b/src/mcp_atlassian/jira/upload_staging.py
@@ -6,13 +6,23 @@ then consumed by the jira_upload_attachment MCP tool to push them to Jira.
 URI scheme: upload://sessions/<session_id>/<file_id>
 """
 
+import importlib
+import json
 import logging
 import os
+import re
 import secrets
+import shutil
+from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger("mcp-jira")
+
+# Server-issued session/file identifiers are URL-safe tokens. Validate them
+# before using them as path components to prevent traversal on disk backends.
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def _utcnow() -> datetime:
@@ -39,7 +49,72 @@ _MAX_SIZE_MB = _safe_int_env("UPLOAD_STAGING_MAX_SIZE_MB", 200)
 _URI_PREFIX = "upload://sessions/"
 
 
-class UploadStagingStore:
+class UploadStagingBackend(ABC):
+    """Abstract base for pluggable upload staging backends.
+
+    A backend mints opaque session tokens, stores file bytes against a
+    session, and retrieves them later for the ``jira_upload_attachment`` tool.
+    Implementations that persist to shared storage (e.g. a shared filesystem or
+    object store) allow the MCP server to run statelessly behind a round-robin
+    load balancer.
+    """
+
+    @property
+    @abstractmethod
+    def max_file_bytes(self) -> int:
+        """Maximum size, in bytes, allowed for a single staged file."""
+
+    @abstractmethod
+    def create_session(self) -> str:
+        """Generate and persist a new opaque upload session token."""
+
+    @abstractmethod
+    def is_valid_session(self, session_id: str) -> bool:
+        """Return True when the session was issued here and is unexpired."""
+
+    @abstractmethod
+    def store(
+        self, session_id: str, filename: str, content: bytes, mime_type: str
+    ) -> str:
+        """Stage a file and return its file_id."""
+
+    @abstractmethod
+    def get(self, session_id: str, file_id: str) -> dict[str, Any] | None:
+        """Return a staged entry, or None if not found / expired."""
+
+    @abstractmethod
+    def remove(self, session_id: str, file_id: str) -> None:
+        """Remove a staged file (call after a successful Jira upload)."""
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Clear all staged files and issued sessions."""
+
+    @abstractmethod
+    def sweep_expired(self) -> int:
+        """Delete expired sessions/files; return the number of files removed."""
+
+    @staticmethod
+    def make_uri(session_id: str, file_id: str) -> str:
+        """Build the canonical upload:// URI for a staged file."""
+        return f"{_URI_PREFIX}{session_id}/{file_id}"
+
+    @staticmethod
+    def parse_uri(uri: str) -> tuple[str, str] | None:
+        """Parse upload://sessions/<session_id>/<file_id> → (session_id, file_id).
+
+        Returns None if the URI does not match the expected format.
+        """
+        if not uri.startswith(_URI_PREFIX):
+            return None
+        rest = uri[len(_URI_PREFIX) :]
+        parts = rest.split("/", 1)
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            return None
+        return parts[0], parts[1]
+
+
+class UploadStagingStore(UploadStagingBackend):
     """In-memory staging store for files uploaded by MCP clients."""
 
     def __init__(self, ttl_minutes: int = 30, max_size_mb: int = 200) -> None:
@@ -49,6 +124,10 @@ class UploadStagingStore:
         self._ttl = timedelta(minutes=ttl_minutes)
         self._max_size_bytes = max_size_mb * 1024 * 1024
         self._current_size_bytes = 0
+
+    @property
+    def max_file_bytes(self) -> int:
+        return self._max_size_bytes
 
     def create_session(self) -> str:
         """Generate a new opaque upload session token."""
@@ -145,28 +224,12 @@ class UploadStagingStore:
         self._sessions.clear()
         self._current_size_bytes = 0
 
-    # ------------------------------------------------------------------
-    # URI helpers
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def make_uri(session_id: str, file_id: str) -> str:
-        """Build the canonical upload:// URI for a staged file."""
-        return f"{_URI_PREFIX}{session_id}/{file_id}"
-
-    @staticmethod
-    def parse_uri(uri: str) -> tuple[str, str] | None:
-        """Parse upload://sessions/<session_id>/<file_id> → (session_id, file_id).
-
-        Returns None if the URI does not match the expected format.
-        """
-        if not uri.startswith(_URI_PREFIX):
-            return None
-        rest = uri[len(_URI_PREFIX) :]
-        parts = rest.split("/", 1)
-        if len(parts) != 2 or not parts[0] or not parts[1]:
-            return None
-        return parts[0], parts[1]
+    def sweep_expired(self) -> int:
+        """Delete expired sessions/files; return the number of files removed."""
+        before = sum(len(files) for files in self._store.values())
+        self._evict_expired()
+        after = sum(len(files) for files in self._store.values())
+        return before - after
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -208,19 +271,271 @@ class UploadStagingStore:
             self.remove(*oldest_key)
 
 
+class FilesystemUploadStagingBackend(UploadStagingBackend):
+    """Staging backend that persists files to a (optionally shared) directory.
+
+    Point ``root_dir`` at a volume shared by every server instance (e.g. NFS or
+    an EFS mount) so any instance behind a round-robin load balancer can serve a
+    staged upload. Each session is a subdirectory holding a ``session.json``
+    marker plus ``<file_id>.bin`` / ``<file_id>.json`` pairs.
+    """
+
+    def __init__(
+        self, root_dir: str, ttl_minutes: int = 30, max_size_mb: int = 200
+    ) -> None:
+        self._root = Path(root_dir)
+        self._ttl = timedelta(minutes=ttl_minutes)
+        self._max_size_bytes = max_size_mb * 1024 * 1024
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def max_file_bytes(self) -> int:
+        return self._max_size_bytes
+
+    def _session_dir(self, session_id: str) -> Path | None:
+        if not _TOKEN_RE.match(session_id):
+            return None
+        return self._root / session_id
+
+    def create_session(self) -> str:
+        session_id = secrets.token_urlsafe(24)
+        session_dir = self._root / session_id
+        session_dir.mkdir(parents=True, exist_ok=True)
+        expires_at = _utcnow() + self._ttl
+        self._write_json(
+            session_dir / "session.json", {"expires_at": expires_at.isoformat()}
+        )
+        return session_id
+
+    def is_valid_session(self, session_id: str) -> bool:
+        session_dir = self._session_dir(session_id)
+        if session_dir is None:
+            return False
+        marker = session_dir / "session.json"
+        if not marker.is_file():
+            return False
+        data = self._read_json(marker)
+        if data is None:
+            return False
+        expires_at = self._parse_dt(data.get("expires_at"))
+        if expires_at is None or _utcnow() > expires_at:
+            self._remove_session_dir(session_dir)
+            return False
+        return True
+
+    def store(
+        self, session_id: str, filename: str, content: bytes, mime_type: str
+    ) -> str:
+        if not self.is_valid_session(session_id):
+            raise PermissionError(
+                "Upload session is invalid or expired. "
+                "Call construct_upload_endpoint to create a new session."
+            )
+
+        content_size = len(content)
+        if content_size > self._max_size_bytes:
+            raise ValueError(
+                f"File size ({content_size} bytes) exceeds staging limit "
+                f"({self._max_size_bytes} bytes)"
+            )
+
+        session_dir = self._session_dir(session_id)
+        if session_dir is None:  # pragma: no cover - guarded by is_valid_session
+            raise PermissionError("Invalid upload session identifier.")
+        file_id = secrets.token_urlsafe(12)
+        created_at = _utcnow()
+        expires_at = created_at + self._ttl
+        self._atomic_write_bytes(session_dir / f"{file_id}.bin", content)
+        self._write_json(
+            session_dir / f"{file_id}.json",
+            {
+                "filename": filename,
+                "mime_type": mime_type,
+                "created_at": created_at.isoformat(),
+                "expires_at": expires_at.isoformat(),
+            },
+        )
+        logger.debug(
+            "Staged upload '%s' \u2192 session=%s file_id=%s (%d bytes) [filesystem]",
+            filename,
+            session_id,
+            file_id,
+            content_size,
+        )
+        return file_id
+
+    def get(self, session_id: str, file_id: str) -> dict[str, Any] | None:
+        session_dir = self._session_dir(session_id)
+        if session_dir is None or not _TOKEN_RE.match(file_id):
+            return None
+        meta_path = session_dir / f"{file_id}.json"
+        bin_path = session_dir / f"{file_id}.bin"
+        if not meta_path.is_file() or not bin_path.is_file():
+            return None
+        meta = self._read_json(meta_path)
+        if meta is None:
+            return None
+        expires_at = self._parse_dt(meta.get("expires_at"))
+        if expires_at is None or _utcnow() > expires_at:
+            self.remove(session_id, file_id)
+            return None
+        try:
+            content = bin_path.read_bytes()
+        except OSError:
+            return None
+        return {
+            "filename": meta.get("filename"),
+            "content": content,
+            "mime_type": meta.get("mime_type"),
+            "created_at": self._parse_dt(meta.get("created_at")),
+            "expires_at": expires_at,
+        }
+
+    def remove(self, session_id: str, file_id: str) -> None:
+        session_dir = self._session_dir(session_id)
+        if session_dir is None or not _TOKEN_RE.match(file_id):
+            return
+        for suffix in (".bin", ".json"):
+            path = session_dir / f"{file_id}{suffix}"
+            path.unlink(missing_ok=True)
+
+    def clear(self) -> None:
+        for child in self._root.iterdir():
+            if child.is_dir():
+                shutil.rmtree(child, ignore_errors=True)
+
+    def sweep_expired(self) -> int:
+        """Delete expired sessions/files; return the number of files removed."""
+        if not self._root.exists():
+            return 0
+        removed = 0
+        now = _utcnow()
+        try:
+            children = list(self._root.iterdir())
+        except OSError:
+            return 0
+        for session_dir in children:
+            if not session_dir.is_dir():
+                continue
+            marker = session_dir / "session.json"
+            data = self._read_json(marker) if marker.is_file() else None
+            session_expires = self._parse_dt(data.get("expires_at")) if data else None
+            # Whole session expired (or marker missing/corrupt): drop the dir.
+            if session_expires is None or now > session_expires:
+                removed += sum(1 for _ in session_dir.glob("*.bin"))
+                self._remove_session_dir(session_dir)
+                continue
+            # Session still valid: drop any individually-expired files.
+            for meta_path in session_dir.glob("*.json"):
+                if meta_path.name == "session.json":
+                    continue
+                meta = self._read_json(meta_path)
+                file_expires = self._parse_dt(meta.get("expires_at")) if meta else None
+                if file_expires is None or now > file_expires:
+                    self.remove(session_dir.name, meta_path.stem)
+                    removed += 1
+        return removed
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_dt(value: Any) -> datetime | None:
+        if not isinstance(value, str):
+            return None
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _write_json(path: Path, data: dict[str, Any]) -> None:
+        FilesystemUploadStagingBackend._atomic_write_bytes(
+            path, json.dumps(data).encode("utf-8")
+        )
+
+    @staticmethod
+    def _read_json(path: Path) -> dict[str, Any] | None:
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+
+    @staticmethod
+    def _atomic_write_bytes(path: Path, data: bytes) -> None:
+        tmp = path.with_name(f"{path.name}.{secrets.token_hex(4)}.tmp")
+        tmp.write_bytes(data)
+        tmp.replace(path)
+
+    @staticmethod
+    def _remove_session_dir(session_dir: Path) -> None:
+        shutil.rmtree(session_dir, ignore_errors=True)
+
+
 # ---------------------------------------------------------------------------
 # Singleton accessor
 # ---------------------------------------------------------------------------
 
-_upload_staging: UploadStagingStore | None = None
+_upload_staging: UploadStagingBackend | None = None
 
 
-def get_upload_staging() -> UploadStagingStore:
-    """Return the process-wide singleton UploadStagingStore."""
-    global _upload_staging
-    if _upload_staging is None:
-        _upload_staging = UploadStagingStore(
+def _load_backend_from_path(path: str) -> UploadStagingBackend:
+    """Instantiate a user-provided backend given a ``pkg.module:ClassName`` path."""
+    module_name, _, class_name = path.partition(":")
+    if not module_name or not class_name:
+        raise ValueError(
+            f"Invalid UPLOAD_STAGING_BACKEND path '{path}'. "
+            "Expected format 'package.module:ClassName'."
+        )
+    module = importlib.import_module(module_name)
+    backend_cls = getattr(module, class_name)
+    instance = backend_cls(ttl_minutes=_TTL_MINUTES, max_size_mb=_MAX_SIZE_MB)
+    if not isinstance(instance, UploadStagingBackend):
+        raise TypeError(
+            f"{path} must be a subclass of UploadStagingBackend, "
+            f"got {type(instance).__name__}."
+        )
+    return instance
+
+
+def _build_upload_staging() -> UploadStagingBackend:
+    """Build the configured upload staging backend from environment settings.
+
+    ``UPLOAD_STAGING_BACKEND`` selects the backend:
+      - ``memory`` (default): process-local in-memory store (single instance).
+      - ``filesystem``: shared directory from ``UPLOAD_STAGING_DIR`` (stateless).
+      - ``package.module:ClassName``: a user-provided backend (e.g. S3), enabling
+        stateless deployments without bundling heavy dependencies in core.
+    """
+    raw = os.environ.get("UPLOAD_STAGING_BACKEND", "memory").strip()
+    if ":" in raw:
+        return _load_backend_from_path(raw)
+
+    name = raw.lower()
+    if name in ("", "memory", "in-memory", "inmemory"):
+        return UploadStagingStore(ttl_minutes=_TTL_MINUTES, max_size_mb=_MAX_SIZE_MB)
+    if name in ("filesystem", "fs", "disk"):
+        root_dir = os.environ.get("UPLOAD_STAGING_DIR")
+        if not root_dir:
+            raise ValueError(
+                "UPLOAD_STAGING_BACKEND=filesystem requires UPLOAD_STAGING_DIR "
+                "to point at a (shared) directory."
+            )
+        return FilesystemUploadStagingBackend(
+            root_dir=root_dir,
             ttl_minutes=_TTL_MINUTES,
             max_size_mb=_MAX_SIZE_MB,
         )
+    raise ValueError(
+        f"Unknown UPLOAD_STAGING_BACKEND '{raw}'. "
+        "Expected 'memory', 'filesystem', or 'package.module:ClassName'."
+    )
+
+
+def get_upload_staging() -> UploadStagingBackend:
+    """Return the process-wide singleton upload staging backend."""
+    global _upload_staging
+    if _upload_staging is None:
+        _upload_staging = _build_upload_staging()
     return _upload_staging

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2251,14 +2251,25 @@ async def construct_download_endpoint(
     Returns:
         JSON string with download_url, expires_at, and attachment metadata.
     """
-    del ctx
-
     cache = get_attachment_cache()
-    token_info = cache.create_download_token(
-        issue_key=issue_key,
-        filename=filename,
-        ttl_minutes=ttl_minutes,
-    )
+    try:
+        token_info = cache.create_download_token(
+            issue_key=issue_key,
+            filename=filename,
+            ttl_minutes=ttl_minutes,
+        )
+    except ValueError:
+        # Cache miss — e.g. the attachment was cached on a different stateless
+        # instance, or not fetched yet. Fetch it on demand so the download-URL
+        # flow works regardless of which instance served jira_download_attachments.
+        jira = await get_jira_fetcher(ctx)
+        if not jira.fetch_and_cache_attachment(issue_key, filename):
+            raise
+        token_info = cache.create_download_token(
+            issue_key=issue_key,
+            filename=filename,
+            ttl_minutes=ttl_minutes,
+        )
     base_url = _get_external_base_url()
     download_url = f"{base_url}/download/{token_info['token']}"
 

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -1,5 +1,6 @@
 """Main FastMCP server setup for Atlassian integration."""
 
+import asyncio
 import json
 import logging
 import os
@@ -102,7 +103,7 @@ async def upload_endpoint(request: Request) -> JSONResponse:
         return JSONResponse({"error": "Invalid multipart form data"}, status_code=400)
 
     uploaded = []
-    max_file_bytes = staging._max_size_bytes
+    max_file_bytes = staging.max_file_bytes
     for _field_name, file_field in form.multi_items():
         if not hasattr(file_field, "filename") or not file_field.filename:
             continue
@@ -210,6 +211,49 @@ async def metrics_endpoint(request: Request) -> Response:
 
     content, content_type = metrics_collector.generate_metrics()
     return Response(content, media_type=content_type)
+
+
+def _cleanup_interval_seconds() -> int:
+    """Resolve the staging cleanup sweep interval in seconds; 0 disables it."""
+    raw = os.environ.get("STAGING_CLEANUP_INTERVAL_MINUTES", "15")
+    try:
+        minutes = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid STAGING_CLEANUP_INTERVAL_MINUTES=%r; using default of 15.", raw
+        )
+        minutes = 15
+    return max(0, minutes) * 60
+
+
+async def _sweep_staging_once() -> None:
+    """Run one cleanup pass over download tokens and staged uploads."""
+    try:
+        tokens = await asyncio.to_thread(get_attachment_cache().sweep_expired)
+        staged = await asyncio.to_thread(get_upload_staging().sweep_expired)
+        if tokens or staged:
+            logger.info(
+                "Staging cleanup reclaimed %d expired download token(s)/cache "
+                "entr(ies) and %d expired staged upload(s).",
+                tokens,
+                staged,
+            )
+        else:
+            logger.debug("Staging cleanup: nothing to reclaim.")
+    except Exception as exc:  # keep the sweeper loop alive across failures
+        logger.warning("Staging cleanup sweep failed: %s", exc, exc_info=True)
+
+
+async def _run_staging_cleanup(interval_seconds: int) -> None:
+    """Periodically reclaim expired download tokens and staged uploads.
+
+    Runs in-process so entries are reclaimed even when a minted download URL is
+    never fetched (nothing reads it to trigger the lazy per-request cleanup).
+    Deletes are idempotent, so every instance can safely sweep a shared volume.
+    """
+    while True:
+        await asyncio.sleep(interval_seconds)
+        await _sweep_staging_once()
 
 
 @asynccontextmanager
@@ -339,6 +383,16 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
     )
     logger.info(f"Enabled tools filter: {enabled_tools or 'All tools enabled'}")
 
+    cleanup_interval = _cleanup_interval_seconds()
+    cleanup_task: asyncio.Task | None = None
+    if cleanup_interval > 0:
+        cleanup_task = asyncio.create_task(_run_staging_cleanup(cleanup_interval))
+        logger.info(
+            "Started staging cleanup sweeper (every %d min).", cleanup_interval // 60
+        )
+    else:
+        logger.info("Staging cleanup sweeper disabled (interval=0).")
+
     try:
         yield {"app_lifespan_context": app_context}
     except Exception as e:
@@ -348,6 +402,12 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
         logger.info("Main Atlassian MCP server lifespan shutting down...")
         # Perform any necessary cleanup here
         try:
+            if cleanup_task is not None:
+                cleanup_task.cancel()
+                try:
+                    await cleanup_task
+                except asyncio.CancelledError:
+                    pass
             # Close any open connections if needed
             if loaded_jira_config:
                 logger.debug("Cleaning up Jira resources...")

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -2,14 +2,26 @@
 
 import os
 import tempfile
+from datetime import timedelta
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
 from mcp_atlassian.jira import JiraFetcher
-from mcp_atlassian.jira.attachment_cache import AttachmentCache
+from mcp_atlassian.jira.attachment_cache import (
+    AttachmentCache,
+    DownloadTokenStore,
+    FilesystemDownloadTokenStore,
+    MemoryDownloadTokenStore,
+    _build_download_token_store,
+)
+from mcp_atlassian.jira.attachment_cache import _utcnow as _cache_utcnow
 from mcp_atlassian.jira.attachments import AttachmentsMixin
-from mcp_atlassian.jira.upload_staging import UploadStagingStore
+from mcp_atlassian.jira.upload_staging import (
+    FilesystemUploadStagingBackend,
+    UploadStagingBackend,
+    UploadStagingStore,
+)
 
 # Test scenarios for AttachmentsMixin
 #
@@ -500,6 +512,74 @@ class TestAttachmentsMixin:
         assert "Failed to cache attachment content" in result["failed"][0]["error"]
         assert "content" not in result["failed"][0]
 
+    def test_fetch_and_cache_attachment_success(self, attachments_mixin):
+        """fetch_and_cache_attachment downloads a single file and stores it."""
+        attachments_mixin.jira.issue.return_value = {
+            "fields": {"attachment": [{"filename": "report.pdf"}]}
+        }
+
+        mock_attachment = MagicMock()
+        mock_attachment.filename = "report.pdf"
+        mock_attachment.url = "https://test.url/report.pdf"
+        mock_attachment.content_type = "application/pdf"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.iter_content.return_value = [b"pdf-", b"bytes"]
+        attachments_mixin.jira._session.get.return_value = mock_response
+
+        cache = MagicMock()
+        with (
+            patch(
+                "mcp_atlassian.models.jira.JiraAttachment.from_api_response",
+                return_value=mock_attachment,
+            ),
+            patch(
+                "mcp_atlassian.jira.attachments.get_attachment_cache",
+                return_value=cache,
+            ),
+        ):
+            result = attachments_mixin.fetch_and_cache_attachment(
+                "TEST-123", "report.pdf"
+            )
+
+        assert result is True
+        cache.store.assert_called_once_with(
+            issue_key="TEST-123",
+            filename="report.pdf",
+            content=b"pdf-bytes",
+            mime_type="application/pdf",
+        )
+
+    def test_fetch_and_cache_attachment_not_found(self, attachments_mixin):
+        """fetch_and_cache_attachment returns False when the filename is absent."""
+        attachments_mixin.jira.issue.return_value = {
+            "fields": {"attachment": [{"filename": "other.txt"}]}
+        }
+
+        mock_attachment = MagicMock()
+        mock_attachment.filename = "other.txt"
+        mock_attachment.url = "https://test.url/other.txt"
+
+        cache = MagicMock()
+        with (
+            patch(
+                "mcp_atlassian.models.jira.JiraAttachment.from_api_response",
+                return_value=mock_attachment,
+            ),
+            patch(
+                "mcp_atlassian.jira.attachments.get_attachment_cache",
+                return_value=cache,
+            ),
+        ):
+            result = attachments_mixin.fetch_and_cache_attachment(
+                "TEST-123", "missing.pdf"
+            )
+
+        assert result is False
+        cache.store.assert_not_called()
+        attachments_mixin.jira._session.get.assert_not_called()
+
 
 class TestUploadStagingStore:
     """Tests for the upload staging session validation flow."""
@@ -881,3 +961,392 @@ class TestAttachmentCacheDownloadTokens:
         # Assertions
         assert result["success"] is False
         assert "No issue key provided" in result["error"]
+
+
+class TestFilesystemUploadStagingBackend:
+    """Tests for the shared-filesystem upload staging backend."""
+
+    @pytest.fixture
+    def backend(self, tmp_path):
+        return FilesystemUploadStagingBackend(
+            root_dir=str(tmp_path / "staging"),
+            ttl_minutes=30,
+            max_size_mb=1,
+        )
+
+    def test_is_a_backend(self, backend):
+        assert isinstance(backend, UploadStagingBackend)
+
+    def test_create_and_validate_session(self, backend):
+        session_id = backend.create_session()
+        assert session_id
+        assert backend.is_valid_session(session_id) is True
+
+    def test_invalid_session_id_rejected(self, backend):
+        assert backend.is_valid_session("../etc/passwd") is False
+        assert backend.is_valid_session("unknown") is False
+
+    def test_store_and_get_roundtrip(self, backend):
+        session_id = backend.create_session()
+        file_id = backend.store(session_id, "hello.txt", b"hi there", "text/plain")
+        entry = backend.get(session_id, file_id)
+        assert entry is not None
+        assert entry["filename"] == "hello.txt"
+        assert entry["content"] == b"hi there"
+        assert entry["mime_type"] == "text/plain"
+        assert entry["created_at"] is not None
+        assert entry["expires_at"] is not None
+
+    def test_store_rejects_unknown_session(self, backend):
+        with pytest.raises(PermissionError):
+            backend.store("unknown-session", "f.txt", b"x", "text/plain")
+
+    def test_store_rejects_oversize_file(self, backend):
+        session_id = backend.create_session()
+        with pytest.raises(ValueError):
+            backend.store(session_id, "big.bin", b"x" * (1024 * 1024 + 1), "app/bin")
+
+    def test_remove_deletes_file(self, backend):
+        session_id = backend.create_session()
+        file_id = backend.store(session_id, "f.txt", b"data", "text/plain")
+        backend.remove(session_id, file_id)
+        assert backend.get(session_id, file_id) is None
+
+    def test_get_unknown_returns_none(self, backend):
+        session_id = backend.create_session()
+        assert backend.get(session_id, "missing") is None
+        assert backend.get(session_id, "../evil") is None
+
+    def test_expired_session_is_invalid(self, tmp_path):
+        backend = FilesystemUploadStagingBackend(
+            root_dir=str(tmp_path / "staging"),
+            ttl_minutes=0,
+            max_size_mb=1,
+        )
+        session_id = backend.create_session()
+        assert backend.is_valid_session(session_id) is False
+
+    def test_clear_removes_sessions(self, backend):
+        session_id = backend.create_session()
+        backend.store(session_id, "f.txt", b"data", "text/plain")
+        backend.clear()
+        assert backend.is_valid_session(session_id) is False
+
+    def test_sweep_expired_reclaims_whole_expired_session(self, backend):
+        """A never-finalized session is reclaimed once its TTL elapses."""
+        session_id = backend.create_session()
+        backend.store(session_id, "f.txt", b"data", "text/plain")
+        future = _cache_utcnow() + timedelta(hours=1)
+        with patch("mcp_atlassian.jira.upload_staging._utcnow", return_value=future):
+            removed = backend.sweep_expired()
+        assert removed == 1
+        assert backend.get(session_id, "f.txt") is None
+
+    def test_sweep_expired_keeps_live_session(self, backend):
+        """Unexpired staged files survive a sweep."""
+        session_id = backend.create_session()
+        file_id = backend.store(session_id, "f.txt", b"data", "text/plain")
+        removed = backend.sweep_expired()
+        assert removed == 0
+        assert backend.get(session_id, file_id) is not None
+
+    def test_persists_across_instances(self, tmp_path):
+        root = str(tmp_path / "shared")
+        first = FilesystemUploadStagingBackend(root_dir=root, max_size_mb=1)
+        session_id = first.create_session()
+        file_id = first.store(session_id, "f.txt", b"shared-bytes", "text/plain")
+
+        # A second instance (simulating a different server pod) sees the file.
+        second = FilesystemUploadStagingBackend(root_dir=root, max_size_mb=1)
+        entry = second.get(session_id, file_id)
+        assert entry is not None
+        assert entry["content"] == b"shared-bytes"
+
+    def test_uri_helpers_inherited(self, backend):
+        uri = backend.make_uri("sess", "file")
+        assert uri == "upload://sessions/sess/file"
+        assert backend.parse_uri(uri) == ("sess", "file")
+
+
+class TestGetUploadStagingFactory:
+    """Tests for the environment-driven upload staging backend factory."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_singleton(self):
+        import mcp_atlassian.jira.upload_staging as staging_module
+
+        staging_module._upload_staging = None
+        yield
+        staging_module._upload_staging = None
+
+    def test_defaults_to_memory(self):
+        from mcp_atlassian.jira.upload_staging import get_upload_staging
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("UPLOAD_STAGING_BACKEND", None)
+            backend = get_upload_staging()
+        assert isinstance(backend, UploadStagingStore)
+
+    def test_memory_explicit(self):
+        from mcp_atlassian.jira.upload_staging import get_upload_staging
+
+        with patch.dict(os.environ, {"UPLOAD_STAGING_BACKEND": "memory"}):
+            backend = get_upload_staging()
+        assert isinstance(backend, UploadStagingStore)
+
+    def test_filesystem_backend(self, tmp_path):
+        from mcp_atlassian.jira.upload_staging import get_upload_staging
+
+        with patch.dict(
+            os.environ,
+            {
+                "UPLOAD_STAGING_BACKEND": "filesystem",
+                "UPLOAD_STAGING_DIR": str(tmp_path / "fs"),
+            },
+        ):
+            backend = get_upload_staging()
+        assert isinstance(backend, FilesystemUploadStagingBackend)
+
+    def test_filesystem_requires_dir(self):
+        from mcp_atlassian.jira.upload_staging import get_upload_staging
+
+        with patch.dict(os.environ, {"UPLOAD_STAGING_BACKEND": "filesystem"}):
+            os.environ.pop("UPLOAD_STAGING_DIR", None)
+            with pytest.raises(ValueError, match="UPLOAD_STAGING_DIR"):
+                get_upload_staging()
+
+    def test_unknown_backend_raises(self):
+        from mcp_atlassian.jira.upload_staging import get_upload_staging
+
+        with patch.dict(os.environ, {"UPLOAD_STAGING_BACKEND": "nope"}):
+            with pytest.raises(ValueError, match="Unknown UPLOAD_STAGING_BACKEND"):
+                get_upload_staging()
+
+    def test_dotted_path_backend(self):
+        from mcp_atlassian.jira.upload_staging import get_upload_staging
+
+        path = "mcp_atlassian.jira.upload_staging:FilesystemUploadStagingBackend"
+        # FilesystemUploadStagingBackend needs a root_dir positional arg, so a
+        # bare dotted path to it will fail construction; use a tiny stub instead.
+        with patch.dict(os.environ, {"UPLOAD_STAGING_BACKEND": path}):
+            with pytest.raises(TypeError):
+                get_upload_staging()
+
+    def test_invalid_dotted_path_raises(self):
+        from mcp_atlassian.jira.upload_staging import get_upload_staging
+
+        with patch.dict(
+            os.environ, {"UPLOAD_STAGING_BACKEND": "not.a.real.module:Nope"}
+        ):
+            with pytest.raises((ImportError, ValueError, AttributeError)):
+                get_upload_staging()
+
+
+class TestFilesystemDownloadTokenStore:
+    """Tests for the shared-filesystem download token store."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        return FilesystemDownloadTokenStore(root_dir=str(tmp_path / "downloads"))
+
+    def _expiry(self, minutes: int = 5):
+        from datetime import timedelta
+
+        from mcp_atlassian.jira.attachment_cache import _utcnow
+
+        return _utcnow() + timedelta(minutes=minutes)
+
+    def test_is_a_store(self, store):
+        assert isinstance(store, DownloadTokenStore)
+
+    def test_create_and_get_roundtrip(self, store):
+        token = store.create(
+            "PROJ-1", "report.pdf", "application/pdf", b"pdf-bytes", self._expiry()
+        )
+        entry = store.get(token)
+        assert entry is not None
+        assert entry["content"] == b"pdf-bytes"
+        assert entry["mime_type"] == "application/pdf"
+        assert entry["filename"] == "report.pdf"
+        assert entry["issue_key"] == "PROJ-1"
+
+    def test_unknown_token_returns_none(self, store):
+        assert store.get("does-not-exist") is None
+        assert store.get("../evil") is None
+
+    def test_expired_token_returns_none(self, store):
+        token = store.create(
+            "PROJ-1", "f.pdf", "application/pdf", b"x", self._expiry(minutes=-1)
+        )
+        assert store.get(token) is None
+
+    def test_clear_removes_tokens(self, store):
+        token = store.create("PROJ-1", "f.pdf", "application/pdf", b"x", self._expiry())
+        store.clear()
+        assert store.get(token) is None
+
+    def test_token_resolvable_across_instances(self, tmp_path):
+        """A token minted by one instance is served by another sharing the dir."""
+        root = str(tmp_path / "shared")
+        first = FilesystemDownloadTokenStore(root_dir=root)
+        token = first.create(
+            "PROJ-1", "f.pdf", "application/pdf", b"shared-bytes", self._expiry()
+        )
+
+        # Simulate a different pod pointed at the same shared volume.
+        second = FilesystemDownloadTokenStore(root_dir=root)
+        entry = second.get(token)
+        assert entry is not None
+        assert entry["content"] == b"shared-bytes"
+
+
+class TestAttachmentCacheWithFilesystemTokens:
+    """AttachmentCache download tokens work across instances via shared dir."""
+
+    def test_download_token_resolvable_by_second_cache(self, tmp_path):
+        root = str(tmp_path / "dl")
+        cache_a = AttachmentCache(
+            ttl_minutes=10,
+            max_size_mb=1,
+            token_store=FilesystemDownloadTokenStore(root_dir=root),
+        )
+        cache_a.store(
+            issue_key="PROJ-1",
+            filename="report.pdf",
+            content=b"pdf-bytes",
+            mime_type="application/pdf",
+        )
+        token_info = cache_a.create_download_token("PROJ-1", "report.pdf")
+
+        # A second cache instance (fresh, empty local cache) resolves the token.
+        cache_b = AttachmentCache(
+            ttl_minutes=10,
+            max_size_mb=1,
+            token_store=FilesystemDownloadTokenStore(root_dir=root),
+        )
+        attachment = cache_b.get_by_download_token(token_info["token"])
+        assert attachment is not None
+        assert attachment["content"] == b"pdf-bytes"
+        assert attachment["mime_type"] == "application/pdf"
+
+
+class TestSweepExpired:
+    """Proactive cleanup of expired download tokens and staged uploads."""
+
+    def test_filesystem_token_store_removes_unfetched_expired_token(self, tmp_path):
+        """A minted-but-never-fetched download token is reclaimed on sweep."""
+        root = tmp_path / "dl"
+        store = FilesystemDownloadTokenStore(root_dir=str(root))
+        token = store.create(
+            issue_key="PROJ-1",
+            filename="report.pdf",
+            mime_type="application/pdf",
+            content=b"pdf-bytes",
+            expires_at=_cache_utcnow() - timedelta(minutes=1),
+        )
+        # Nothing ever reads the token, so only a sweep can reclaim it.
+        assert (root / f"{token}.bin").exists()
+        assert (root / f"{token}.json").exists()
+
+        removed = store.sweep_expired()
+
+        assert removed == 1
+        assert not (root / f"{token}.bin").exists()
+        assert not (root / f"{token}.json").exists()
+
+    def test_filesystem_token_store_keeps_live_token(self, tmp_path):
+        store = FilesystemDownloadTokenStore(root_dir=str(tmp_path / "dl"))
+        token = store.create(
+            issue_key="PROJ-1",
+            filename="report.pdf",
+            mime_type="application/pdf",
+            content=b"pdf-bytes",
+            expires_at=_cache_utcnow() + timedelta(minutes=5),
+        )
+        assert store.sweep_expired() == 0
+        assert store.get(token) is not None
+
+    def test_filesystem_token_store_reaps_old_temp_files(self, tmp_path):
+        root = tmp_path / "dl"
+        store = FilesystemDownloadTokenStore(root_dir=str(root))
+        stale = root / "abc.json.deadbeef.tmp"
+        stale.write_bytes(b"partial")
+        old = (_cache_utcnow() - timedelta(hours=2)).timestamp()
+        os.utime(stale, (old, old))
+
+        store.sweep_expired()
+
+        assert not stale.exists()
+
+    def test_memory_token_store_sweep_expired(self):
+        store = MemoryDownloadTokenStore()
+        token = store.create(
+            issue_key="PROJ-1",
+            filename="f.txt",
+            mime_type="text/plain",
+            content=b"x",
+            expires_at=_cache_utcnow() - timedelta(minutes=1),
+        )
+        assert store.sweep_expired() == 1
+        assert store.get(token) is None
+
+    def test_memory_staging_sweep_expired(self):
+        store = UploadStagingStore(ttl_minutes=30, max_size_mb=1)
+        session_id = store.create_session()
+        store.store(session_id, "f.txt", b"data", "text/plain")
+        future = _cache_utcnow() + timedelta(hours=1)
+        with patch("mcp_atlassian.jira.upload_staging._utcnow", return_value=future):
+            removed = store.sweep_expired()
+        assert removed == 1
+
+    def test_attachment_cache_sweep_delegates_to_token_store(self, tmp_path):
+        store = FilesystemDownloadTokenStore(root_dir=str(tmp_path / "dl"))
+        cache = AttachmentCache(ttl_minutes=10, max_size_mb=1, token_store=store)
+        store.create(
+            issue_key="PROJ-1",
+            filename="f.txt",
+            mime_type="text/plain",
+            content=b"x",
+            expires_at=_cache_utcnow() - timedelta(minutes=1),
+        )
+        assert cache.sweep_expired() >= 1
+
+
+class TestBuildDownloadTokenStoreFactory:
+    """Tests for the environment-driven download token store factory."""
+
+    def test_defaults_to_memory(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ATTACHMENT_DOWNLOAD_BACKEND", None)
+            store = _build_download_token_store()
+        assert isinstance(store, MemoryDownloadTokenStore)
+
+    def test_filesystem_backend(self, tmp_path):
+        with patch.dict(
+            os.environ,
+            {
+                "ATTACHMENT_DOWNLOAD_BACKEND": "filesystem",
+                "ATTACHMENT_DOWNLOAD_DIR": str(tmp_path / "dl"),
+            },
+        ):
+            store = _build_download_token_store()
+        assert isinstance(store, FilesystemDownloadTokenStore)
+
+    def test_filesystem_requires_dir(self):
+        with patch.dict(os.environ, {"ATTACHMENT_DOWNLOAD_BACKEND": "filesystem"}):
+            os.environ.pop("ATTACHMENT_DOWNLOAD_DIR", None)
+            with pytest.raises(ValueError, match="ATTACHMENT_DOWNLOAD_DIR"):
+                _build_download_token_store()
+
+    def test_unknown_backend_raises(self):
+        with patch.dict(os.environ, {"ATTACHMENT_DOWNLOAD_BACKEND": "nope"}):
+            with pytest.raises(ValueError, match="Unknown ATTACHMENT_DOWNLOAD_BACKEND"):
+                _build_download_token_store()
+
+    def test_invalid_dotted_path_raises(self):
+        with patch.dict(
+            os.environ,
+            {"ATTACHMENT_DOWNLOAD_BACKEND": "not.a.real.module:Nope"},
+        ):
+            with pytest.raises((ImportError, ValueError, AttributeError)):
+                _build_download_token_store()

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -772,6 +772,95 @@ async def test_construct_download_endpoint_tool():
     )
 
 
+@pytest.mark.anyio
+async def test_construct_download_endpoint_fetches_on_cache_miss():
+    """On a cache miss the tool fetches the attachment on demand, then retries.
+
+    Regression test for the stateless download-URL flow: when the attachment was
+    cached on a different instance (or not yet fetched), the tool must populate
+    the cache via the Jira fetcher instead of failing with 'not cached'.
+    """
+    from mcp_atlassian.servers.jira import construct_download_endpoint
+
+    class IsoDate:
+        def isoformat(self) -> str:
+            return "2026-04-10T00:00:00+00:00"
+
+    cache = MagicMock()
+    # First call: cache miss -> ValueError; second call (after fetch): success.
+    cache.create_download_token.side_effect = [
+        ValueError("Attachment 'report.pdf' for issue 'PROJ-1' is not cached."),
+        {
+            "token": "download-token",
+            "expires_at": IsoDate(),
+            "issue_key": "PROJ-1",
+            "filename": "report.pdf",
+            "mime_type": "application/pdf",
+        },
+    ]
+
+    mock_fetcher = MagicMock()
+    mock_fetcher.fetch_and_cache_attachment.return_value = True
+
+    with (
+        patch("mcp_atlassian.servers.jira.get_attachment_cache", return_value=cache),
+        patch(
+            "mcp_atlassian.servers.jira.get_jira_fetcher",
+            AsyncMock(return_value=mock_fetcher),
+        ),
+        patch(
+            "mcp_atlassian.servers.jira._get_external_base_url",
+            return_value="http://localhost:8932",
+        ),
+    ):
+        response = await construct_download_endpoint.fn(
+            MagicMock(),
+            issue_key="PROJ-1",
+            filename="report.pdf",
+            ttl_minutes=5,
+        )
+
+    payload = json.loads(response)
+    assert payload["download_url"] == "http://localhost:8932/download/download-token"
+    mock_fetcher.fetch_and_cache_attachment.assert_called_once_with(
+        "PROJ-1", "report.pdf"
+    )
+    assert cache.create_download_token.call_count == 2
+
+
+@pytest.mark.anyio
+async def test_construct_download_endpoint_raises_when_attachment_missing():
+    """If on-demand fetch cannot find the attachment, the original error propagates."""
+    from mcp_atlassian.servers.jira import construct_download_endpoint
+
+    cache = MagicMock()
+    cache.create_download_token.side_effect = ValueError(
+        "Attachment 'missing.pdf' for issue 'PROJ-1' is not cached."
+    )
+
+    mock_fetcher = MagicMock()
+    mock_fetcher.fetch_and_cache_attachment.return_value = False
+
+    with (
+        patch("mcp_atlassian.servers.jira.get_attachment_cache", return_value=cache),
+        patch(
+            "mcp_atlassian.servers.jira.get_jira_fetcher",
+            AsyncMock(return_value=mock_fetcher),
+        ),
+    ):
+        with pytest.raises(ValueError, match="not cached"):
+            await construct_download_endpoint.fn(
+                MagicMock(),
+                issue_key="PROJ-1",
+                filename="missing.pdf",
+                ttl_minutes=5,
+            )
+
+    mock_fetcher.fetch_and_cache_attachment.assert_called_once_with(
+        "PROJ-1", "missing.pdf"
+    )
+
+
 def test_attachment_cache_clear_deregisters_static_resources(monkeypatch):
     """Test cached attachment cleanup removes static resource registrations."""
     from mcp_atlassian.servers import jira as jira_server

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -1,6 +1,7 @@
 """Tests for the main MCP server implementation."""
 
 import json
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -10,6 +11,8 @@ from starlette.responses import JSONResponse
 
 from mcp_atlassian.servers.main import (
     UserTokenMiddleware,
+    _cleanup_interval_seconds,
+    _sweep_staging_once,
     download_endpoint,
     main_mcp,
     upload_endpoint,
@@ -239,6 +242,62 @@ async def test_download_endpoint_serves_cached_attachment():
     assert response.body == b"pdf-bytes"
     assert response.headers["content-type"] == "application/pdf"
     assert "filename*=UTF-8''report%201.pdf" in response.headers["content-disposition"]
+
+
+class TestStagingCleanup:
+    """Tests for the in-process staging/token cleanup sweeper."""
+
+    def test_cleanup_interval_default(self):
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("STAGING_CLEANUP_INTERVAL_MINUTES", None)
+            assert _cleanup_interval_seconds() == 15 * 60
+
+    def test_cleanup_interval_custom(self):
+        with patch.dict("os.environ", {"STAGING_CLEANUP_INTERVAL_MINUTES": "5"}):
+            assert _cleanup_interval_seconds() == 5 * 60
+
+    def test_cleanup_interval_zero_disables(self):
+        with patch.dict("os.environ", {"STAGING_CLEANUP_INTERVAL_MINUTES": "0"}):
+            assert _cleanup_interval_seconds() == 0
+
+    def test_cleanup_interval_invalid_falls_back(self):
+        with patch.dict("os.environ", {"STAGING_CLEANUP_INTERVAL_MINUTES": "nope"}):
+            assert _cleanup_interval_seconds() == 15 * 60
+
+    @pytest.mark.anyio
+    async def test_sweep_once_invokes_both_stores(self):
+        cache = MagicMock()
+        cache.sweep_expired.return_value = 2
+        staging = MagicMock()
+        staging.sweep_expired.return_value = 1
+        with (
+            patch(
+                "mcp_atlassian.servers.main.get_attachment_cache", return_value=cache
+            ),
+            patch(
+                "mcp_atlassian.servers.main.get_upload_staging", return_value=staging
+            ),
+        ):
+            await _sweep_staging_once()
+        cache.sweep_expired.assert_called_once()
+        staging.sweep_expired.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_sweep_once_swallows_errors(self):
+        cache = MagicMock()
+        cache.sweep_expired.side_effect = RuntimeError("boom")
+        with (
+            patch(
+                "mcp_atlassian.servers.main.get_attachment_cache", return_value=cache
+            ),
+            patch(
+                "mcp_atlassian.servers.main.get_upload_staging",
+                return_value=MagicMock(),
+            ),
+        ):
+            # Must not raise despite the sweep failing.
+            await _sweep_staging_once()
+        cache.sweep_expired.assert_called_once()
 
 
 class TestUserTokenMiddleware:

--- a/tests/unit/test_main_transport_selection.py
+++ b/tests/unit/test_main_transport_selection.py
@@ -113,7 +113,59 @@ class TestMainTransportSelection:
                             # Verify error was handled - sys.exit called with 1 for error
                             # and then with 0 in the finally block
                             assert mock_exit.call_count == 2
-                            assert mock_exit.call_args_list[0][0][0] == 1  # Error exit
+                            # Error exit
+                            assert mock_exit.call_args_list[0][0][0] == 1
                             assert (
                                 mock_exit.call_args_list[1][0][0] == 0
                             )  # Finally exit
+
+
+class TestStatelessHttpSelection:
+    """Test resolution of the stateless_http option into run_async kwargs."""
+
+    def _run_main_and_capture_kwargs(self, argv, env):
+        """Invoke main() and return the kwargs passed to run_async."""
+        with patch(
+            "mcp_atlassian.servers.main_mcp.run_async", new_callable=MagicMock
+        ) as mock_run_async:
+            with patch("asyncio.run"):
+                with patch.dict("os.environ", env, clear=False):
+                    with patch("sys.argv", argv):
+                        try:
+                            main()
+                        except SystemExit:
+                            pass
+        assert mock_run_async.called
+        return mock_run_async.call_args.kwargs
+
+    def test_stateless_http_defaults_to_false(self):
+        kwargs = self._run_main_and_capture_kwargs(
+            ["mcp-atlassian"], {"TRANSPORT": "streamable-http"}
+        )
+        assert kwargs["stateless_http"] is False
+
+    def test_stateless_http_enabled_via_cli_flag(self):
+        kwargs = self._run_main_and_capture_kwargs(
+            ["mcp-atlassian", "--stateless-http"], {"TRANSPORT": "streamable-http"}
+        )
+        assert kwargs["stateless_http"] is True
+
+    def test_stateless_http_enabled_via_env(self):
+        kwargs = self._run_main_and_capture_kwargs(
+            ["mcp-atlassian"],
+            {"TRANSPORT": "streamable-http", "STATELESS_HTTP": "true"},
+        )
+        assert kwargs["stateless_http"] is True
+
+    def test_cli_flag_overrides_env(self):
+        kwargs = self._run_main_and_capture_kwargs(
+            ["mcp-atlassian", "--stateless-http"],
+            {"TRANSPORT": "streamable-http", "STATELESS_HTTP": "false"},
+        )
+        assert kwargs["stateless_http"] is True
+
+    def test_stateless_http_not_passed_for_stdio(self):
+        kwargs = self._run_main_and_capture_kwargs(
+            ["mcp-atlassian"], {"TRANSPORT": "stdio", "STATELESS_HTTP": "true"}
+        )
+        assert "stateless_http" not in kwargs


### PR DESCRIPTION
## Description

Adds first-class **stateless HTTP** support so the `streamable-http` transport can run
behind a round-robin load balancer with multiple replicas — no sticky sessions required.
Previously per-session transport state (and the in-memory upload-staging / attachment-download
token stores) forced single-instance or session-affinity deployments. This PR exposes the
stateless switch and externalizes the remaining per-instance state behind pluggable backends,
enabling horizontal scaling and autoscaling.

Fixes: #

## Changes

- **Stateless transport switch**: new `--stateless-http` CLI flag and `STATELESS_HTTP` env var
  in `src/mcp_atlassian/__init__.py`, plumbed through `run_kwargs` → `run_async` →
  `AtlassianMCP.http_app(stateless_http=...)`. CLI flag takes precedence over the env var;
  ignored for `stdio`.
- **Pluggable upload-staging backends** (`jira/upload_staging.py`): `UploadStagingBackend` ABC
  with `memory` (default) and `filesystem` (shared dir) implementations + factory selected via
  `UPLOAD_STAGING_BACKEND` / `UPLOAD_STAGING_DIR`, so staged uploads survive across instances.
- **Pluggable download-token store** (`jira/attachment_cache.py`): `DownloadTokenStore` ABC with
  `memory` (default) and `filesystem` implementations + factory selected via
  `ATTACHMENT_DOWNLOAD_BACKEND` / `ATTACHMENT_DOWNLOAD_DIR`.
- **Helm chart**: `deployment.yaml` injects `STATELESS_HTTP=true` plus the filesystem
  upload/download backends and mounts a shared RWX PVC when `sharedStorage.enabled` and
  `sharedStorage.existingClaim` are set; adds `listenerset.yaml` and updates `httproute.yaml`;
  documents the new values in `values.yaml`.
- **Docs**: README gains a "Stateless HTTP (Horizontal Scaling)" section covering the
  `--stateless-http` flag and `STATELESS_HTTP=true` env var with examples.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `deployed multi-replica behind an NGINX/round-robin LB; verified` \
  `initialize + tools/list return HTTP 200 with NO mcp-session-id header, and cold requests are` \
  `served evenly across pods with no session affinity (stateless confirmed)`

- Added `TestStatelessHttpSelection` in `tests/unit/test_main_transport_selection.py` covering
  default-off, enable via CLI flag, enable via env, CLI-over-env precedence, and stdio-ignored.
- Extended `tests/unit/jira/test_attachments.py` for the memory/filesystem backends and factory
  selection.
- Full suite: **1596 passed, 216 skipped**; `pre-commit` (ruff-format, ruff, mypy) clean.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).