### PR TITLE
fix: support classic Cloud API tokens in header-based multi-tenant auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,16 +125,19 @@ With header-based authentication, you can pass Jira, Confluence, and Bitbucket c
 **Required Headers:**
 
 For **Jira authentication**:
-- `X-Atlassian-Jira-Personal-Token`: Your Jira PAT or API token
+- `X-Atlassian-Jira-Personal-Token`: Your Jira PAT, or a classic Cloud API token
 - `X-Atlassian-Jira-Url`: Your Jira instance URL
+- `X-Atlassian-Jira-Username` (optional): Your Atlassian account email — set this **only** when `X-Atlassian-Jira-Personal-Token` is a classic Cloud API token (created at `id.atlassian.com/manage-profile/security/api-tokens`), which Atlassian Cloud only accepts via Basic auth. Omit it for Server/Data Center PATs or OAuth access tokens, which keep using Bearer/Token auth as before.
 
 For **Confluence authentication**:
-- `X-Atlassian-Confluence-Personal-Token`: Your Confluence PAT or API token
+- `X-Atlassian-Confluence-Personal-Token`: Your Confluence PAT, or a classic Cloud API token
 - `X-Atlassian-Confluence-Url`: Your Confluence instance URL
+- `X-Atlassian-Confluence-Username` (optional): Same rule as `X-Atlassian-Jira-Username`, for a classic Cloud API token.
 
 For **Bitbucket authentication**:
-- `X-Atlassian-Bitbucket-Personal-Token`: Your Bitbucket PAT or app password
+- `X-Atlassian-Bitbucket-Personal-Token`: Your Bitbucket PAT, app password, or a classic Cloud API token
 - `X-Atlassian-Bitbucket-Url`: Your Bitbucket instance URL
+- `X-Atlassian-Bitbucket-Username` (optional): Same rule as `X-Atlassian-Jira-Username`, for a classic Cloud API token.
 
 For **Xray for Jira authentication**:
 - Reuses your Jira headers (`X-Atlassian-Jira-Personal-Token` and `X-Atlassian-Jira-Url`), which must point to a Server/Data Center Jira with Xray installed.
@@ -219,10 +222,13 @@ There are three main approaches to configure the Docker container:
 > **Header-Based Authentication** (no environment variables needed):
 > - `X-Atlassian-Jira-Personal-Token`: Jira PAT/API token (passed as HTTP header), used for XRay as well
 > - `X-Atlassian-Jira-Url`: Jira instance URL (passed as HTTP header), used for XRay as well
