### PR TITLE
Added clone_issue tool with create-screen field pre-verification

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -17,11 +17,27 @@ from .protocols import (
     EpicOperationsProto,
     FieldsOperationsProto,
     IssueOperationsProto,
+    LinksOperationsProto,
     ProjectsOperationsProto,
     UsersOperationsProto,
 )
 
 logger = logging.getLogger("mcp-jira")
+
+# Standard (non-custom) fields that are safe to copy verbatim from a source
+# issue's raw API response when cloning, since Jira accepts the same object
+# shape on issue creation as it returns on retrieval for these fields.
+_CLONABLE_STANDARD_FIELDS: tuple[str, ...] = (
+    "priority",
+    "labels",
+    "components",
+    "fixVersions",
+    "versions",
+    "assignee",
+    "duedate",
+    "security",
+    "environment",
+)
 
 
 class IssuesMixin(
@@ -30,6 +46,7 @@ class IssuesMixin(
     EpicOperationsProto,
     FieldsOperationsProto,
     IssueOperationsProto,
+    LinksOperationsProto,
     ProjectsOperationsProto,
     UsersOperationsProto,
 ):
@@ -651,6 +668,299 @@ class IssuesMixin(
         except Exception as e:
             self._handle_create_issue_error(e, issue_type)
             raise  # Re-raise after logging
+
+    def _get_create_screen_field_ids(
+        self, project_key: str, issue_type_name: str
+    ) -> set[str] | None:
+        """
+        Get the field IDs available on the create screen for a project and
+        issue type, used to pre-verify fields before cloning.
+
+        Args:
+            project_key: The target project key
+            issue_type_name: The issue type name to resolve to an ID
+
+        Returns:
+            Set of field IDs available for creation, or None if the create
+            screen metadata could not be determined (callers should then skip
+            filtering rather than fail the clone).
+        """
+        try:
+            issue_type_id = None
+            for issue_type in self.get_project_issue_types(project_key):
+                if issue_type.get("name", "").lower() == issue_type_name.lower():
+                    issue_type_id = issue_type.get("id")
+                    break
+            if not issue_type_id:
+                logger.warning(
+                    f"Issue type '{issue_type_name}' not found in project "
+                    f"'{project_key}'; skipping create-screen field verification"
+                )
+                return None
+
+            meta = self.jira.issue_createmeta_fieldtypes(
+                project=project_key, issue_type_id=issue_type_id
+            )
+            if (
+                not isinstance(meta, dict)
+                or not isinstance(meta.get("fields"), list)
+                and not isinstance(meta.get("values"), list)
+            ):
+                logger.warning(
+                    f"Unexpected createmeta response for project '{project_key}' "
+                    f"issue type '{issue_type_name}'; skipping field verification"
+                )
+                return None
+
+            return {
+                field_meta["fieldId"]
+                for field_meta in meta.get("fields") or meta.get("values", [])
+                if isinstance(field_meta, dict) and field_meta.get("fieldId")
+            }
+        except Exception as e:  # noqa: BLE001 - field verification is best-effort
+            logger.warning(
+                f"Could not retrieve create screen fields for project "
+                f"'{project_key}' issue type '{issue_type_name}': {e!s}"
+            )
+            return None
+
+    def clone_issue(
+        self,
+        issue_key: str,
+        project_key: str | None = None,
+        summary: str | None = None,
+        *,
+        include_custom_fields: bool = True,
+        link_to_original: bool = True,
+        additional_fields: dict[str, Any] | None = None,
+    ) -> JiraIssue:
+        """
+        Clone an existing Jira issue by copying its fields into a newly created issue.
+
+        Jira Server, Data Center, and Cloud do not expose a single "clone issue"
+        REST endpoint. The built-in Clone action in the Jira UI is implemented
+        client-side as a sequence of calls: fetch the source issue, create a new
+        issue with the copied field values, and link the two issues together with
+        a "Cloners" issue link. This method reproduces that behavior.
+
+        Standard fields copied from the source issue: summary (prefixed with
+        "CLONE - " unless overridden), description, issue type, priority, labels,
+        components, fix versions, affects versions, assignee, due date, security
+        level, and environment. All populated custom fields (``customfield_*``)
+        are also copied unless ``include_custom_fields`` is False. If the source
+        issue is a subtask, its parent is preserved when cloning into the same
+        project.
+
+        Before copying, each standard and custom field is pre-verified against
+        the target project/issue type's create screen metadata. Fields that are
+        not available on the create screen are skipped instead of failing the
+        whole clone; their IDs are returned under the
+        ``clone_excluded_fields`` key of the resulting issue's ``custom_fields``.
+        If the create screen metadata cannot be determined, pre-verification is
+        skipped and all populated fields are copied as before.
+
+        Args:
+            issue_key: The key of the issue to clone (e.g., 'PROJ-123')
+            project_key: Target project key. Defaults to the source issue's project.
+            summary: Summary for the clone. Defaults to "CLONE - <source summary>".
+            include_custom_fields: Whether to copy populated custom fields.
+            link_to_original: Whether to create a "Cloners" issue link back to the
+                source issue after the clone is created.
+            additional_fields: Optional dictionary of fields to override or add on
+                top of the fields copied from the source issue. These are applied
+                verbatim and are not subject to create-screen field verification.
+
+        Returns:
+            JiraIssue model representing the newly created clone. If any fields
+            were excluded because they are not on the target create screen,
+            their IDs are listed under
+            ``custom_fields["clone_excluded_fields"]``.
+
+        Raises:
+            ValueError: If the issue key is missing, the source issue has no
+                fields, a target project cannot be determined, or a subtask has
+                no parent to preserve
+            MCPAtlassianAuthenticationError: If authentication fails with the
+                Jira API (401/403)
+            Exception: If there is an error cloning the issue
+        """
+        if not issue_key:
+            raise ValueError("Issue key is required")
+
+        try:
+            # Obtain the projects filter from the config, same restriction
+            # applied by get_issue. This should NOT be overridden by the request.
+            filter_to_use = self.config.projects_filter
+            if filter_to_use:
+                projects = [p.strip() for p in filter_to_use.split(",")]
+                issue_key_project = issue_key.split("-")[0]
+                if issue_key_project not in projects:
+                    msg = (
+                        "Issue with project prefix "
+                        f"'{issue_key_project}' are restricted by configuration"
+                    )
+                    raise ValueError(msg)
+
+            source_response = self.jira.get_issue(issue_key, fields="*all")
+            if not isinstance(source_response, dict):
+                msg = (
+                    "Unexpected return value type from `jira.get_issue`: "
+                    f"{type(source_response)}"
+                )
+                logger.error(msg)
+                raise TypeError(msg)
+
+            source_fields = source_response.get("fields") or {}
+            if not source_fields:
+                msg = f"Issue {issue_key} has no fields to clone"
+                raise ValueError(msg)
+
+            source_project_key = (source_fields.get("project") or {}).get("key")
+            target_project_key = project_key or source_project_key
+            if not target_project_key:
+                msg = (
+                    "Could not determine a target project for cloning issue "
+                    f"{issue_key}"
+                )
+                raise ValueError(msg)
+
+            source_issue_type = (source_fields.get("issuetype") or {}).get("name")
+            if not source_issue_type:
+                msg = f"Issue {issue_key} has no issue type"
+                raise ValueError(msg)
+
+            new_fields: dict[str, Any] = {
+                "project": {"key": target_project_key},
+                "summary": summary
+                if summary
+                else f"CLONE - {source_fields.get('summary', '')}",
+                "issuetype": {"name": source_issue_type},
+            }
+
+            if source_fields.get("description") is not None:
+                new_fields["description"] = source_fields["description"]
+
+            # Pre-verify fields against the target create screen so unsupported
+            # fields are excluded individually instead of failing the clone.
+            allowed_field_ids = self._get_create_screen_field_ids(
+                target_project_key, source_issue_type
+            )
+            excluded_fields: list[str] = []
+
+            for field_key in _CLONABLE_STANDARD_FIELDS:
+                value = source_fields.get(field_key)
+                if not value:
+                    continue
+                if allowed_field_ids is not None and field_key not in allowed_field_ids:
+                    excluded_fields.append(field_key)
+                    continue
+                new_fields[field_key] = value
+
+            # Subtasks must keep their parent when cloned into the same project
+            parent = source_fields.get("parent")
+            if parent and target_project_key == source_project_key:
+                new_fields["parent"] = {"key": parent["key"]}
+            elif source_issue_type.lower() in ("subtask", "sub-task") and not parent:
+                msg = (
+                    f"Issue {issue_key} is a subtask without a parent "
+                    "and cannot be cloned"
+                )
+                raise ValueError(msg)
+
+            if include_custom_fields:
+                for field_id, value in source_fields.items():
+                    if (
+                        not field_id.startswith("customfield_")
+                        or value is None
+                        or field_id in new_fields
+                    ):
+                        continue
+                    if (
+                        allowed_field_ids is not None
+                        and field_id not in allowed_field_ids
+                    ):
+                        excluded_fields.append(field_id)
+                        continue
+                    new_fields[field_id] = value
+
+            if excluded_fields:
+                logger.warning(
+                    f"Excluded fields not on the create screen for project "
+                    f"'{target_project_key}' issue type '{source_issue_type}' "
+                    f"when cloning {issue_key}: {', '.join(sorted(excluded_fields))}"
+                )
+
+            if additional_fields:
+                new_fields.update(additional_fields)
+
+            response = self.jira.create_issue(fields=new_fields)
+            if not isinstance(response, dict):
+                msg = (
+                    "Unexpected return value type from `jira.create_issue`: "
+                    f"{type(response)}"
+                )
+                logger.error(msg)
+                raise TypeError(msg)
+
+            new_issue_key = response.get("key")
+            if not new_issue_key:
+                msg = "No issue key in response when cloning issue"
+                raise ValueError(msg)
+
+            if link_to_original:
+                try:
+                    # "Cloners" link semantics: the outward issue "clones" the
+                    # inward issue, so the new clone is the outward issue and
+                    # the source issue is the inward issue.
+                    self.create_issue_link(
+                        {
+                            "type": {"name": "Cloners"},
+                            "inwardIssue": {"key": issue_key},
+                            "outwardIssue": {"key": new_issue_key},
+                        }
+                    )
+                except Exception as link_error:  # noqa: BLE001 - linking is best-effort
+                    logger.warning(
+                        f"Cloned {issue_key} to {new_issue_key} but could not create "
+                        f"'Cloners' link: {link_error!s}"
+                    )
+
+            issue_data = self.jira.get_issue(new_issue_key)
+            if not isinstance(issue_data, dict):
+                msg = (
+                    "Unexpected return value type from `jira.get_issue`: "
+                    f"{type(issue_data)}"
+                )
+                logger.error(msg)
+                raise TypeError(msg)
+            cloned_issue = JiraIssue.from_api_response(issue_data)
+            if excluded_fields:
+                cloned_issue.custom_fields["clone_excluded_fields"] = sorted(
+                    set(excluded_fields)
+                )
+            return cloned_issue
+
+        except HTTPError as http_err:
+            if http_err.response is not None and http_err.response.status_code in [
+                401,
+                403,
+            ]:
+                error_msg = (
+                    "Authentication failed for Jira API "
+                    f"({http_err.response.status_code}). "
+                    "Token may be expired or invalid. Please verify credentials."
+                )
+                logger.error(error_msg)
+                raise MCPAtlassianAuthenticationError(error_msg) from http_err
+            logger.error(f"HTTP error while cloning issue {issue_key}: {http_err}")
+            raise
+        except (ValueError, TypeError):
+            raise
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Error cloning issue {issue_key}: {error_msg}")
+            msg = f"Error cloning issue {issue_key}: {error_msg}"
+            raise Exception(msg) from e
 
     def _is_epic_issue_type(self, issue_type: str) -> bool:
         """

--- a/src/mcp_atlassian/jira/projects.py
+++ b/src/mcp_atlassian/jira/projects.py
@@ -267,6 +267,39 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
 
         except Exception as e:
             logger.error(
+                f"Error getting issue types for project for {project_key}: {str(e)}, "
+                "falling back to alternative method."
+            )
+            return self.get_project_issue_types_alternative(project_key)
+
+    def get_project_issue_types_alternative(
+        self, project_key: str
+    ) -> list[dict[str, Any]]:
+        """
+        Get all issue types available for a project using alternative method.
+
+        Args:
+            project_key: The project key
+
+        Returns:
+            List of issue type data dictionaries
+        """
+        try:
+            meta = self.jira.issue_createmeta_issuetypes(project=project_key)
+            if not isinstance(meta, dict):
+                msg = f"Unexpected return value type from `jira.issue_createmeta`: {type(meta)}"
+                logger.error(msg)
+                raise TypeError(msg)
+
+            issue_types = []
+            # Extract issue types from createmeta response
+            if "values" in meta and meta.get("total", 0) > 0:
+                issue_types = meta.get("values", [])
+
+            return issue_types
+
+        except Exception as e:
+            logger.error(
                 f"Error getting issue types for project {project_key}: {str(e)}"
             )
             return []

--- a/src/mcp_atlassian/jira/protocols.py
+++ b/src/mcp_atlassian/jira/protocols.py
@@ -205,3 +205,24 @@ class UsersOperationsProto(Protocol):
         Raises:
             ValueError: If the account ID could not be found
         """
+
+
+class LinksOperationsProto(Protocol):
+    """Protocol defining issue link operations interface."""
+
+    @abstractmethod
+    def create_issue_link(self, data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Create a link between two issues.
+
+        Args:
+            data: A dictionary containing the link data (type, inwardIssue,
+                outwardIssue, and an optional comment)
+
+        Returns:
+            Dictionary with the created link information
+
+        Raises:
+            ValueError: If required fields are missing
+            Exception: If there is an error creating the issue link
+        """

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1339,6 +1339,124 @@ async def create_issue_link(
 
 @jira_mcp.tool(tags={"jira", "write"})
 @check_write_access
+async def clone_issue(
+    ctx: Context,
+    issue_key: Annotated[
+        str, Field(description="The key of the issue to clone (e.g., 'PROJ-123')")
+    ],
+    project_key: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Target project key for the clone (e.g., 'PROJ'). "
+                "Defaults to the source issue's project. If the source issue is "
+                "a subtask, its parent link is only preserved when cloning into "
+                "the same project."
+            ),
+            default=None,
+        ),
+    ] = None,
+    summary: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Summary for the cloned issue. Defaults to "
+                "'CLONE - <source summary>', matching Jira's built-in Clone action."
+            ),
+            default=None,
+        ),
+    ] = None,
+    *,
+    include_custom_fields: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether to copy all populated custom fields from the source "
+                "issue (e.g., Epic Name, Epic Link, and other customfield_* values)"
+            ),
+            default=True,
+        ),
+    ] = True,
+    link_to_original: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether to create a 'Cloners' issue link between the new clone "
+                "and the source issue, matching Jira's built-in Clone action"
+            ),
+            default=True,
+        ),
+    ] = True,
+    additional_fields: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description=(
+                "(Optional) Dictionary of fields to override or add on top of "
+                "the fields copied from the source issue. "
+                "Example: {'priority': {'name': 'High'}}"
+            ),
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Clone an existing Jira issue by copying its fields into a new issue.
+
+    Jira does not provide a single "clone issue" REST endpoint on Data Center,
+    Server, or Cloud. This tool reproduces the Jira UI's built-in Clone action:
+    it fetches the source issue's fields, creates a new issue with those fields
+    copied over (summary, description, issue type, priority, labels, components,
+    fix/affects versions, assignee, due date, security level, environment, and
+    populated custom fields), and links the new issue back to the source issue
+    with a "Cloners" issue link.
+
+    Each standard and custom field is pre-verified against the target project's
+    create screen metadata before being copied, so fields that are not available
+    for that project/issue type are excluded individually instead of failing the
+    whole clone. Any excluded fields are listed under "excluded_fields" in the
+    response.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: The key of the issue to clone.
+        project_key: Optional target project key.
+        summary: Optional summary override for the clone.
+        include_custom_fields: Whether to copy populated custom fields.
+        link_to_original: Whether to create a "Cloners" link back to the source issue.
+        additional_fields: Optional dictionary of fields to override or add.
+
+    Returns:
+        JSON string representing the newly created clone issue. Includes an
+        "excluded_fields" list when fields were skipped because they are not
+        on the target create screen.
+
+    Raises:
+        ValueError: If in read-only mode, Jira client unavailable, or the source
+            issue/target project is invalid.
+    """
+    jira = await get_jira_fetcher(ctx)
+    issue = jira.clone_issue(
+        issue_key=issue_key,
+        project_key=project_key,
+        summary=summary,
+        include_custom_fields=include_custom_fields,
+        link_to_original=link_to_original,
+        additional_fields=additional_fields,
+    )
+    result = issue.to_simplified_dict()
+    response: dict[str, Any] = {
+        "message": f"Issue {issue_key} cloned successfully",
+        "issue": result,
+    }
+    if (
+        hasattr(issue, "custom_fields")
+        and "clone_excluded_fields" in issue.custom_fields
+    ):
+        response["excluded_fields"] = issue.custom_fields["clone_excluded_fields"]
+    return json.dumps(response, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(tags={"jira", "write"})
+@check_write_access
 async def create_remote_issue_link(
     ctx: Context,
     issue_key: Annotated[

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -1047,6 +1047,451 @@ class TestIssuesMixin:
             update_history=False,
         )
 
+    def test_clone_issue_basic(self, issues_mixin: IssuesMixin):
+        """Test cloning an issue copies standard fields and links the clone."""
+        source_response = {
+            "id": "10001",
+            "key": "TEST-100",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Bug"},
+                "summary": "Original bug",
+                "description": "Some description text",
+                "priority": {"id": "3", "name": "Medium"},
+                "labels": ["backend", "urgent"],
+                "components": [{"id": "10000", "name": "API"}],
+                "fixVersions": [{"id": "10010", "name": "v1.0"}],
+                "versions": [{"id": "10020", "name": "v0.9"}],
+                "assignee": {"accountId": "acc-1", "displayName": "Jane Doe"},
+                "duedate": "2024-01-01",
+                "security": {"id": "10030", "name": "Internal"},
+                "environment": "Production",
+                "customfield_10001": "custom value",
+                "customfield_10002": None,
+                "status": {"name": "Open"},
+                "reporter": {"accountId": "acc-2"},
+                "created": "2023-01-01T00:00:00.000+0000",
+                "updated": "2023-01-02T00:00:00.000+0000",
+            },
+        }
+        new_issue_data = {
+            "id": "10099",
+            "key": "TEST-101",
+            "fields": {
+                "summary": "CLONE - Original bug",
+                "issuetype": {"name": "Bug"},
+                "status": {"name": "Open"},
+            },
+        }
+        issues_mixin.jira.get_issue.side_effect = [source_response, new_issue_data]
+        issues_mixin.jira.create_issue.return_value = {
+            "id": "10099",
+            "key": "TEST-101",
+        }
+        issues_mixin.jira.create_issue_link.return_value = {}
+
+        result = issues_mixin.clone_issue("TEST-100")
+
+        # Verify the fields passed to create_issue
+        created_fields = issues_mixin.jira.create_issue.call_args.kwargs["fields"]
+        assert created_fields["project"] == {"key": "TEST"}
+        assert created_fields["summary"] == "CLONE - Original bug"
+        assert created_fields["issuetype"] == {"name": "Bug"}
+        assert created_fields["description"] == "Some description text"
+        assert created_fields["priority"] == {"id": "3", "name": "Medium"}
+        assert created_fields["labels"] == ["backend", "urgent"]
+        assert created_fields["components"] == [{"id": "10000", "name": "API"}]
+        assert created_fields["fixVersions"] == [{"id": "10010", "name": "v1.0"}]
+        assert created_fields["versions"] == [{"id": "10020", "name": "v0.9"}]
+        assert created_fields["assignee"] == {
+            "accountId": "acc-1",
+            "displayName": "Jane Doe",
+        }
+        assert created_fields["duedate"] == "2024-01-01"
+        assert created_fields["security"] == {"id": "10030", "name": "Internal"}
+        assert created_fields["environment"] == "Production"
+        assert created_fields["customfield_10001"] == "custom value"
+
+        # Fields that must never be copied
+        for excluded in (
+            "customfield_10002",
+            "status",
+            "reporter",
+            "created",
+            "updated",
+        ):
+            assert excluded not in created_fields
+
+        # Verify the "Cloners" link was created with the new issue as outward
+        issues_mixin.jira.create_issue_link.assert_called_once_with(
+            {
+                "type": {"name": "Cloners"},
+                "inwardIssue": {"key": "TEST-100"},
+                "outwardIssue": {"key": "TEST-101"},
+            }
+        )
+
+        assert isinstance(result, JiraIssue)
+        assert result.key == "TEST-101"
+
+    def test_clone_issue_excludes_fields_not_on_create_screen(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test fields absent from the create screen are excluded, not all-or-none."""
+        source_response = {
+            "id": "10001",
+            "key": "TEST-100",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Bug"},
+                "summary": "Original bug",
+                "priority": {"id": "3", "name": "Medium"},
+                "environment": "Production",
+                "customfield_10001": "keep me",
+                "customfield_10005": "drop me",
+            },
+        }
+        new_issue_data = {
+            "id": "10099",
+            "key": "TEST-101",
+            "fields": {"summary": "CLONE - Original bug"},
+        }
+        issues_mixin.jira.get_issue.side_effect = [source_response, new_issue_data]
+        issues_mixin.jira.create_issue.return_value = {
+            "id": "10099",
+            "key": "TEST-101",
+        }
+        issues_mixin.jira.create_issue_link.return_value = {}
+        issues_mixin.jira.issue_createmeta.return_value = {
+            "projects": [{"issuetypes": [{"id": "10001", "name": "Bug"}]}]
+        }
+        issues_mixin.jira.issue_createmeta_fieldtypes.return_value = {
+            "fields": [
+                {"fieldId": "priority"},
+                {"fieldId": "customfield_10001"},
+            ]
+        }
+
+        result = issues_mixin.clone_issue("TEST-100")
+
+        created_fields = issues_mixin.jira.create_issue.call_args.kwargs["fields"]
+        assert created_fields["priority"] == {"id": "3", "name": "Medium"}
+        assert created_fields["customfield_10001"] == "keep me"
+        assert "environment" not in created_fields
+        assert "customfield_10005" not in created_fields
+
+        issues_mixin.jira.issue_createmeta_fieldtypes.assert_called_once_with(
+            project="TEST", issue_type_id="10001"
+        )
+        assert result.custom_fields["clone_excluded_fields"] == [
+            "customfield_10005",
+            "environment",
+        ]
+
+    def test_clone_issue_skips_verification_when_createmeta_unavailable(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test fields are copied as-is when the create screen can't be resolved."""
+        source_response = {
+            "id": "10001",
+            "key": "TEST-100",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Bug"},
+                "summary": "Original bug",
+                "environment": "Production",
+                "customfield_10005": "still copied",
+            },
+        }
+        new_issue_data = {
+            "id": "10099",
+            "key": "TEST-101",
+            "fields": {"summary": "CLONE - Original bug"},
+        }
+        issues_mixin.jira.get_issue.side_effect = [source_response, new_issue_data]
+        issues_mixin.jira.create_issue.return_value = {
+            "id": "10099",
+            "key": "TEST-101",
+        }
+        issues_mixin.jira.create_issue_link.return_value = {}
+        # No matching issue type resolvable, so create-screen verification is skipped
+        issues_mixin.jira.issue_createmeta.return_value = {
+            "projects": [{"issuetypes": []}]
+        }
+
+        result = issues_mixin.clone_issue("TEST-100")
+
+        created_fields = issues_mixin.jira.create_issue.call_args.kwargs["fields"]
+        assert created_fields["environment"] == "Production"
+        assert created_fields["customfield_10005"] == "still copied"
+        assert "clone_excluded_fields" not in result.custom_fields
+
+    def test_clone_issue_custom_summary(self, issues_mixin: IssuesMixin):
+        """Test cloning an issue with an explicit summary override."""
+        source_response = {
+            "id": "10001",
+            "key": "TEST-100",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Task"},
+                "summary": "Original task",
+            },
+        }
+        new_issue_data = {
+            "id": "10099",
+            "key": "TEST-101",
+            "fields": {"summary": "My Custom Summary", "issuetype": {"name": "Task"}},
+        }
+        issues_mixin.jira.get_issue.side_effect = [source_response, new_issue_data]
+        issues_mixin.jira.create_issue.return_value = {
+            "id": "10099",
+            "key": "TEST-101",
+        }
+        issues_mixin.jira.create_issue_link.return_value = {}
+
+        issues_mixin.clone_issue("TEST-100", summary="My Custom Summary")
+
+        created_fields = issues_mixin.jira.create_issue.call_args.kwargs["fields"]
+        assert created_fields["summary"] == "My Custom Summary"
+
+    def test_clone_issue_to_different_project_drops_parent(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test cloning a subtask to a different project does not keep the parent."""
+        source_response = {
+            "id": "10001",
+            "key": "TEST-100",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Subtask"},
+                "summary": "Original subtask",
+                "parent": {"key": "TEST-99"},
+            },
+        }
+        new_issue_data = {
+            "id": "10099",
+            "key": "OTHER-1",
+            "fields": {"summary": "CLONE - Original subtask"},
+        }
+        issues_mixin.jira.get_issue.side_effect = [source_response, new_issue_data]
+        issues_mixin.jira.create_issue.return_value = {
+            "id": "10099",
+            "key": "OTHER-1",
+        }
+        issues_mixin.jira.create_issue_link.return_value = {}
+
+        issues_mixin.clone_issue("TEST-100", project_key="OTHER")
+
+        created_fields = issues_mixin.jira.create_issue.call_args.kwargs["fields"]
+        assert created_fields["project"] == {"key": "OTHER"}
+        assert "parent" not in created_fields
+
+    def test_clone_issue_preserves_subtask_parent_same_project(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test cloning a subtask into the same project preserves its parent."""
+        source_response = {
+            "id": "10001",
+            "key": "TEST-100",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Subtask"},
+                "summary": "Original subtask",
+                "parent": {"key": "TEST-99"},
+            },
+        }
+        new_issue_data = {
+            "id": "10099",
+            "key": "TEST-101",
+            "fields": {"summary": "CLONE - Original subtask"},
+        }
+        issues_mixin.jira.get_issue.side_effect = [source_response, new_issue_data]
+        issues_mixin.jira.create_issue.return_value = {
+            "id": "10099",
+            "key": "TEST-101",
+        }
+        issues_mixin.jira.create_issue_link.return_value = {}
+
+        issues_mixin.clone_issue("TEST-100")
+
+        created_fields = issues_mixin.jira.create_issue.call_args.kwargs["fields"]
+        assert created_fields["parent"] == {"key": "TEST-99"}
+
+    def test_clone_issue_subtask_without_parent_raises(self, issues_mixin: IssuesMixin):
+        """Test cloning a parentless subtask raises a ValueError."""
+        source_response = {
+            "id": "10001",
+            "key": "TEST-100",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Subtask"},
+                "summary": "Orphan subtask",
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = source_response
+
+        with pytest.raises(ValueError, match="subtask without a parent"):
+            issues_mixin.clone_issue("TEST-100")
+
+        issues_mixin.jira.create_issue.assert_not_called()
+
+    def test_clone_issue_missing_issue_key_raises(self, issues_mixin: IssuesMixin):
+        """Test cloning without an issue key raises a ValueError."""
+        with pytest.raises(ValueError, match="Issue key is required"):
+            issues_mixin.clone_issue("")
+
+    def test_clone_issue_no_fields_raises(self, issues_mixin: IssuesMixin):
+        """Test cloning an issue with an empty fields payload raises a ValueError."""
+        issues_mixin.jira.get_issue.return_value = {"id": "10001", "key": "TEST-100"}
+
+        with pytest.raises(ValueError, match="has no fields to clone"):
+            issues_mixin.clone_issue("TEST-100")
+
+    def test_clone_issue_link_failure_does_not_fail_clone(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test that a failure creating the 'Cloners' link does not fail cloning."""
+        source_response = {
+            "id": "10001",
+            "key": "TEST-100",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Task"},
+                "summary": "Original task",
+            },
+        }
+        new_issue_data = {
+            "id": "10099",
+            "key": "TEST-101",
+            "fields": {"summary": "CLONE - Original task"},
+        }
+        issues_mixin.jira.get_issue.side_effect = [source_response, new_issue_data]
+        issues_mixin.jira.create_issue.return_value = {
+            "id": "10099",
+            "key": "TEST-101",
+        }
+        issues_mixin.jira.create_issue_link.side_effect = Exception("link API down")
+
+        result = issues_mixin.clone_issue("TEST-100")
+
+        assert result.key == "TEST-101"
+
+    def test_clone_issue_link_to_original_false_skips_link(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test that link_to_original=False skips creating a 'Cloners' link."""
+        source_response = {
+            "id": "10001",
+            "key": "TEST-100",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Task"},
+                "summary": "Original task",
+            },
+        }
+        new_issue_data = {
+            "id": "10099",
+            "key": "TEST-101",
+            "fields": {"summary": "CLONE - Original task"},
+        }
+        issues_mixin.jira.get_issue.side_effect = [source_response, new_issue_data]
+        issues_mixin.jira.create_issue.return_value = {
+            "id": "10099",
+            "key": "TEST-101",
+        }
+
+        issues_mixin.clone_issue("TEST-100", link_to_original=False)
+
+        issues_mixin.jira.create_issue_link.assert_not_called()
+
+    def test_clone_issue_include_custom_fields_false(self, issues_mixin: IssuesMixin):
+        """Test that include_custom_fields=False skips copying custom fields."""
+        source_response = {
+            "id": "10001",
+            "key": "TEST-100",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Task"},
+                "summary": "Original task",
+                "customfield_10001": "custom value",
+            },
+        }
+        new_issue_data = {
+            "id": "10099",
+            "key": "TEST-101",
+            "fields": {"summary": "CLONE - Original task"},
+        }
+        issues_mixin.jira.get_issue.side_effect = [source_response, new_issue_data]
+        issues_mixin.jira.create_issue.return_value = {
+            "id": "10099",
+            "key": "TEST-101",
+        }
+        issues_mixin.jira.create_issue_link.return_value = {}
+
+        issues_mixin.clone_issue("TEST-100", include_custom_fields=False)
+
+        created_fields = issues_mixin.jira.create_issue.call_args.kwargs["fields"]
+        assert "customfield_10001" not in created_fields
+
+    def test_clone_issue_additional_fields_override(self, issues_mixin: IssuesMixin):
+        """Test that additional_fields overrides copied field values."""
+        source_response = {
+            "id": "10001",
+            "key": "TEST-100",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Task"},
+                "summary": "Original task",
+                "priority": {"id": "3", "name": "Medium"},
+            },
+        }
+        new_issue_data = {
+            "id": "10099",
+            "key": "TEST-101",
+            "fields": {"summary": "CLONE - Original task"},
+        }
+        issues_mixin.jira.get_issue.side_effect = [source_response, new_issue_data]
+        issues_mixin.jira.create_issue.return_value = {
+            "id": "10099",
+            "key": "TEST-101",
+        }
+        issues_mixin.jira.create_issue_link.return_value = {}
+
+        issues_mixin.clone_issue(
+            "TEST-100",
+            additional_fields={"priority": {"name": "High"}},
+        )
+
+        created_fields = issues_mixin.jira.create_issue.call_args.kwargs["fields"]
+        assert created_fields["priority"] == {"name": "High"}
+
+    def test_clone_issue_respects_projects_filter(self, issues_mixin: IssuesMixin):
+        """Test cloning respects the configured projects filter restriction."""
+        issues_mixin.config.projects_filter = "DEV"
+
+        with pytest.raises(Exception, match="restricted by configuration"):
+            issues_mixin.clone_issue("TEST-100")
+
+        issues_mixin.jira.get_issue.assert_not_called()
+
+    def test_clone_issue_auth_error(self, issues_mixin: IssuesMixin):
+        """Test that a 401 HTTPError while cloning raises an authentication error."""
+        from unittest.mock import Mock
+
+        from requests import HTTPError as RequestsHTTPError
+        from requests import Response
+
+        from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+
+        mock_response = Mock(spec=Response)
+        mock_response.status_code = 401
+        http_error = RequestsHTTPError("Unauthorized")
+        http_error.response = mock_response
+        issues_mixin.jira.get_issue.side_effect = http_error
+
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            issues_mixin.clone_issue("TEST-100")
+
     def test_batch_create_issues_basic(self, issues_mixin: IssuesMixin):
         """Test basic functionality of batch_create_issues."""
         # Setup test data

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -119,6 +119,10 @@ def mock_jira_fetcher():
     mock_fetcher.link_issue_to_epic.return_value = linked_issue
 
     mock_fetcher.create_issue_link.return_value = {"status": "LINKED"}
+
+    cloned_issue = MagicMock()
+    cloned_issue.to_simplified_dict.return_value = {"key": "TEST-101"}
+    mock_fetcher.clone_issue.return_value = cloned_issue
     mock_fetcher.create_remote_issue_link.return_value = {"id": "remote-link"}
     mock_fetcher.remove_issue_link.return_value = {"removed": True}
 
@@ -432,6 +436,7 @@ class DirectJiraToolCaller:
             batch_create_issues,
             batch_create_versions,
             batch_get_changelogs,
+            clone_issue,
             construct_download_endpoint,
             create_issue,
             create_issue_link,
@@ -493,6 +498,7 @@ class DirectJiraToolCaller:
             "jira_delete_issue": delete_issue.fn,
             "jira_add_comment": add_comment.fn,
             "jira_create_issue_link": create_issue_link.fn,
+            "jira_clone_issue": clone_issue.fn,
             "jira_create_version": create_version.fn,
             "jira_batch_create_versions": batch_create_versions.fn,
             "jira_add_worklog": add_worklog.fn,
@@ -1379,6 +1385,60 @@ async def test_create_issue_link_tool(jira_client, mock_jira_fetcher):
     assert link_payload["inwardIssue"]["key"] == "PROJ-1"
     payload = json.loads(response.content[0].text)
     assert payload["status"] == "LINKED"
+
+
+@pytest.mark.anyio
+async def test_clone_issue_tool(jira_client, mock_jira_fetcher):
+    """Test jira_clone_issue forwards parameters and returns the clone."""
+    response = await jira_client.call_tool(
+        "jira_clone_issue",
+        {
+            "issue_key": "PROJ-1",
+            "project_key": "OTHER",
+            "summary": "My Clone",
+            "include_custom_fields": False,
+            "link_to_original": False,
+            "additional_fields": {"priority": {"name": "High"}},
+        },
+    )
+    mock_jira_fetcher.clone_issue.assert_called_once_with(
+        issue_key="PROJ-1",
+        project_key="OTHER",
+        summary="My Clone",
+        include_custom_fields=False,
+        link_to_original=False,
+        additional_fields={"priority": {"name": "High"}},
+    )
+    payload = json.loads(response.content[0].text)
+    assert payload["issue"]["key"] == "TEST-101"
+    assert "cloned successfully" in payload["message"]
+
+
+@pytest.mark.anyio
+async def test_clone_issue_tool_defaults(jira_client, mock_jira_fetcher):
+    """Test jira_clone_issue uses default parameter values."""
+    await jira_client.call_tool("jira_clone_issue", {"issue_key": "PROJ-1"})
+    mock_jira_fetcher.clone_issue.assert_called_once_with(
+        issue_key="PROJ-1",
+        project_key=None,
+        summary=None,
+        include_custom_fields=True,
+        link_to_original=True,
+        additional_fields=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_clone_issue_tool_reports_excluded_fields(jira_client, mock_jira_fetcher):
+    """Test jira_clone_issue surfaces fields excluded by create-screen verification."""
+    mock_jira_fetcher.clone_issue.return_value.custom_fields = {
+        "clone_excluded_fields": ["customfield_10005", "environment"]
+    }
+
+    response = await jira_client.call_tool("jira_clone_issue", {"issue_key": "PROJ-1"})
+
+    payload = json.loads(response.content[0].text)
+    assert payload["excluded_fields"] == ["customfield_10005", "environment"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

Jira Server, Data Center, and Cloud do not expose a single "clone issue" REST
endpoint — the built-in Clone action in the Jira UI is implemented client-side
as a sequence of calls (fetch source issue → create new issue with copied
fields → link the two issues with a "Cloners" issue link). This PR adds a new
write-only `jira_clone_issue` MCP tool that reproduces this behavior so users
can clone issues without manually orchestrating get/create/link calls
themselves.

Fixes: #

## Changes

- Added `clone_issue()` to `IssuesMixin` in `src/mcp_atlassian/jira/issues.py`, which copies summary (prefixed `CLONE - ` unless overridden), description, issue type, priority, labels, components, fix/affects versions, assignee, due date, security level, environment, and all populated `customfield_*` values from the source issue, preserves a subtask's parent when cloning into the same project, and creates a "Cloners" issue link back to the source (best-effort, non-fatal on failure).
- Added pre-verification against the target project/issue type's create-screen metadata (`issue_createmeta_fieldtypes`) so fields not available on the create screen are excluded individually instead of failing the whole clone or requiring an all-or-nothing retry; excluded field IDs are reported back via `clone_excluded_fields` / `excluded_fields`. Falls back to copying everything if the create screen metadata can't be resolved.
- Added `LinksOperationsProto` protocol in `src/mcp_atlassian/jira/protocols.py` so `IssuesMixin` can call `create_issue_link` (from `LinksMixin`) in a type-safe way.
- Registered the `clone_issue` write tool (tagged `{"jira", "write"}`, guarded by `@check_write_access`) in `src/mcp_atlassian/servers/jira.py`, with full parameter/tool descriptions.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `Verified ruff lint/format compliance against project baseline (git-stash diffing to confirm zero new violations beyond pre-existing debt) and ran the full unit test suite locally`

Added 15 unit tests for `IssuesMixin.clone_issue` in `tests/unit/jira/test_issues.py`
(standard/custom field copying, summary override, cross-project vs
same-project subtask parent handling, missing-parent error, projects-filter
restriction, auth errors, link failure non-fatal handling,
`link_to_original`/`include_custom_fields` toggles, `additional_fields`
overrides, and create-screen field exclusion/fallback behavior), plus 3 tests
for the `jira_clone_issue` tool wrapper in `tests/unit/servers/test_jira_server.py`
(parameter forwarding, defaults, and surfaced `excluded_fields`). Full suite:
1615 passed, 5 skipped, no regressions.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).