+> - `X-Atlassian-Jira-Username`: Optional; set alongside a classic Cloud API token to force Basic auth (see [Header-Based Authentication](#d-dynamic-header-based-authentication---multi-tenant))
 > - `X-Atlassian-Confluence-Personal-Token`: Confluence PAT/API token (passed as HTTP header)
 > - `X-Atlassian-Confluence-Url`: Confluence instance URL (passed as HTTP header)
+> - `X-Atlassian-Confluence-Username`: Optional; same purpose as `X-Atlassian-Jira-Username`
 > - `X-Atlassian-Bitbucket-Url`: Bitbucket URL (passed as HTTP header)
 > - `X-Atlassian-Bitbucket-Personal-Token`: Bitbucket PAT token (passed as HTTP header)
+> - `X-Atlassian-Bitbucket-Username`: Optional; same purpose as `X-Atlassian-Jira-Username`
 > - `X-Atlassian-Read-Only-Mode`: Global per-request read-only mode — applies to all products (passed as HTTP header)
 > - `X-Atlassian-Jira-Read-Only-Mode`: Per-request read-only mode for Jira only (passed as HTTP header)
 > - `X-Atlassian-Confluence-Read-Only-Mode`: Per-request read-only mode for Confluence only (passed as HTTP header)

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -219,6 +219,7 @@ async def get_jira_fetcher(ctx: Context) -> JiraFetcher:
         service_headers = getattr(request.state, "atlassian_service_headers", {})
         jira_url_header = service_headers.get("X-Atlassian-Jira-Url")
         jira_token_header = service_headers.get("X-Atlassian-Jira-Personal-Token")
+        jira_username_header = service_headers.get("X-Atlassian-Jira-Username")
 
         if (
             user_auth_type == "pat"
@@ -226,21 +227,46 @@ async def get_jira_fetcher(ctx: Context) -> JiraFetcher:
             and jira_token_header
             and not hasattr(request.state, "user_atlassian_token")
         ):
-            logger.info(
-                f"Creating header-based JiraFetcher with URL: {jira_url_header} and PAT token"
-            )
-            header_config = JiraConfig(
-                url=jira_url_header,
-                auth_type="pat",
-                personal_token=jira_token_header,
-                ssl_verify=True,
-                projects_filter=None,
-                http_proxy=None,
-                https_proxy=None,
-                no_proxy=None,
-                socks_proxy=None,
-                custom_headers=None,
-            )
+            # A username header accompanying the token indicates a classic
+            # Atlassian Cloud API token, which the API only accepts via Basic
+            # auth (base64 username:token) -- never as a Bearer/Token header.
+            # Without the username header, fall back to the previous
+            # Bearer/Token-based behavior (OAuth access tokens, Server/DC PATs).
+            if jira_username_header:
+                logger.info(
+                    f"Creating header-based JiraFetcher with URL: {jira_url_header} "
+                    "and Basic auth (username + Cloud API token)"
+                )
+                header_config = JiraConfig(
+                    url=jira_url_header,
+                    auth_type="basic",
+                    username=jira_username_header,
+                    api_token=jira_token_header,
+                    ssl_verify=True,
+                    projects_filter=None,
+                    http_proxy=None,
+                    https_proxy=None,
+                    no_proxy=None,
+                    socks_proxy=None,
+                    custom_headers=None,
+                )
+            else:
+                logger.info(
+                    f"Creating header-based JiraFetcher with URL: {jira_url_header} "
+                    "and PAT token"
+                )
+                header_config = JiraConfig(
+                    url=jira_url_header,
+                    auth_type="pat",
+                    personal_token=jira_token_header,
+                    ssl_verify=True,
+                    projects_filter=None,
+                    http_proxy=None,
+                    https_proxy=None,
+                    no_proxy=None,
+                    socks_proxy=None,
+                    custom_headers=None,
+                )
             try:
                 header_jira_fetcher = JiraFetcher(config=header_config)
                 current_user_id = header_jira_fetcher.get_current_user_account_id()
@@ -371,6 +397,9 @@ async def get_confluence_fetcher(ctx: Context) -> ConfluenceFetcher:
         confluence_token_header = service_headers.get(
             "X-Atlassian-Confluence-Personal-Token"
         )
+        confluence_username_header = service_headers.get(
+            "X-Atlassian-Confluence-Username"
+        )
 
         if (
             user_auth_type == "pat"
@@ -378,21 +407,45 @@ async def get_confluence_fetcher(ctx: Context) -> ConfluenceFetcher:
             and confluence_token_header
             and not hasattr(request.state, "user_atlassian_token")
         ):
-            logger.info(
-                f"Creating header-based ConfluenceFetcher with URL: {confluence_url_header} and PAT token"
-            )
-            header_config = ConfluenceConfig(
-                url=confluence_url_header,
-                auth_type="pat",
-                personal_token=confluence_token_header,
-                ssl_verify=True,
-                spaces_filter=None,
-                http_proxy=None,
-                https_proxy=None,
-                no_proxy=None,
-                socks_proxy=None,
-                custom_headers=None,
-            )
+            # A username header accompanying the token indicates a classic
+            # Atlassian Cloud API token, which requires Basic auth (see
+            # get_jira_fetcher above for the same pattern).
+            if confluence_username_header:
+                logger.info(
+                    "Creating header-based ConfluenceFetcher with URL: "
+                    f"{confluence_url_header} and Basic auth "
+                    "(username + Cloud API token)"
+                )
+                header_config = ConfluenceConfig(
+                    url=confluence_url_header,
+                    auth_type="basic",
+                    username=confluence_username_header,
+                    api_token=confluence_token_header,
+                    ssl_verify=True,
+                    spaces_filter=None,
+                    http_proxy=None,
+                    https_proxy=None,
+                    no_proxy=None,
+                    socks_proxy=None,
+                    custom_headers=None,
+                )
+            else:
+                logger.info(
+                    "Creating header-based ConfluenceFetcher with URL: "
+                    f"{confluence_url_header} and PAT token"
+                )
+                header_config = ConfluenceConfig(
+                    url=confluence_url_header,
+                    auth_type="pat",
+                    personal_token=confluence_token_header,
+                    ssl_verify=True,
+                    spaces_filter=None,
+                    http_proxy=None,
+                    https_proxy=None,
+                    no_proxy=None,
+                    socks_proxy=None,
+                    custom_headers=None,
+                )
             try:
                 header_confluence_fetcher = ConfluenceFetcher(config=header_config)
                 current_user_data = header_confluence_fetcher.get_current_user_info()
@@ -556,6 +609,9 @@ async def get_bitbucket_fetcher(ctx: Context) -> BitbucketFetcher:
         bitbucket_token_header = service_headers.get(
             "X-Atlassian-Bitbucket-Personal-Token"
         )
+        bitbucket_username_header = service_headers.get(
+            "X-Atlassian-Bitbucket-Username"
+        )
 
         if (
             user_auth_type == "pat"
@@ -563,21 +619,45 @@ async def get_bitbucket_fetcher(ctx: Context) -> BitbucketFetcher:
             and bitbucket_token_header
             and not hasattr(request.state, "user_atlassian_token")
         ):
-            logger.info(
-                f"Creating header-based BitbucketFetcher with URL: {bitbucket_url_header} and PAT token"
-            )
-            header_config = BitbucketConfig(
-                url=bitbucket_url_header,
-                auth_type="pat",
-                username=None,
-                personal_token=bitbucket_token_header,
-                ssl_verify=True,
-                http_proxy=None,
-                https_proxy=None,
-                no_proxy=None,
-                socks_proxy=None,
-                custom_headers=None,
-            )
+            # A username header accompanying the token indicates a classic
+            # Atlassian Cloud API token, which requires Basic auth (see
+            # get_jira_fetcher above for the same pattern).
+            if bitbucket_username_header:
+                logger.info(
+                    "Creating header-based BitbucketFetcher with URL: "
+                    f"{bitbucket_url_header} and Basic auth "
+                    "(username + Cloud API token)"
+                )
+                header_config = BitbucketConfig(
+                    url=bitbucket_url_header,
+                    auth_type="basic",
+                    username=bitbucket_username_header,
+                    app_password=bitbucket_token_header,
+                    personal_token=None,
+                    ssl_verify=True,
+                    http_proxy=None,
+                    https_proxy=None,
+                    no_proxy=None,
+                    socks_proxy=None,
+                    custom_headers=None,
+                )
+            else:
+                logger.info(
+                    "Creating header-based BitbucketFetcher with URL: "
+                    f"{bitbucket_url_header} and PAT token"
+                )
+                header_config = BitbucketConfig(
+                    url=bitbucket_url_header,
+                    auth_type="pat",
+                    username=None,
+                    personal_token=bitbucket_token_header,
+                    ssl_verify=True,
+                    http_proxy=None,
+                    https_proxy=None,
+                    no_proxy=None,
+                    socks_proxy=None,
+                    custom_headers=None,
+                )
             try:
                 header_bitbucket_fetcher = BitbucketFetcher(config=header_config)
                 current_user_data = header_bitbucket_fetcher.get_current_user_info()

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -1009,6 +1009,14 @@ class UserTokenMiddleware:
                 jira_url_header.decode("latin-1") if jira_url_header else None
             )
 
+            # Optional username accompanying a classic Cloud API token (which must
+            # be sent as Basic auth, not Bearer/Token) for the header-based
+            # multi-tenant auth path. See get_*_fetcher in servers/dependencies.py.
+            jira_username_header = headers.get(b"x-atlassian-jira-username")
+            jira_username_header_str = (
+                jira_username_header.decode("latin-1") if jira_username_header else None
+            )
+
             confluence_token_header = headers.get(
                 b"x-atlassian-confluence-personal-token"
             )
@@ -1025,6 +1033,15 @@ class UserTokenMiddleware:
                 else None
             )
 
+            confluence_username_header = headers.get(
+                b"x-atlassian-confluence-username"
+            )
+            confluence_username_header_str = (
+                confluence_username_header.decode("latin-1")
+                if confluence_username_header
+                else None
+            )
+
             bitbucket_token_header = headers.get(
                 b"x-atlassian-bitbucket-personal-token"
             )
@@ -1037,6 +1054,15 @@ class UserTokenMiddleware:
             bitbucket_url_header = headers.get(b"x-atlassian-bitbucket-url")
             bitbucket_url_header_str = (
                 bitbucket_url_header.decode("latin-1") if bitbucket_url_header else None
+            )
+
+            bitbucket_username_header = headers.get(
+                b"x-atlassian-bitbucket-username"
+            )
+            bitbucket_username_header_str = (
+                bitbucket_username_header.decode("latin-1")
+                if bitbucket_username_header
+                else None
             )
             effective_xray_token = None
             effective_xray_url = None
@@ -1180,6 +1206,10 @@ class UserTokenMiddleware:
                 )
             if jira_url_header_str:
                 service_headers["X-Atlassian-Jira-Url"] = jira_url_header_str
+            if jira_username_header_str:
+                service_headers["X-Atlassian-Jira-Username"] = (
+                    jira_username_header_str
+                )
             if confluence_token_header_str:
                 service_headers["X-Atlassian-Confluence-Personal-Token"] = (
                     confluence_token_header_str
@@ -1188,12 +1218,20 @@ class UserTokenMiddleware:
                 service_headers["X-Atlassian-Confluence-Url"] = (
                     confluence_url_header_str
                 )
+            if confluence_username_header_str:
+                service_headers["X-Atlassian-Confluence-Username"] = (
+                    confluence_username_header_str
+                )
             if bitbucket_token_header_str:
                 service_headers["X-Atlassian-Bitbucket-Personal-Token"] = (
                     bitbucket_token_header_str
                 )
             if bitbucket_url_header_str:
                 service_headers["X-Atlassian-Bitbucket-Url"] = bitbucket_url_header_str
+            if bitbucket_username_header_str:
+                service_headers["X-Atlassian-Bitbucket-Username"] = (
+                    bitbucket_username_header_str
+                )
             if enable_xray_header_value is not None:
                 service_headers["X-Atlassian-Enable-Xray"] = enable_xray_header_value
 

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -487,6 +487,86 @@ class TestGetJiraFetcher:
         assert result == cached_fetcher
         mock_jira_fetcher_class.assert_not_called()
 
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
+    async def test_header_based_fetcher_with_username_uses_basic_auth(
+        self,
+        mock_jira_fetcher_class,
+        mock_get_http_request,
+        mock_context,
+        mock_request,
+        config_factory,
+    ):
+        """A classic Cloud API token (sent with a username header) must be
+        authenticated via Basic auth, not Bearer/Token."""
+        mock_request.state.user_atlassian_auth_type = "pat"
+        mock_request.state.user_atlassian_email = None
+        mock_request.state.jira_fetcher = None
+        if hasattr(mock_request.state, "user_atlassian_token"):
+            delattr(mock_request.state, "user_atlassian_token")
+
+        mock_request.state.atlassian_service_headers = {
+            "X-Atlassian-Jira-Url": "https://jira.example.com",
+            "X-Atlassian-Jira-Personal-Token": "ATATclassic-cloud-api-token",
+            "X-Atlassian-Jira-Username": "user@example.com",
+        }
+        mock_get_http_request.return_value = mock_request
+
+        app_context = config_factory.create_app_context()
+        _setup_mock_context(mock_context, app_context)
+
+        mock_fetcher = _create_mock_fetcher(JiraFetcher)
+        mock_jira_fetcher_class.return_value = mock_fetcher
+
+        result = await get_jira_fetcher(mock_context)
+
+        assert result == mock_fetcher
+        mock_jira_fetcher_class.assert_called_once()
+
+        called_config = mock_jira_fetcher_class.call_args[1]["config"]
+        assert called_config.auth_type == "basic"
+        assert called_config.username == "user@example.com"
+        assert called_config.api_token == "ATATclassic-cloud-api-token"
+        assert called_config.personal_token is None
+
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
+    async def test_header_based_fetcher_without_username_uses_pat(
+        self,
+        mock_jira_fetcher_class,
+        mock_get_http_request,
+        mock_context,
+        mock_request,
+        config_factory,
+    ):
+        """Regression: header-based auth without a username header keeps the
+        pre-existing PAT/Bearer behavior (OAuth access tokens, Server/DC PATs)."""
+        mock_request.state.user_atlassian_auth_type = "pat"
+        mock_request.state.user_atlassian_email = None
+        mock_request.state.jira_fetcher = None
+        if hasattr(mock_request.state, "user_atlassian_token"):
+            delattr(mock_request.state, "user_atlassian_token")
+
+        mock_request.state.atlassian_service_headers = {
+            "X-Atlassian-Jira-Url": "https://jira.example.com",
+            "X-Atlassian-Jira-Personal-Token": "header-jira-token",
+        }
+        mock_get_http_request.return_value = mock_request
+
+        app_context = config_factory.create_app_context()
+        _setup_mock_context(mock_context, app_context)
+
+        mock_fetcher = _create_mock_fetcher(JiraFetcher)
+        mock_jira_fetcher_class.return_value = mock_fetcher
+
+        result = await get_jira_fetcher(mock_context)
+
+        assert result == mock_fetcher
+        called_config = mock_jira_fetcher_class.call_args[1]["config"]
+        assert called_config.auth_type == "pat"
+        assert called_config.personal_token == "header-jira-token"
+        assert called_config.username is None
+
     @pytest.mark.parametrize("scenario_key", ["pat"])
     @patch("mcp_atlassian.servers.dependencies.get_http_request")
     @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
@@ -657,6 +737,86 @@ class TestGetConfluenceFetcher:
 
         assert result == cached_fetcher
         mock_confluence_fetcher_class.assert_not_called()
+
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
+    async def test_header_based_fetcher_with_username_uses_basic_auth(
+        self,
+        mock_confluence_fetcher_class,
+        mock_get_http_request,
+        mock_context,
+        mock_request,
+        config_factory,
+    ):
+        """A classic Cloud API token (sent with a username header) must be
+        authenticated via Basic auth, not Bearer/Token."""
+        mock_request.state.user_atlassian_auth_type = "pat"
+        mock_request.state.user_atlassian_email = None
+        mock_request.state.confluence_fetcher = None
+        if hasattr(mock_request.state, "user_atlassian_token"):
+            delattr(mock_request.state, "user_atlassian_token")
+
+        mock_request.state.atlassian_service_headers = {
+            "X-Atlassian-Confluence-Url": "https://confluence.example.com",
+            "X-Atlassian-Confluence-Personal-Token": "ATATclassic-cloud-api-token",
+            "X-Atlassian-Confluence-Username": "user@example.com",
+        }
+        mock_get_http_request.return_value = mock_request
+
+        app_context = config_factory.create_app_context()
+        _setup_mock_context(mock_context, app_context)
+
+        mock_fetcher = _create_mock_fetcher(ConfluenceFetcher)
+        mock_confluence_fetcher_class.return_value = mock_fetcher
+
+        result = await get_confluence_fetcher(mock_context)
+
+        assert result == mock_fetcher
+        mock_confluence_fetcher_class.assert_called_once()
+
+        called_config = mock_confluence_fetcher_class.call_args[1]["config"]
+        assert called_config.auth_type == "basic"
+        assert called_config.username == "user@example.com"
+        assert called_config.api_token == "ATATclassic-cloud-api-token"
+        assert called_config.personal_token is None
+
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
+    async def test_header_based_fetcher_without_username_uses_pat(
+        self,
+        mock_confluence_fetcher_class,
+        mock_get_http_request,
+        mock_context,
+        mock_request,
+        config_factory,
+    ):
+        """Regression: header-based auth without a username header keeps the
+        pre-existing PAT/Bearer behavior (OAuth access tokens, Server/DC PATs)."""
+        mock_request.state.user_atlassian_auth_type = "pat"
+        mock_request.state.user_atlassian_email = None
+        mock_request.state.confluence_fetcher = None
+        if hasattr(mock_request.state, "user_atlassian_token"):
+            delattr(mock_request.state, "user_atlassian_token")
+
+        mock_request.state.atlassian_service_headers = {
+            "X-Atlassian-Confluence-Url": "https://confluence.example.com",
+            "X-Atlassian-Confluence-Personal-Token": "header-confluence-token",
+        }
+        mock_get_http_request.return_value = mock_request
+
+        app_context = config_factory.create_app_context()
+        _setup_mock_context(mock_context, app_context)
+
+        mock_fetcher = _create_mock_fetcher(ConfluenceFetcher)
+        mock_confluence_fetcher_class.return_value = mock_fetcher
+
+        result = await get_confluence_fetcher(mock_context)
+
+        assert result == mock_fetcher
+        called_config = mock_confluence_fetcher_class.call_args[1]["config"]
+        assert called_config.auth_type == "pat"
+        assert called_config.personal_token == "header-confluence-token"
+        assert called_config.username is None
 
     @pytest.mark.parametrize("scenario_key", ["pat"])
     @patch("mcp_atlassian.servers.dependencies.get_http_request")


### PR DESCRIPTION
Fixes #78

## Summary
- Classic Atlassian Cloud API tokens (`ATAT...`, created at id.atlassian.com) must be sent as `Authorization: Basic base64(email:token)`. The header-based multi-tenant auth path always used `auth_type="pat"`, which the underlying client turns into `Authorization: Bearer <token>` — Atlassian Cloud rejects that with `403 Failed to parse Connect Session Auth Token`.
- Adds three new **optional** headers: `X-Atlassian-Jira-Username`, `X-Atlassian-Confluence-Username`, `X-Atlassian-Bitbucket-Username`. When one is set alongside the existing `*-Personal-Token` header, the corresponding fetcher now builds a Basic-auth config (`username` + `api_token`) instead of PAT/Bearer.
- Without the new header, behavior is unchanged — existing OAuth access tokens and Server/Data Center PATs keep using Bearer/Token auth exactly as before.
- Applied to Jira, Confluence, and Bitbucket, since all three share the same `pat`→Bearer client code path.

## Test plan
- [x] New unit tests in `tests/unit/servers/test_dependencies.py`: username header present → `auth_type="basic"` with token as `api_token`; username header absent → unchanged `auth_type="pat"` (regression guard).
- [x] `uv run pytest tests/unit/servers/ tests/unit/utils/test_environment.py` — 451 passed.
- [x] README updated to document the new optional headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)